### PR TITLE
src: lore_api_client: use color_eyre::Result

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5,9 +5,7 @@ use patch_hub::{
     lore_session::{
         self, LoreSession
     },
-    lore_api_client::{
-        BlockingLoreAPIClient, FailedFeedRequest
-    },
+    lore_api_client::BlockingLoreAPIClient,
     mailing_list::MailingList,
     patch::Patch
 };
@@ -74,15 +72,7 @@ impl LatestPatchsetsState {
     }
 
     pub fn fetch_current_page(self: &mut Self) -> color_eyre::Result<()> {
-        if let Err(failed_feed_request) = self
-            .lore_session.process_n_representative_patches(&self.lore_api_client, self.page_size * &self.page_number) {
-            match failed_feed_request {
-                FailedFeedRequest::UnknownError(error) => bail!("[FailedFeedRequest::UnknownError]\n*\tFailed to request feed\n*\t{error:#?}"),
-                FailedFeedRequest::StatusNotOk(feed_response) => bail!("[FailedFeedRequest::StatusNotOk]\n*\tRequest returned with non-OK status\n*\t{feed_response:#?}"),
-                FailedFeedRequest::EndOfFeed => (),
-            }
-        };
-        Ok(())
+        self.lore_session.process_n_representative_patches(&self.lore_api_client, self.page_size * &self.page_number)
     }
 
     pub fn select_below_patchset(self: &mut Self) {

--- a/src/lore_session/tests.rs
+++ b/src/lore_session/tests.rs
@@ -6,7 +6,7 @@ use std::fs;
 
 struct FakeLoreAPIClient { src_path: String }
 impl PatchFeedRequest for FakeLoreAPIClient {
-    fn request_patch_feed(self: &Self, target_list: &str, min_index: u32) -> Result<String, FailedFeedRequest> {
+    fn request_patch_feed(self: &Self, target_list: &str, min_index: u32) -> Result<String> {
         let _ = min_index;
         let _ = target_list;
         Ok(fs::read_to_string(&self.src_path).unwrap())


### PR DESCRIPTION
`FailedFeedRequest` now is a valid `Report` so can be used in `Result` type from color_eyre.

All other changes are collateral.

This is part of #2 