### PR TITLE
[2/n] feat: setup cargo clippy (rust-clippy)

### DIFF
--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -1,0 +1,34 @@
+name: Format and lint
+on:
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
+    - labeled
+    paths:
+    - src/**
+  push:
+    paths:
+    - src/**
+    branches: 
+    - master
+    - unstable
+jobs:
+  format-and-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: '!github.event.pull_request.draft'
+    steps:
+      - name: Run format_and_lint.sh
+        shell: bash
+        run: |
+          chmod +x format_and_lint.sh
+          ./format_and_lint.sh
+      - name: Verify code changes
+        shell: bash
+        run: |
+          [ -n "$(git status --porcelain)" ] && \
+          echo "Code changes found. Commit them before continuing" && \
+          exit 1

--- a/format_and_lint.sh
+++ b/format_and_lint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# making bash exit if anything fails
+set -e
+
+function format () {
+	echo "Formatting..."
+	cargo fmt --all
+}
+
+# TODO: run rust-clippy
+
+format

--- a/format_and_lint.sh
+++ b/format_and_lint.sh
@@ -3,11 +3,23 @@
 # making bash exit if anything fails
 set -e
 
+CLIPPY_CONFIGS="
+--allow=clippy::too-many-arguments \
+--deny=warnings \
+--deny=clippy::map_unwrap_or \
+--deny=unconditional_recursion
+"
+
 function format () {
 	echo "Formatting..."
 	cargo fmt --all
 }
 
-# TODO: run rust-clippy
+function lint () {
+	echo "Running clippy..."
+	cargo clippy --all-features --all-targets --tests -- $CLIPPY_CONFIGS
+}
 
-format
+format && 
+lint && 
+echo "format_and_lint.sh finished successfully"

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,30 +16,30 @@ pub struct BookmarkedPatchsetsState {
 }
 
 impl BookmarkedPatchsetsState {
-    pub fn select_below_patchset(self: &mut Self) {
+    pub fn select_below_patchset(&mut self) {
         if (self.patchset_index as usize) + 1 < self.bookmarked_patchsets.len() {
             self.patchset_index += 1;
         }
     }
 
-    pub fn select_above_patchset(self: &mut Self) {
+    pub fn select_above_patchset(&mut self) {
         self.patchset_index = self.patchset_index.saturating_sub(1);
     }
 
-    fn get_selected_patchset(self: &Self) -> Patch {
+    fn get_selected_patchset(&self) -> Patch {
         self.bookmarked_patchsets
             .get(self.patchset_index as usize)
             .unwrap()
             .clone()
     }
 
-    fn bookmark_selected_patch(self: &mut Self, patch_to_bookmark: &Patch) {
+    fn bookmark_selected_patch(&mut self, patch_to_bookmark: &Patch) {
         if !self.bookmarked_patchsets.contains(patch_to_bookmark) {
             self.bookmarked_patchsets.push(patch_to_bookmark.clone());
         }
     }
 
-    fn unbookmark_selected_patch(self: &mut Self, patch_to_unbookmark: &Patch) {
+    fn unbookmark_selected_patch(&mut self, patch_to_unbookmark: &Patch) {
         if let Some(index) = self
             .bookmarked_patchsets
             .iter()
@@ -71,10 +71,10 @@ impl LatestPatchsetsState {
         }
     }
 
-    pub fn fetch_current_page(self: &mut Self) -> color_eyre::Result<()> {
+    pub fn fetch_current_page(&mut self) -> color_eyre::Result<()> {
         if let Err(failed_feed_request) = self.lore_session.process_n_representative_patches(
             &self.lore_api_client,
-            self.page_size * &self.page_number,
+            self.page_size * self.page_number,
         ) {
             match failed_feed_request {
                 FailedFeedRequest::UnknownError(error) => bail!("[FailedFeedRequest::UnknownError]\n*\tFailed to request feed\n*\t{error:#?}"),
@@ -85,22 +85,22 @@ impl LatestPatchsetsState {
         Ok(())
     }
 
-    pub fn select_below_patchset(self: &mut Self) {
-        if self.patchset_index + 1 < self.page_size * &self.page_number {
+    pub fn select_below_patchset(&mut self) {
+        if self.patchset_index + 1 < self.page_size * self.page_number {
             self.patchset_index += 1;
         }
     }
 
-    pub fn select_above_patchset(self: &mut Self) {
+    pub fn select_above_patchset(&mut self) {
         if self.patchset_index == 0 {
             return;
         }
-        if self.patchset_index - 1 >= self.page_size * (&self.page_number - 1) {
+        if self.patchset_index > self.page_size * (&self.page_number - 1) {
             self.patchset_index -= 1;
         }
     }
 
-    pub fn increment_page(self: &mut Self) {
+    pub fn increment_page(&mut self) {
         let patchsets_processed: u32 = self
             .lore_session
             .get_representative_patches_ids()
@@ -114,7 +114,7 @@ impl LatestPatchsetsState {
         self.patchset_index = self.page_size * (&self.page_number - 1);
     }
 
-    pub fn decrement_page(self: &mut Self) {
+    pub fn decrement_page(&mut self) {
         if self.page_number == 1 {
             return;
         }
@@ -122,19 +122,19 @@ impl LatestPatchsetsState {
         self.patchset_index = self.page_size * (&self.page_number - 1);
     }
 
-    pub fn get_target_list(self: &Self) -> &str {
+    pub fn get_target_list(&self) -> &str {
         &self.target_list
     }
 
-    pub fn get_page_number(self: &Self) -> u32 {
+    pub fn get_page_number(&self) -> u32 {
         self.page_number
     }
 
-    pub fn get_patchset_index(self: &Self) -> u32 {
+    pub fn get_patchset_index(&self) -> u32 {
         self.patchset_index
     }
 
-    pub fn get_selected_patchset(self: &Self) -> Patch {
+    pub fn get_selected_patchset(&self) -> Patch {
         let message_id: &str = self
             .lore_session
             .get_representative_patches_ids()
@@ -147,7 +147,7 @@ impl LatestPatchsetsState {
             .clone()
     }
 
-    pub fn get_current_patch_feed_page(self: &Self) -> Option<Vec<&Patch>> {
+    pub fn get_current_patch_feed_page(&self) -> Option<Vec<&Patch>> {
         self.lore_session
             .get_patch_feed_page(self.page_size, self.page_number)
     }
@@ -169,48 +169,48 @@ pub enum PatchsetAction {
 }
 
 impl PatchsetDetailsAndActionsState {
-    pub fn preview_next_patch(self: &mut Self) {
+    pub fn preview_next_patch(&mut self) {
         if ((self.preview_index as usize) + 1) < self.patches.len() {
             self.preview_index += 1;
             self.preview_scroll_offset = 0;
         }
     }
 
-    pub fn preview_previous_patch(self: &mut Self) {
+    pub fn preview_previous_patch(&mut self) {
         if (self.preview_index as usize) > 0 {
             self.preview_index -= 1;
             self.preview_scroll_offset = 0;
         }
     }
 
-    pub fn preview_scroll_down(self: &mut Self) {
+    pub fn preview_scroll_down(&mut self) {
         let number_of_lines = self.patches[self.preview_index as usize].lines().count();
         if ((self.preview_scroll_offset as usize) + 1) <= number_of_lines {
             self.preview_scroll_offset += 1;
         }
     }
 
-    pub fn preview_scroll_up(self: &mut Self) {
+    pub fn preview_scroll_up(&mut self) {
         if (self.preview_scroll_offset as usize) > 0 {
             self.preview_scroll_offset -= 1;
         }
     }
 
-    pub fn toggle_bookmark_action(self: &mut Self) {
+    pub fn toggle_bookmark_action(&mut self) {
         self.toggle_action(PatchsetAction::Bookmark);
     }
 
-    pub fn toggle_reply_with_reviewed_by_action(self: &mut Self) {
+    pub fn toggle_reply_with_reviewed_by_action(&mut self) {
         self.toggle_action(PatchsetAction::ReplyWithReviewedBy);
     }
 
-    fn toggle_action(self: &mut Self, patchset_action: PatchsetAction) {
+    fn toggle_action(&mut self, patchset_action: PatchsetAction) {
         let current_value = *self.patchset_actions.get(&patchset_action).unwrap();
         self.patchset_actions
             .insert(patchset_action, !current_value);
     }
 
-    pub fn actions_require_user_io(self: &Self) -> bool {
+    pub fn actions_require_user_io(&self) -> bool {
         *self
             .patchset_actions
             .get(&PatchsetAction::ReplyWithReviewedBy)
@@ -218,7 +218,7 @@ impl PatchsetDetailsAndActionsState {
     }
 
     pub fn reply_patchset_with_reviewed_by(
-        self: &Self,
+        &self,
         target_list: &str,
     ) -> color_eyre::Result<Vec<u32>> {
         let lore_api_client = BlockingLoreAPIClient::new();
@@ -267,7 +267,7 @@ pub struct MailingListSelectionState {
 }
 
 impl MailingListSelectionState {
-    pub fn refresh_available_mailing_lists(self: &mut Self) -> color_eyre::Result<()> {
+    pub fn refresh_available_mailing_lists(&mut self) -> color_eyre::Result<()> {
         let lore_api_client = BlockingLoreAPIClient::new();
 
         match lore_session::fetch_available_lists(&lore_api_client) {
@@ -286,24 +286,24 @@ impl MailingListSelectionState {
         Ok(())
     }
 
-    pub fn remove_last_target_list_char(self: &mut Self) {
+    pub fn remove_last_target_list_char(&mut self) {
         if !self.target_list.is_empty() {
             self.target_list.pop();
             self.process_possible_mailing_lists();
         }
     }
 
-    pub fn push_char_to_target_list(self: &mut Self, ch: char) {
+    pub fn push_char_to_target_list(&mut self, ch: char) {
         self.target_list.push(ch);
         self.process_possible_mailing_lists();
     }
 
-    pub fn clear_target_list(self: &mut Self) {
+    pub fn clear_target_list(&mut self) {
         self.target_list.clear();
         self.process_possible_mailing_lists();
     }
 
-    fn process_possible_mailing_lists(self: &mut Self) {
+    fn process_possible_mailing_lists(&mut self) {
         let mut possible_mailing_lists: Vec<MailingList> = Vec::new();
 
         for mailing_list in &self.mailing_lists {
@@ -316,24 +316,24 @@ impl MailingListSelectionState {
         self.highlighted_list_index = 0;
     }
 
-    pub fn highlight_below_list(self: &mut Self) {
+    pub fn highlight_below_list(&mut self) {
         if (self.highlighted_list_index as usize) + 1 < self.possible_mailing_lists.len() {
             self.highlighted_list_index += 1;
         }
     }
 
-    pub fn highlight_above_list(self: &mut Self) {
+    pub fn highlight_above_list(&mut self) {
         self.highlighted_list_index = self.highlighted_list_index.saturating_sub(1);
     }
 
-    pub fn has_valid_target_list(self: &Self) -> bool {
+    pub fn has_valid_target_list(&self) -> bool {
         let list_length = self.possible_mailing_lists.len(); // Possible mailing list length
         let list_index = self.highlighted_list_index as usize; // Index of the selected mailing list
 
-        if list_index <= list_length - 1 {
+        if list_index < list_length {
             return true;
         }
-        return false;
+        false
     }
 }
 
@@ -357,25 +357,24 @@ pub struct App {
 
 impl App {
     pub fn new() -> App {
-        let mailing_lists: Vec<MailingList>;
-        let bookmarked_patchsets: Vec<Patch>;
-        let reviewed_patchsets: HashMap<String, Vec<u32>>;
         let config: Config = Config::build();
 
-        match lore_session::load_available_lists(&config.mailing_lists_path) {
-            Ok(vec_of_mailing_lists) => mailing_lists = vec_of_mailing_lists,
-            Err(_) => mailing_lists = Vec::new(),
-        }
+        let mailing_lists = match lore_session::load_available_lists(&config.mailing_lists_path) {
+            Ok(vec_of_mailing_lists) => vec_of_mailing_lists,
+            Err(_) => Vec::new(),
+        };
 
-        match lore_session::load_bookmarked_patchsets(&config.bookmarked_patchsets_path) {
-            Ok(vec_of_patchsets) => bookmarked_patchsets = vec_of_patchsets,
-            Err(_) => bookmarked_patchsets = Vec::new(),
-        }
+        let bookmarked_patchsets =
+            match lore_session::load_bookmarked_patchsets(&config.bookmarked_patchsets_path) {
+                Ok(vec_of_patchsets) => vec_of_patchsets,
+                Err(_) => Vec::new(),
+            };
 
-        match lore_session::load_reviewed_patchsets(&config.reviewed_patchsets_path) {
-            Ok(vec_of_patchsets) => reviewed_patchsets = vec_of_patchsets,
-            Err(_) => reviewed_patchsets = HashMap::new(),
-        }
+        let reviewed_patchsets =
+            match lore_session::load_reviewed_patchsets(&config.reviewed_patchsets_path) {
+                Ok(vec_of_patchsets) => vec_of_patchsets,
+                Err(_) => HashMap::new(),
+            };
 
         App {
             current_screen: CurrentScreen::MailingListSelection,
@@ -397,7 +396,7 @@ impl App {
         }
     }
 
-    pub fn init_latest_patchsets_state(self: &mut Self) {
+    pub fn init_latest_patchsets_state(&mut self) {
         // the target mailing list for "latest patchsets" is the highlighted
         // entry in the possible lists of "mailing list selection"
         let list_index = self.mailing_list_selection_state.highlighted_list_index as usize;
@@ -411,17 +410,16 @@ impl App {
         ));
     }
 
-    pub fn reset_latest_patchsets_state(self: &mut Self) {
+    pub fn reset_latest_patchsets_state(&mut self) {
         self.latest_patchsets_state = None;
     }
 
     pub fn init_patchset_details_and_actions_state(
-        self: &mut Self,
+        &mut self,
         current_screen: CurrentScreen,
     ) -> color_eyre::Result<()> {
         let representative_patch: Patch;
         let mut is_patchset_bookmarked = true;
-        let patchset_path: String;
 
         match current_screen {
             CurrentScreen::BookmarkedPatchsets => {
@@ -444,13 +442,13 @@ impl App {
             screen => bail!(format!("Invalid screen passed as argument {screen:?}")),
         };
 
-        match lore_session::download_patchset(
+        let patchset_path = match lore_session::download_patchset(
             &self.config.patchsets_cache_dir,
             &representative_patch,
         ) {
-            Ok(result) => patchset_path = result,
+            Ok(result) => result,
             Err(io_error) => bail!("{io_error}"),
-        }
+        };
 
         match lore_session::split_patchset(&patchset_path) {
             Ok(patches) => {
@@ -471,11 +469,11 @@ impl App {
         }
     }
 
-    pub fn reset_patchset_details_and_actions_state(self: &mut Self) {
+    pub fn reset_patchset_details_and_actions_state(&mut self) {
         self.patchset_details_and_actions_state = None;
     }
 
-    pub fn consolidate_patchset_actions(self: &mut Self) -> color_eyre::Result<()> {
+    pub fn consolidate_patchset_actions(&mut self) -> color_eyre::Result<()> {
         let representative_patch = &self
             .patchset_details_and_actions_state
             .as_ref()
@@ -537,7 +535,7 @@ impl App {
         Ok(())
     }
 
-    pub fn set_current_screen(self: &mut Self, new_current_screen: CurrentScreen) {
+    pub fn set_current_screen(&mut self, new_current_screen: CurrentScreen) {
         self.current_screen = new_current_screen;
     }
 }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -23,22 +23,34 @@ impl Config {
 
         patchsets_cache_dir = match env::var("KW_CACHE_DIR") {
             Ok(value) => format!("{value}/patch_hub/patchsets"),
-            Err(_) => format!("{}/.cache/kw/patch_hub/patchsets", env::var("HOME").unwrap()),
+            Err(_) => format!(
+                "{}/.cache/kw/patch_hub/patchsets",
+                env::var("HOME").unwrap()
+            ),
         };
 
         bookmarked_patchsets_path = match env::var("KW_DATA_DIR") {
             Ok(value) => format!("{value}/patch_hub/bookmarked_patchsets.json"),
-            Err(_) => format!("{}/.local/share/kw/patch_hub/bookmarked_patchsets.json", env::var("HOME").unwrap()),
+            Err(_) => format!(
+                "{}/.local/share/kw/patch_hub/bookmarked_patchsets.json",
+                env::var("HOME").unwrap()
+            ),
         };
 
         mailing_lists_path = match env::var("KW_DATA_DIR") {
             Ok(value) => format!("{value}/patch_hub/mailing_lists.json"),
-            Err(_) => format!("{}/.local/share/kw/patch_hub/mailing_lists.json", env::var("HOME").unwrap()),
+            Err(_) => format!(
+                "{}/.local/share/kw/patch_hub/mailing_lists.json",
+                env::var("HOME").unwrap()
+            ),
         };
 
         reviewed_patchsets_path = match env::var("KW_DATA_DIR") {
             Ok(value) => format!("{value}/patch_hub/reviewed_patchsets.json"),
-            Err(_) => format!("{}/.local/share/kw/patch_hub/reviewed_patchsets.json", env::var("HOME").unwrap()),
+            Err(_) => format!(
+                "{}/.local/share/kw/patch_hub/reviewed_patchsets.json",
+                env::var("HOME").unwrap()
+            ),
         };
 
         Config {

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -10,18 +10,12 @@ pub struct Config {
 
 impl Config {
     pub fn build() -> Self {
-        let page_size: u32;
-        let patchsets_cache_dir: String;
-        let bookmarked_patchsets_path: String;
-        let mailing_lists_path: String;
-        let reviewed_patchsets_path: String;
-
-        page_size = match env::var("PATCH_HUB_PAGE_SIZE") {
+        let page_size = match env::var("PATCH_HUB_PAGE_SIZE") {
             Ok(value) => value.parse().unwrap(),
             Err(_) => 30,
         };
 
-        patchsets_cache_dir = match env::var("KW_CACHE_DIR") {
+        let patchsets_cache_dir = match env::var("KW_CACHE_DIR") {
             Ok(value) => format!("{value}/patch_hub/patchsets"),
             Err(_) => format!(
                 "{}/.cache/kw/patch_hub/patchsets",
@@ -29,7 +23,7 @@ impl Config {
             ),
         };
 
-        bookmarked_patchsets_path = match env::var("KW_DATA_DIR") {
+        let bookmarked_patchsets_path = match env::var("KW_DATA_DIR") {
             Ok(value) => format!("{value}/patch_hub/bookmarked_patchsets.json"),
             Err(_) => format!(
                 "{}/.local/share/kw/patch_hub/bookmarked_patchsets.json",
@@ -37,7 +31,7 @@ impl Config {
             ),
         };
 
-        mailing_lists_path = match env::var("KW_DATA_DIR") {
+        let mailing_lists_path = match env::var("KW_DATA_DIR") {
             Ok(value) => format!("{value}/patch_hub/mailing_lists.json"),
             Err(_) => format!(
                 "{}/.local/share/kw/patch_hub/mailing_lists.json",
@@ -45,7 +39,7 @@ impl Config {
             ),
         };
 
-        reviewed_patchsets_path = match env::var("KW_DATA_DIR") {
+        let reviewed_patchsets_path = match env::var("KW_DATA_DIR") {
             Ok(value) => format!("{value}/patch_hub/reviewed_patchsets.json"),
             Err(_) => format!(
                 "{}/.local/share/kw/patch_hub/reviewed_patchsets.json",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod lore_session;
 pub mod lore_api_client;
+pub mod lore_session;
 pub mod mailing_list;
 pub mod patch;

--- a/src/lore_api_client.rs
+++ b/src/lore_api_client.rs
@@ -14,6 +14,7 @@ pub enum FailedFeedRequest {
     EndOfFeed,
 }
 
+#[derive(Default)]
 pub struct BlockingLoreAPIClient {}
 
 impl BlockingLoreAPIClient {
@@ -24,7 +25,7 @@ impl BlockingLoreAPIClient {
 
 pub trait PatchFeedRequest {
     fn request_patch_feed(
-        self: &Self,
+        &self,
         target_list: &str,
         min_index: u32,
     ) -> Result<String, FailedFeedRequest>;
@@ -32,19 +33,15 @@ pub trait PatchFeedRequest {
 
 impl PatchFeedRequest for BlockingLoreAPIClient {
     fn request_patch_feed(
-        self: &Self,
+        &self,
         target_list: &str,
         min_index: u32,
     ) -> Result<String, FailedFeedRequest> {
-        let feed_request: String;
-        let feed_response: Response;
-        let feed_response_body: String;
-
-        feed_request =
+        let feed_request =
             format!("{LORE_DOMAIN}/{target_list}/{BASE_QUERY_FOR_FEED_REQUEST}&o={min_index}");
 
-        match reqwest::blocking::get(feed_request) {
-            Ok(response) => feed_response = response,
+        let feed_response = match reqwest::blocking::get(feed_request) {
+            Ok(response) => response,
             Err(error) => return Err(FailedFeedRequest::UnknownError(error)),
         };
 
@@ -53,7 +50,7 @@ impl PatchFeedRequest for BlockingLoreAPIClient {
             _ => return Err(FailedFeedRequest::StatusNotOk(feed_response)),
         };
 
-        feed_response_body = feed_response.text().unwrap();
+        let feed_response_body = feed_response.text().unwrap();
         if feed_response_body.eq(r"</feed>") {
             return Err(FailedFeedRequest::EndOfFeed);
         };
@@ -70,23 +67,20 @@ pub enum FailedAvailableListsRequest {
 
 pub trait AvailableListsRequest {
     fn request_available_lists(
-        self: &Self,
+        &self,
         min_index: u32,
     ) -> Result<String, FailedAvailableListsRequest>;
 }
 
 impl AvailableListsRequest for BlockingLoreAPIClient {
     fn request_available_lists(
-        self: &Self,
+        &self,
         min_index: u32,
     ) -> Result<String, FailedAvailableListsRequest> {
-        let available_lists_request: String;
-        let available_lists: Response;
+        let available_lists_request = format!("{LORE_DOMAIN}/?&o={min_index}");
 
-        available_lists_request = format!("{LORE_DOMAIN}/?&o={min_index}");
-
-        match reqwest::blocking::get(available_lists_request) {
-            Ok(response) => available_lists = response,
+        let available_lists = match reqwest::blocking::get(available_lists_request) {
+            Ok(response) => response,
             Err(error) => return Err(FailedAvailableListsRequest::UnknownError(error)),
         };
 
@@ -107,7 +101,7 @@ pub enum FailedPatchHTMLRequest {
 
 pub trait PatchHTMLRequest {
     fn request_patch_html(
-        self: &Self,
+        &self,
         target_list: &str,
         message_id: &str,
     ) -> Result<String, FailedPatchHTMLRequest>;
@@ -115,17 +109,14 @@ pub trait PatchHTMLRequest {
 
 impl PatchHTMLRequest for BlockingLoreAPIClient {
     fn request_patch_html(
-        self: &Self,
+        &self,
         target_list: &str,
         message_id: &str,
     ) -> Result<String, FailedPatchHTMLRequest> {
-        let patch_html_request: String;
-        let patch_html: Response;
+        let patch_html_request = format!("{LORE_DOMAIN}/{target_list}/{message_id}/");
 
-        patch_html_request = format!("{LORE_DOMAIN}/{target_list}/{message_id}/");
-
-        match reqwest::blocking::get(patch_html_request) {
-            Ok(response) => patch_html = response,
+        let patch_html = match reqwest::blocking::get(patch_html_request) {
+            Ok(response) => response,
             Err(error) => return Err(FailedPatchHTMLRequest::UnknownError(error)),
         };
 

--- a/src/lore_api_client.rs
+++ b/src/lore_api_client.rs
@@ -23,20 +23,29 @@ impl BlockingLoreAPIClient {
 }
 
 pub trait PatchFeedRequest {
-    fn request_patch_feed(self: &Self, target_list: &str, min_index: u32) -> Result<String, FailedFeedRequest>;
+    fn request_patch_feed(
+        self: &Self,
+        target_list: &str,
+        min_index: u32,
+    ) -> Result<String, FailedFeedRequest>;
 }
 
 impl PatchFeedRequest for BlockingLoreAPIClient {
-    fn request_patch_feed(self: &Self, target_list: &str, min_index: u32) -> Result<String, FailedFeedRequest> {
+    fn request_patch_feed(
+        self: &Self,
+        target_list: &str,
+        min_index: u32,
+    ) -> Result<String, FailedFeedRequest> {
         let feed_request: String;
         let feed_response: Response;
         let feed_response_body: String;
-        
-        feed_request = format!("{LORE_DOMAIN}/{target_list}/{BASE_QUERY_FOR_FEED_REQUEST}&o={min_index}");
+
+        feed_request =
+            format!("{LORE_DOMAIN}/{target_list}/{BASE_QUERY_FOR_FEED_REQUEST}&o={min_index}");
 
         match reqwest::blocking::get(feed_request) {
             Ok(response) => feed_response = response,
-            Err(error) =>  return Err(FailedFeedRequest::UnknownError(error)),
+            Err(error) => return Err(FailedFeedRequest::UnknownError(error)),
         };
 
         match feed_response.status().as_u16() {
@@ -60,19 +69,25 @@ pub enum FailedAvailableListsRequest {
 }
 
 pub trait AvailableListsRequest {
-    fn request_available_lists(self: &Self, min_index: u32) -> Result<String, FailedAvailableListsRequest>;
+    fn request_available_lists(
+        self: &Self,
+        min_index: u32,
+    ) -> Result<String, FailedAvailableListsRequest>;
 }
 
 impl AvailableListsRequest for BlockingLoreAPIClient {
-    fn request_available_lists(self: &Self, min_index: u32) -> Result<String, FailedAvailableListsRequest> {
+    fn request_available_lists(
+        self: &Self,
+        min_index: u32,
+    ) -> Result<String, FailedAvailableListsRequest> {
         let available_lists_request: String;
         let available_lists: Response;
-        
+
         available_lists_request = format!("{LORE_DOMAIN}/?&o={min_index}");
 
         match reqwest::blocking::get(available_lists_request) {
             Ok(response) => available_lists = response,
-            Err(error) =>  return Err(FailedAvailableListsRequest::UnknownError(error)),
+            Err(error) => return Err(FailedAvailableListsRequest::UnknownError(error)),
         };
 
         match available_lists.status().as_u16() {
@@ -91,11 +106,19 @@ pub enum FailedPatchHTMLRequest {
 }
 
 pub trait PatchHTMLRequest {
-    fn request_patch_html(self: &Self, target_list: &str, message_id: &str) -> Result<String, FailedPatchHTMLRequest>;
+    fn request_patch_html(
+        self: &Self,
+        target_list: &str,
+        message_id: &str,
+    ) -> Result<String, FailedPatchHTMLRequest>;
 }
 
 impl PatchHTMLRequest for BlockingLoreAPIClient {
-    fn request_patch_html(self: &Self, target_list: &str, message_id: &str) -> Result<String, FailedPatchHTMLRequest> {
+    fn request_patch_html(
+        self: &Self,
+        target_list: &str,
+        message_id: &str,
+    ) -> Result<String, FailedPatchHTMLRequest> {
         let patch_html_request: String;
         let patch_html: Response;
 
@@ -103,7 +126,7 @@ impl PatchHTMLRequest for BlockingLoreAPIClient {
 
         match reqwest::blocking::get(patch_html_request) {
             Ok(response) => patch_html = response,
-            Err(error) =>  return Err(FailedPatchHTMLRequest::UnknownError(error)),
+            Err(error) => return Err(FailedPatchHTMLRequest::UnknownError(error)),
         };
 
         match patch_html.status().as_u16() {

--- a/src/lore_api_client/tests.rs
+++ b/src/lore_api_client/tests.rs
@@ -50,7 +50,7 @@ fn blocking_client_should_detect_failed_patch_feed_request() {
 fn blocking_client_can_request_valid_available_lists() {
     let lore_api_client = BlockingLoreAPIClient::new();
 
-    if let Err(_) = lore_api_client.request_available_lists(0) {
+    if lore_api_client.request_available_lists(0).is_err() {
         panic!("Valid request should be successful");
     }
 }
@@ -60,8 +60,9 @@ fn blocking_client_can_request_valid_available_lists() {
 fn blocking_client_can_request_valid_patch_html() {
     let lore_api_client = BlockingLoreAPIClient::new();
 
-    if let Err(_) =
-        lore_api_client.request_patch_html("all", "Pine.LNX.4.58.0507282031180.3307@g5.osdl.org")
+    if lore_api_client
+        .request_patch_html("all", "Pine.LNX.4.58.0507282031180.3307@g5.osdl.org")
+        .is_err()
     {
         panic!("Valid request should be successful");
     }

--- a/src/lore_api_client/tests.rs
+++ b/src/lore_api_client/tests.rs
@@ -10,7 +10,9 @@ fn blocking_client_can_request_valid_patch_feed() {
     let patch_feed: PatchFeed = serde_xml_rs::from_str(&patch_feed).unwrap();
     let patches = patch_feed.get_patches();
 
-    assert_eq!(200, patches.len(),
+    assert_eq!(
+        200,
+        patches.len(),
         "Should successfully request patch feed with 200 patches"
     );
 }
@@ -23,7 +25,9 @@ fn blocking_client_should_detect_failed_patch_feed_request() {
     if let Err(failed_feed_request) = lore_api_client.request_patch_feed("invalid-list", 0) {
         match failed_feed_request {
             FailedFeedRequest::StatusNotOk(_) => (),
-            _ => panic!("Invalid request should return non 200 OK status.\n{failed_feed_request:#?}")
+            _ => {
+                panic!("Invalid request should return non 200 OK status.\n{failed_feed_request:#?}")
+            }
         }
     } else {
         panic!("Invalid request shouldn't be successful");
@@ -32,7 +36,9 @@ fn blocking_client_should_detect_failed_patch_feed_request() {
     if let Err(failed_feed_request) = lore_api_client.request_patch_feed("amd-gfx", 300000) {
         match failed_feed_request {
             FailedFeedRequest::EndOfFeed => (),
-            _ => panic!("Out-of-bounds request should return end of feed.\n{failed_feed_request:#?}")
+            _ => {
+                panic!("Out-of-bounds request should return end of feed.\n{failed_feed_request:#?}")
+            }
         }
     } else {
         panic!("Out-of-bounds request shouldn't be successful");
@@ -54,7 +60,9 @@ fn blocking_client_can_request_valid_available_lists() {
 fn blocking_client_can_request_valid_patch_html() {
     let lore_api_client = BlockingLoreAPIClient::new();
 
-    if let Err(_) = lore_api_client.request_patch_html("all", "Pine.LNX.4.58.0507282031180.3307@g5.osdl.org") {
+    if let Err(_) =
+        lore_api_client.request_patch_html("all", "Pine.LNX.4.58.0507282031180.3307@g5.osdl.org")
+    {
         panic!("Valid request should be successful");
     }
 }

--- a/src/lore_session.rs
+++ b/src/lore_session.rs
@@ -1,16 +1,20 @@
+use crate::lore_api_client::{
+    AvailableListsRequest, FailedAvailableListsRequest, FailedFeedRequest, FailedPatchHTMLRequest,
+    PatchFeedRequest, PatchHTMLRequest,
+};
 use crate::mailing_list::MailingList;
 use crate::patch::{Patch, PatchFeed, PatchRegex};
-use crate::lore_api_client::{
-    AvailableListsRequest, FailedAvailableListsRequest, FailedFeedRequest, FailedPatchHTMLRequest, PatchFeedRequest, PatchHTMLRequest
-};
-use std::collections::HashMap;
-use std::mem::swap;
-use std::{fs::{self, File}, io};
-use std::io::{BufRead, BufReader};
-use std::path::Path;
-use std::process::{Command, Stdio};
 use regex::Regex;
 use serde_xml_rs::from_str;
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader};
+use std::mem::swap;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::{
+    fs::{self, File},
+    io,
+};
 
 #[cfg(test)]
 mod tests;
@@ -44,7 +48,11 @@ impl LoreSession {
         self.processed_patches_map.get(message_id)
     }
 
-    pub fn process_n_representative_patches<T: PatchFeedRequest>(self: &mut Self, lore_api_client: &T, n: u32) -> Result<(), FailedFeedRequest> {
+    pub fn process_n_representative_patches<T: PatchFeedRequest>(
+        self: &mut Self,
+        lore_api_client: &T,
+        n: u32,
+    ) -> Result<(), FailedFeedRequest> {
         let mut patch_feed: PatchFeed;
         let mut processed_patches_ids: Vec<String>;
 
@@ -69,9 +77,13 @@ impl LoreSession {
         for mut patch in patch_feed.get_patches() {
             patch.update_patch_metadata(&self.patch_regex);
 
-            if !self.processed_patches_map.contains_key(&patch.get_message_id().href) {
+            if !self
+                .processed_patches_map
+                .contains_key(&patch.get_message_id().href)
+            {
                 processed_patches_ids.push(patch.get_message_id().href.clone());
-                self.processed_patches_map.insert(patch.get_message_id().href.clone(), patch);
+                self.processed_patches_map
+                    .insert(patch.get_message_id().href.clone(), patch);
             }
         }
 
@@ -89,12 +101,14 @@ impl LoreSession {
             if patch_number_in_series > 1 {
                 continue;
             }
-            
+
             if patch_number_in_series == 1 {
                 if let Some(in_reply_to) = &patch.get_in_reply_to() {
-                    if let Some(patch_in_reply_to) = self.processed_patches_map.get(&in_reply_to.href) {
-                        if (patch_in_reply_to.get_number_in_series() == 0) &&
-                            (patch.get_version() == patch_in_reply_to.get_version())
+                    if let Some(patch_in_reply_to) =
+                        self.processed_patches_map.get(&in_reply_to.href)
+                    {
+                        if (patch_in_reply_to.get_number_in_series() == 0)
+                            && (patch.get_version() == patch_in_reply_to.get_version())
                         {
                             continue;
                         };
@@ -102,13 +116,20 @@ impl LoreSession {
                 };
             }
 
-            self.representative_patches_ids.push(patch.get_message_id().href.clone());
+            self.representative_patches_ids
+                .push(patch.get_message_id().href.clone());
         }
     }
 
-    pub fn get_patch_feed_page(self: &Self, page_size: u32, page_number: u32) -> Option<Vec<&Patch>> {
+    pub fn get_patch_feed_page(
+        self: &Self,
+        page_size: u32,
+        page_number: u32,
+    ) -> Option<Vec<&Patch>> {
         let mut patch_feed_page: Vec<&Patch> = Vec::new();
-        let representative_patches_ids_max_index: u32 = (self.representative_patches_ids.len() - 1).try_into().unwrap();
+        let representative_patches_ids_max_index: u32 = (self.representative_patches_ids.len() - 1)
+            .try_into()
+            .unwrap();
         let lower_end: u32 = page_size * (page_number - 1);
         let mut upper_end: u32 = page_size * page_number;
 
@@ -122,10 +143,9 @@ impl LoreSession {
 
         for i in lower_end..upper_end {
             patch_feed_page.push(
-                self.processed_patches_map.get(
-                    &self.representative_patches_ids[usize::try_from(i).unwrap()]
-                ).
-                unwrap()
+                self.processed_patches_map
+                    .get(&self.representative_patches_ids[usize::try_from(i).unwrap()])
+                    .unwrap(),
             )
         }
 
@@ -182,9 +202,9 @@ pub fn split_patchset(patchset_path_str: &str) -> Result<Vec<String>, String> {
     let cover_letter_path: &Path = Path::new(&cover_letter_path_str);
 
     if !patchset_path.exists() {
-        return Err(format!("{}: Path doesn't exist", patchset_path.display()))
+        return Err(format!("{}: Path doesn't exist", patchset_path.display()));
     } else if !patchset_path.is_file() {
-        return Err(format!("{}: Not a file", patchset_path.display()))
+        return Err(format!("{}: Not a file", patchset_path.display()));
     }
 
     if cover_letter_path.exists() && cover_letter_path.is_file() {
@@ -202,9 +222,7 @@ fn extract_patches(mbox_path: &Path, patches: &mut Vec<String>) {
     let mut is_reading_patch: bool = false;
     let mut is_last_line: bool = false;
 
-    mbox_reader = io::BufReader::new(
-        fs::File::open(mbox_path).unwrap()
-    );
+    mbox_reader = io::BufReader::new(fs::File::open(mbox_path).unwrap());
 
     for line in mbox_reader.lines() {
         let line = line.unwrap();
@@ -242,7 +260,10 @@ fn extract_patches(mbox_path: &Path, patches: &mut Vec<String>) {
     }
 }
 
-pub fn save_bookmarked_patchsets(bookmarked_patchsets: &Vec<Patch>, filepath: &str) -> io::Result<()> {
+pub fn save_bookmarked_patchsets(
+    bookmarked_patchsets: &Vec<Patch>,
+    filepath: &str,
+) -> io::Result<()> {
     if let Some(parent) = Path::new(filepath).parent() {
         fs::create_dir_all(parent)?;
     }
@@ -262,8 +283,12 @@ pub fn load_bookmarked_patchsets(filepath: &str) -> io::Result<Vec<Patch>> {
     Ok(bookmarked_patchesets)
 }
 
-pub fn fetch_available_lists<T>(lore_api_client: &T) -> Result<Vec<MailingList>, FailedAvailableListsRequest>
-where T: AvailableListsRequest {
+pub fn fetch_available_lists<T>(
+    lore_api_client: &T,
+) -> Result<Vec<MailingList>, FailedAvailableListsRequest>
+where
+    T: AvailableListsRequest,
+{
     let mut available_lists: Vec<MailingList> = Vec::new();
     let mut min_index = 0;
 
@@ -313,7 +338,10 @@ fn process_available_lists(available_lists_str: String) -> Vec<MailingList> {
         list_descriptions.push(description);
     }
 
-    let pairs: Vec<(&str, &str)> = list_names.into_iter().zip(list_descriptions.into_iter()).collect();
+    let pairs: Vec<(&str, &str)> = list_names
+        .into_iter()
+        .zip(list_descriptions.into_iter())
+        .collect();
 
     for (name, description) in pairs {
         if name == "all" {
@@ -346,17 +374,24 @@ pub fn load_available_lists(filepath: &str) -> io::Result<Vec<MailingList>> {
 }
 
 pub fn prepare_reply_patchset_with_reviewed_by<T>(
-    lore_api_client: &T, tmp_dir: &Path, target_list: &str,
-    patches: &Vec<String>, git_signature: &str
+    lore_api_client: &T,
+    tmp_dir: &Path,
+    target_list: &str,
+    patches: &Vec<String>,
+    git_signature: &str,
 ) -> Result<Vec<Command>, FailedPatchHTMLRequest>
-where T: PatchHTMLRequest {
+where
+    T: PatchHTMLRequest,
+{
     let mut git_reply_commands: Vec<Command> = Vec::new();
     let re_message_id = Regex::new(r#"(?m)^Message-Id: <(.*?)>"#).unwrap();
 
     for patch in patches.iter() {
         let message_id = re_message_id
-            .captures(patch).unwrap()
-            .get(1).unwrap()
+            .captures(patch)
+            .unwrap()
+            .get(1)
+            .unwrap()
             .as_str();
 
         let reply_path = tmp_dir.join(format!("{message_id}-reply.mbx"));
@@ -388,7 +423,10 @@ fn generate_patch_reply_template(patch_contents: &str) -> String {
 
         if line.starts_with("Subject: ") {
             line_to_push = line.replace("Subject: ", "Subject: Re: ") + "\n";
-        } else if line.starts_with("From: ") || line.starts_with("Date: ") || line.starts_with("Message-Id: ") {
+        } else if line.starts_with("From: ")
+            || line.starts_with("Date: ")
+            || line.starts_with("Message-Id: ")
+        {
             continue;
         } else if !line.trim().is_empty() {
             line_to_push = format!("{}\n", line);
@@ -415,9 +453,8 @@ fn extract_git_reply_command(patch_html: &str) -> Command {
     git_reply_command.arg("--dry-run");
     git_reply_command.arg("--suppress-cc=all");
 
-    let re_full_git_command = Regex::new(
-        r#"(?s)git-send-email\(1\):(.*?)/path/to/YOUR_REPLY"#
-    ).unwrap();
+    let re_full_git_command =
+        Regex::new(r#"(?s)git-send-email\(1\):(.*?)/path/to/YOUR_REPLY"#).unwrap();
     let re_long_options = Regex::new(r"--[^\s=]+=[^\s]+").unwrap();
 
     if let Some(capture) = re_full_git_command.captures(patch_html) {
@@ -436,28 +473,41 @@ fn extract_git_reply_command(patch_html: &str) -> Command {
 pub fn get_git_signature(git_repo_path: &str) -> (String, String) {
     let mut git_user_name_command = Command::new("git");
     if !git_repo_path.is_empty() {
-        git_user_name_command.arg("-C").arg(format!("{}", git_repo_path));
+        git_user_name_command
+            .arg("-C")
+            .arg(format!("{}", git_repo_path));
     }
-    let git_user_name_output = git_user_name_command.arg("config")
+    let git_user_name_output = git_user_name_command
+        .arg("config")
         .arg("user.name")
         .output()
         .unwrap();
-    let git_user_name = std::str::from_utf8(&git_user_name_output.stdout).unwrap().trim();
+    let git_user_name = std::str::from_utf8(&git_user_name_output.stdout)
+        .unwrap()
+        .trim();
 
     let mut git_user_email_command = Command::new("git");
     if !git_repo_path.is_empty() {
-        git_user_email_command.arg("-C").arg(format!("{}", git_repo_path));
+        git_user_email_command
+            .arg("-C")
+            .arg(format!("{}", git_repo_path));
     }
-    let git_user_email_output = git_user_email_command.arg("config")
+    let git_user_email_output = git_user_email_command
+        .arg("config")
         .arg("user.email")
         .output()
         .unwrap();
-    let git_user_email = std::str::from_utf8(&git_user_email_output.stdout).unwrap().trim();
+    let git_user_email = std::str::from_utf8(&git_user_email_output.stdout)
+        .unwrap()
+        .trim();
 
     (git_user_name.to_owned(), git_user_email.to_owned())
 }
 
-pub fn save_reviewed_patchsets(reviewed_patchsets: &HashMap<String, Vec<u32>>, filepath: &str) -> io::Result<()> {
+pub fn save_reviewed_patchsets(
+    reviewed_patchsets: &HashMap<String, Vec<u32>>,
+    filepath: &str,
+) -> io::Result<()> {
     if let Some(parent) = Path::new(filepath).parent() {
         fs::create_dir_all(parent)?;
     }

--- a/src/lore_session/tests.rs
+++ b/src/lore_session/tests.rs
@@ -4,9 +4,15 @@ use super::*;
 use crate::patch::Author;
 use std::fs;
 
-struct FakeLoreAPIClient { src_path: String }
+struct FakeLoreAPIClient {
+    src_path: String,
+}
 impl PatchFeedRequest for FakeLoreAPIClient {
-    fn request_patch_feed(self: &Self, target_list: &str, min_index: u32) -> Result<String, FailedFeedRequest> {
+    fn request_patch_feed(
+        self: &Self,
+        target_list: &str,
+        min_index: u32,
+    ) -> Result<String, FailedFeedRequest> {
         let _ = min_index;
         let _ = target_list;
         Ok(fs::read_to_string(&self.src_path).unwrap())
@@ -17,7 +23,8 @@ impl PatchFeedRequest for FakeLoreAPIClient {
 fn can_initialize_fresh_lore_session() {
     let lore_session: LoreSession = LoreSession::new("some-list".to_string());
 
-    assert!(lore_session.get_representative_patches_ids().len() == 0,
+    assert!(
+        lore_session.get_representative_patches_ids().len() == 0,
         "`LoreSession` should initialize with an empty vector of representative patches IDs"
     );
 }
@@ -25,35 +32,55 @@ fn can_initialize_fresh_lore_session() {
 #[test]
 fn should_process_one_representative_patch() {
     let mut lore_session: LoreSession = LoreSession::new("some-list".to_string());
-    let lore_api_client: FakeLoreAPIClient = FakeLoreAPIClient { src_path: "src/test_samples/lore_session/process_representative_patch/patch_feed_sample_1.xml".to_string() };
+    let lore_api_client: FakeLoreAPIClient = FakeLoreAPIClient {
+        src_path:
+            "src/test_samples/lore_session/process_representative_patch/patch_feed_sample_1.xml"
+                .to_string(),
+    };
     let message_id: &str = "http://lore.kernel.org/some-subsystem/1234.567-1-john@johnson.com/";
     let patch: &Patch;
 
     if let Ok(_) = lore_session.process_n_representative_patches(&lore_api_client, 1) {};
 
-    assert_eq!(1, lore_session.get_representative_patches_ids().len(),
+    assert_eq!(
+        1,
+        lore_session.get_representative_patches_ids().len(),
         "Should have processed exactly 1 representative patches, but processed {}",
         lore_session.get_representative_patches_ids().len()
     );
 
-    assert_eq!(message_id, lore_session.get_representative_patches_ids().get(0).unwrap(),
+    assert_eq!(
+        message_id,
+        lore_session
+            .get_representative_patches_ids()
+            .get(0)
+            .unwrap(),
         "Wrong representative patch message ID"
     );
 
     patch = lore_session.get_processed_patch(message_id).unwrap();
-    assert_eq!("some/subsystem: Do this and that", patch.get_title(),
+    assert_eq!(
+        "some/subsystem: Do this and that",
+        patch.get_title(),
         "Wrong title of processed patch"
     );
-    assert_eq!(&Author { name: "John Johnson".to_string(), email: "john@johnson.com".to_string() }, patch.get_author(),
+    assert_eq!(
+        &Author {
+            name: "John Johnson".to_string(),
+            email: "john@johnson.com".to_string()
+        },
+        patch.get_author(),
         "Wrong author of processed patch"
     );
-    assert_eq!(1, patch.get_version(),
-        "Wrong version of processed patch"
-    );
-    assert_eq!(0, patch.get_number_in_series(),
+    assert_eq!(1, patch.get_version(), "Wrong version of processed patch");
+    assert_eq!(
+        0,
+        patch.get_number_in_series(),
         "Wrong number in series of processed patch"
     );
-    assert_eq!(2, patch.get_total_in_series(),
+    assert_eq!(
+        2,
+        patch.get_total_in_series(),
         "Wrong total in series of processed patch"
     );
 }
@@ -61,25 +88,46 @@ fn should_process_one_representative_patch() {
 #[test]
 fn should_process_multiple_representative_patches() {
     let mut lore_session: LoreSession = LoreSession::new("some-list".to_string());
-    let lore_api_client: FakeLoreAPIClient = FakeLoreAPIClient { src_path: "src/test_samples/lore_session/process_representative_patch/patch_feed_sample_2.xml".to_string() };
+    let lore_api_client: FakeLoreAPIClient = FakeLoreAPIClient {
+        src_path:
+            "src/test_samples/lore_session/process_representative_patch/patch_feed_sample_2.xml"
+                .to_string(),
+    };
     let message_id_1: &str = "http://lore.kernel.org/some-subsystem/1234.567-1-roberto@silva.br/";
     let message_id_2: &str = "http://lore.kernel.org/some-subsystem/first-patch-lima@luma.rs/";
     let message_id_3: &str = "http://lore.kernel.org/some-subsystem/1234.567-1-john@johnson.com/";
 
     if let Ok(_) = lore_session.process_n_representative_patches(&lore_api_client, 3) {};
 
-    assert_eq!(3, lore_session.get_representative_patches_ids().len(),
+    assert_eq!(
+        3,
+        lore_session.get_representative_patches_ids().len(),
         "Should have processed exactly 3 representative patches, but processed {}",
         lore_session.get_representative_patches_ids().len()
     );
 
-    assert_eq!(message_id_1 , lore_session.get_representative_patches_ids().get(0).unwrap(),
+    assert_eq!(
+        message_id_1,
+        lore_session
+            .get_representative_patches_ids()
+            .get(0)
+            .unwrap(),
         "Wrong representative patch message ID at index 0"
     );
-    assert_eq!(message_id_2 , lore_session.get_representative_patches_ids().get(1).unwrap(),
+    assert_eq!(
+        message_id_2,
+        lore_session
+            .get_representative_patches_ids()
+            .get(1)
+            .unwrap(),
         "Wrong representative patch message ID at index 1"
     );
-    assert_eq!(message_id_3 , lore_session.get_representative_patches_ids().get(2).unwrap(),
+    assert_eq!(
+        message_id_3,
+        lore_session
+            .get_representative_patches_ids()
+            .get(2)
+            .unwrap(),
         "Wrong representative patch message ID at index 2"
     );
 }
@@ -89,130 +137,173 @@ fn test_split_patchset_invalid_cases() {
     let ret: Result<Vec<String>, String> = split_patchset("invalid/path");
     assert_eq!(Err(format!("invalid/path: Path doesn't exist")), ret);
 
-    let ret: Result<Vec<String>, String> = split_patchset("src/test_samples/lore_session/split_patchset/not_a_file");
-    assert_eq!(Err(format!("src/test_samples/lore_session/split_patchset/not_a_file: Not a file")), ret);
+    let ret: Result<Vec<String>, String> =
+        split_patchset("src/test_samples/lore_session/split_patchset/not_a_file");
+    assert_eq!(
+        Err(format!(
+            "src/test_samples/lore_session/split_patchset/not_a_file: Not a file"
+        )),
+        ret
+    );
 }
 
 #[test]
 fn should_split_patchset_without_cover_letter() {
     let ret: Result<Vec<String>, String> = split_patchset(
-        "src/test_samples/lore_session/split_patchset/patchset_sample_without_cover_letter.mbx"
+        "src/test_samples/lore_session/split_patchset/patchset_sample_without_cover_letter.mbx",
     );
 
     if let Err(_) = ret {
         panic!("Should return a `Vec<String>` type");
     }
-    
+
     let patches = ret.unwrap();
 
-    assert_eq!(
-        3, patches.len(),
-        "Wrong number of patches"
-    );
+    assert_eq!(3, patches.len(), "Wrong number of patches");
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_1.mbx").unwrap(), patches[0],
+        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_1.mbx")
+            .unwrap(),
+        patches[0],
         "Wrong patch number 1"
     );
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_2.mbx").unwrap(), patches[1],
+        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_2.mbx")
+            .unwrap(),
+        patches[1],
         "Wrong patch number 2"
     );
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_3.mbx").unwrap(), patches[2],
+        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_3.mbx")
+            .unwrap(),
+        patches[2],
         "Wrong patch number 3"
     );
 }
 
 #[test]
 fn should_split_patchset_complete() {
-    let ret: Result<Vec<String>, String> = split_patchset(
-        "src/test_samples/lore_session/split_patchset/patchset_sample_complete.mbx"
-    );
+    let ret: Result<Vec<String>, String> =
+        split_patchset("src/test_samples/lore_session/split_patchset/patchset_sample_complete.mbx");
 
     if let Err(_) = ret {
         panic!("Should return a `Vec<String>` type");
     }
-    
+
     let patches = ret.unwrap();
 
-    assert_eq!(
-        4, patches.len(),
-        "Wrong number of patches"
-    );
+    assert_eq!(4, patches.len(), "Wrong number of patches");
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_cover_letter.cover").unwrap(), patches[0],
+        fs::read_to_string(
+            "src/test_samples/lore_session/split_patchset/expected_cover_letter.cover"
+        )
+        .unwrap(),
+        patches[0],
         "Wrong cover letter"
     );
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_1.mbx").unwrap(), patches[1],
+        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_1.mbx")
+            .unwrap(),
+        patches[1],
         "Wrong patch number 1"
     );
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_2.mbx").unwrap(), patches[2],
+        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_2.mbx")
+            .unwrap(),
+        patches[2],
         "Wrong patch number 2"
     );
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_3.mbx").unwrap(), patches[3],
+        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_3.mbx")
+            .unwrap(),
+        patches[3],
         "Wrong patch number 3"
     );
 }
 
 #[test]
 fn should_process_available_lists() {
-    let available_lists_response = fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-1.html").unwrap();
+    let available_lists_response = fs::read_to_string(
+        "src/test_samples/lore_session/process_available_lists/available_lists_response-1.html",
+    )
+    .unwrap();
     let available_lists = process_available_lists(available_lists_response);
 
-    assert_eq!(199, available_lists.len(),
-        "Should've processed 199 lists"
-    );
+    assert_eq!(199, available_lists.len(), "Should've processed 199 lists");
 
-    assert_eq!("linux-mm".to_string(), available_lists[0].get_name(),
+    assert_eq!(
+        "linux-mm".to_string(),
+        available_lists[0].get_name(),
         "Wrong list name for index 0"
     );
-    assert_eq!("Linux-mm Archive on lore.kernel.org".to_string(), available_lists[0].get_description(),
+    assert_eq!(
+        "Linux-mm Archive on lore.kernel.org".to_string(),
+        available_lists[0].get_description(),
         "Wrong list description for index 0"
     );
-    assert_eq!("linux-kselftest".to_string(), available_lists[42].get_name(),
+    assert_eq!(
+        "linux-kselftest".to_string(),
+        available_lists[42].get_name(),
         "Wrong list name for index 42"
     );
-    assert_eq!("Linux Kernel Selftest development".to_string(), available_lists[42].get_description(),
+    assert_eq!(
+        "Linux Kernel Selftest development".to_string(),
+        available_lists[42].get_description(),
         "Wrong list description for index 42"
     );
-    assert_eq!("distributions".to_string(), available_lists[99].get_name(),
+    assert_eq!(
+        "distributions".to_string(),
+        available_lists[99].get_name(),
         "Wrong list name for index 99"
     );
-    assert_eq!("Forum for Linux distributions to discuss problems and share PSAs".to_string(), available_lists[99].get_description(),
+    assert_eq!(
+        "Forum for Linux distributions to discuss problems and share PSAs".to_string(),
+        available_lists[99].get_description(),
         "Wrong list description for index 99"
     );
-    assert_eq!("grub-devel".to_string(), available_lists[135].get_name(),
+    assert_eq!(
+        "grub-devel".to_string(),
+        available_lists[135].get_name(),
         "Wrong list name for index 135"
     );
-    assert_eq!("Grub Development Archive on lore.kernel.org".to_string(), available_lists[135].get_description(),
+    assert_eq!(
+        "Grub Development Archive on lore.kernel.org".to_string(),
+        available_lists[135].get_description(),
         "Wrong list description for index 135"
     );
-    assert_eq!("linux-nilfs".to_string(), available_lists[180].get_name(),
+    assert_eq!(
+        "linux-nilfs".to_string(),
+        available_lists[180].get_name(),
         "Wrong list name for index 180"
     );
-    assert_eq!("Linux NILFS development".to_string(), available_lists[180].get_description(),
+    assert_eq!(
+        "Linux NILFS development".to_string(),
+        available_lists[180].get_description(),
         "Wrong list description for index 180"
     );
-    assert_eq!("linux-sparse".to_string(), available_lists[198].get_name(),
+    assert_eq!(
+        "linux-sparse".to_string(),
+        available_lists[198].get_name(),
         "Wrong list name for index 198"
     );
-    assert_eq!("Linux SPARSE checker discussions".to_string(), available_lists[198].get_description(),
+    assert_eq!(
+        "Linux SPARSE checker discussions".to_string(),
+        available_lists[198].get_description(),
         "Wrong list description for index 198"
     );
 }
 
 impl AvailableListsRequest for FakeLoreAPIClient {
-    fn request_available_lists(self: &Self, min_index: u32) -> Result<String, FailedAvailableListsRequest> {
+    fn request_available_lists(
+        self: &Self,
+        min_index: u32,
+    ) -> Result<String, FailedAvailableListsRequest> {
         match min_index {
             0 => Ok(fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-1.html").unwrap()),
             200 => Ok(fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-2.html").unwrap()),
@@ -224,25 +315,39 @@ impl AvailableListsRequest for FakeLoreAPIClient {
 
 #[test]
 fn should_fetch_all_available_lists() {
-    let lore_api_client = FakeLoreAPIClient { src_path: "".to_string() };
+    let lore_api_client = FakeLoreAPIClient {
+        src_path: "".to_string(),
+    };
     let sorted_available_lists = fetch_available_lists(&lore_api_client).unwrap();
 
-    assert_eq!("accel-config".to_string(), sorted_available_lists[0].get_name(),
+    assert_eq!(
+        "accel-config".to_string(),
+        sorted_available_lists[0].get_name(),
         "Wrong list name for index 0"
     );
-    assert_eq!("Accel-Config development".to_string(), sorted_available_lists[0].get_description(),
+    assert_eq!(
+        "Accel-Config development".to_string(),
+        sorted_available_lists[0].get_description(),
         "Wrong list description for index 0"
     );
-    assert_eq!("linux-mediatek".to_string(), sorted_available_lists[159].get_name(),
+    assert_eq!(
+        "linux-mediatek".to_string(),
+        sorted_available_lists[159].get_name(),
         "Wrong list name for index 159"
     );
-    assert_eq!("Linux-mediatek Archive on lore.kernel.org".to_string(), sorted_available_lists[159].get_description(),
+    assert_eq!(
+        "Linux-mediatek Archive on lore.kernel.org".to_string(),
+        sorted_available_lists[159].get_description(),
         "Wrong list description for index 159"
     );
-    assert_eq!("yocto-toaster".to_string(), sorted_available_lists[319].get_name(),
+    assert_eq!(
+        "yocto-toaster".to_string(),
+        sorted_available_lists[319].get_name(),
         "Wrong list name for index 319"
     );
-    assert_eq!("Yocto Toaster".to_string(), sorted_available_lists[319].get_description(),
+    assert_eq!(
+        "Yocto Toaster".to_string(),
+        sorted_available_lists[319].get_description(),
         "Wrong list description for index 319"
     );
 
@@ -251,25 +356,34 @@ fn should_fetch_all_available_lists() {
 
 #[test]
 fn should_generate_patch_reply_template() {
-    let patch_sample = fs::read_to_string("src/test_samples/lore_session/generate_patch_reply_template/patch_sample.mbx").unwrap();
-    let expected_reply_template = fs::read_to_string("src/test_samples/lore_session/generate_patch_reply_template/expected_reply_template.mbx").unwrap();
+    let patch_sample = fs::read_to_string(
+        "src/test_samples/lore_session/generate_patch_reply_template/patch_sample.mbx",
+    )
+    .unwrap();
+    let expected_reply_template = fs::read_to_string(
+        "src/test_samples/lore_session/generate_patch_reply_template/expected_reply_template.mbx",
+    )
+    .unwrap();
 
     let reply_template = generate_patch_reply_template(&patch_sample);
 
-    assert_eq!(expected_reply_template, reply_template,
+    assert_eq!(
+        expected_reply_template, reply_template,
         "Reply template wasn't correctly generated"
     )
 }
 
 fn commands_eq(cmd1: &Command, cmd2: &Command) -> bool {
-    cmd1.get_program() == cmd2.get_program() &&
-    cmd1.get_args().collect::<Vec<_>>() == cmd2.get_args().collect::<Vec<_>>()
+    cmd1.get_program() == cmd2.get_program()
+        && cmd1.get_args().collect::<Vec<_>>() == cmd2.get_args().collect::<Vec<_>>()
 }
 
 #[test]
-fn should_extract_git_reply_command_from_patch_html()
-{
-    let patch_html = fs::read_to_string("src/test_samples/lore_session/extract_git_reply_command/patch_lore_sample.html").unwrap();
+fn should_extract_git_reply_command_from_patch_html() {
+    let patch_html = fs::read_to_string(
+        "src/test_samples/lore_session/extract_git_reply_command/patch_lore_sample.html",
+    )
+    .unwrap();
     let mut expected_git_reply_command = Command::new("git");
     expected_git_reply_command
         .arg("send-email")
@@ -283,8 +397,11 @@ fn should_extract_git_reply_command_from_patch_html()
 
     let git_reply_command = extract_git_reply_command(&patch_html);
 
-    assert!(commands_eq(&expected_git_reply_command, &git_reply_command),
-        "Wrong git reply command\nExpected:{:?}\n  Actual:{:?}", expected_git_reply_command, git_reply_command
+    assert!(
+        commands_eq(&expected_git_reply_command, &git_reply_command),
+        "Wrong git reply command\nExpected:{:?}\n  Actual:{:?}",
+        expected_git_reply_command,
+        git_reply_command
     );
 }
 
@@ -302,7 +419,11 @@ fn files_eq(path1: &str, path2: &str) -> io::Result<bool> {
 }
 
 impl PatchHTMLRequest for FakeLoreAPIClient {
-    fn request_patch_html(self: &Self, _target_list: &str, message_id: &str) -> Result<String, FailedPatchHTMLRequest> {
+    fn request_patch_html(
+        self: &Self,
+        _target_list: &str,
+        message_id: &str,
+    ) -> Result<String, FailedPatchHTMLRequest> {
         let patch_html = "git-send-email(1): ".to_owned();
         let patch_html = match message_id {
             "1234.567-0-foo@bar.foo.bar" => patch_html + "git send-email --in-reply-to=1234.567-0-foo@bar.foo.bar --to=foo@bar.foo.bar /path/to/YOUR_REPLY",
@@ -318,13 +439,8 @@ impl PatchHTMLRequest for FakeLoreAPIClient {
 
 #[test]
 fn should_prepare_reply_patchset_with_reviewed_by() {
-    let tmp_dir = Command::new("mktemp")
-        .arg("--directory")
-        .output()
-        .unwrap();
-    let tmp_dir = Path::new(
-        std::str::from_utf8(&tmp_dir.stdout).unwrap().trim()
-    );
+    let tmp_dir = Command::new("mktemp").arg("--directory").output().unwrap();
+    let tmp_dir = Path::new(std::str::from_utf8(&tmp_dir.stdout).unwrap().trim());
 
     let mut expected_git_reply_command_0 = Command::new("git");
     expected_git_reply_command_0
@@ -333,7 +449,10 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
         .arg("--suppress-cc=all")
         .arg("--in-reply-to=1234.567-0-foo@bar.foo.bar")
         .arg("--to=foo@bar.foo.bar")
-        .arg(format!("{}/1234.567-0-foo@bar.foo.bar-reply.mbx", tmp_dir.display()));
+        .arg(format!(
+            "{}/1234.567-0-foo@bar.foo.bar-reply.mbx",
+            tmp_dir.display()
+        ));
     let mut expected_git_reply_command_1 = Command::new("git");
     expected_git_reply_command_1
         .arg("send-email")
@@ -341,7 +460,10 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
         .arg("--suppress-cc=all")
         .arg("--in-reply-to=1234.567-1-foo@bar.foo.bar")
         .arg("--to=foo@bar.foo.bar")
-        .arg(format!("{}/1234.567-1-foo@bar.foo.bar-reply.mbx", tmp_dir.display()));
+        .arg(format!(
+            "{}/1234.567-1-foo@bar.foo.bar-reply.mbx",
+            tmp_dir.display()
+        ));
     let mut expected_git_reply_command_2 = Command::new("git");
     expected_git_reply_command_2
         .arg("send-email")
@@ -349,7 +471,10 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
         .arg("--suppress-cc=all")
         .arg("--in-reply-to=1234.567-2-foo@bar.foo.bar")
         .arg("--to=foo@bar.foo.bar")
-        .arg(format!("{}/1234.567-2-foo@bar.foo.bar-reply.mbx", tmp_dir.display()));
+        .arg(format!(
+            "{}/1234.567-2-foo@bar.foo.bar-reply.mbx",
+            tmp_dir.display()
+        ));
     let mut expected_git_reply_command_3 = Command::new("git");
     expected_git_reply_command_3
         .arg("send-email")
@@ -357,42 +482,73 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
         .arg("--suppress-cc=all")
         .arg("--in-reply-to=1234.567-3-foo@bar.foo.bar")
         .arg("--to=foo@bar.foo.bar")
-        .arg(format!("{}/1234.567-3-foo@bar.foo.bar-reply.mbx", tmp_dir.display()));
+        .arg(format!(
+            "{}/1234.567-3-foo@bar.foo.bar-reply.mbx",
+            tmp_dir.display()
+        ));
 
     let expected_git_reply_commands = vec![
         expected_git_reply_command_0,
         expected_git_reply_command_1,
         expected_git_reply_command_2,
-        expected_git_reply_command_3
+        expected_git_reply_command_3,
     ];
 
-    let lore_api_client = FakeLoreAPIClient{ src_path: "".to_owned() };
+    let lore_api_client = FakeLoreAPIClient {
+        src_path: "".to_owned(),
+    };
 
     let patches = vec![
-        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/cover_letter.cover").unwrap(),
-        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/patch_1.mbx").unwrap(),
-        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/patch_2.mbx").unwrap(),
-        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/patch_3.mbx").unwrap(),
+        fs::read_to_string(
+            "src/test_samples/lore_session/prepare_reply_w_reviewed_by/cover_letter.cover",
+        )
+        .unwrap(),
+        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/patch_1.mbx")
+            .unwrap(),
+        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/patch_2.mbx")
+            .unwrap(),
+        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/patch_3.mbx")
+            .unwrap(),
     ];
 
     let git_reply_commands = prepare_reply_patchset_with_reviewed_by(
-        &lore_api_client, &tmp_dir, "all", &patches, "Bar Foo <bar@foo.bar.foo>"
-    ).unwrap();
+        &lore_api_client,
+        &tmp_dir,
+        "all",
+        &patches,
+        "Bar Foo <bar@foo.bar.foo>",
+    )
+    .unwrap();
 
-    for (expected, actual) in expected_git_reply_commands.iter().zip(git_reply_commands.iter()) {
-        assert!(commands_eq(&expected, &actual),
-            "Wrong git reply command\nExpected:{:?}\n  Actual:{:?}", expected, actual 
+    for (expected, actual) in expected_git_reply_commands
+        .iter()
+        .zip(git_reply_commands.iter())
+    {
+        assert!(
+            commands_eq(&expected, &actual),
+            "Wrong git reply command\nExpected:{:?}\n  Actual:{:?}",
+            expected,
+            actual
         );
-
     }
 
     for i in 0..=3 {
-        let expected_path = format!("src/test_samples/lore_session/prepare_reply_w_reviewed_by/expected_patch_{}-reply.mbx", i);
-        let actual_path = format!("{}/1234.567-{}-foo@bar.foo.bar-reply.mbx", tmp_dir.display(), i);
-        assert!(files_eq(&expected_path, &actual_path).unwrap(),
+        let expected_path = format!(
+            "src/test_samples/lore_session/prepare_reply_w_reviewed_by/expected_patch_{}-reply.mbx",
+            i
+        );
+        let actual_path = format!(
+            "{}/1234.567-{}-foo@bar.foo.bar-reply.mbx",
+            tmp_dir.display(),
+            i
+        );
+        assert!(
+            files_eq(&expected_path, &actual_path).unwrap(),
             "Wrong reply with reviewed-by generated\nExpected ({}):\n{}\n  Actual({}):\n{}\n",
-            &expected_path, &fs::read_to_string(&expected_path).unwrap(),
-            &actual_path, &fs::read_to_string(&actual_path).unwrap()
+            &expected_path,
+            &fs::read_to_string(&expected_path).unwrap(),
+            &actual_path,
+            &fs::read_to_string(&actual_path).unwrap()
         );
     }
 
@@ -401,22 +557,17 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
 
 #[test]
 fn should_get_local_git_signature() {
-    let mocked_git_repo = Command::new("mktemp")
-        .arg("--directory")
-        .output()
-        .unwrap();
-    let mocked_git_repo = Path::new(
-        std::str::from_utf8(&mocked_git_repo.stdout).unwrap().trim()
-    );
+    let mocked_git_repo = Command::new("mktemp").arg("--directory").output().unwrap();
+    let mocked_git_repo = Path::new(std::str::from_utf8(&mocked_git_repo.stdout).unwrap().trim());
 
-    let _ =Command::new("git")
+    let _ = Command::new("git")
         .arg("-C")
         .arg(format!("{}", mocked_git_repo.display()))
         .arg("init")
         .output()
         .unwrap();
 
-    let _ =Command::new("git")
+    let _ = Command::new("git")
         .arg("-C")
         .arg(format!("{}", mocked_git_repo.display()))
         .arg("config")
@@ -426,7 +577,7 @@ fn should_get_local_git_signature() {
         .output()
         .unwrap();
 
-    let _ =Command::new("git")
+    let _ = Command::new("git")
         .arg("-C")
         .arg(format!("{}", mocked_git_repo.display()))
         .arg("config")
@@ -438,11 +589,15 @@ fn should_get_local_git_signature() {
 
     let (git_user_name, git_user_email) = get_git_signature(mocked_git_repo.to_str().unwrap());
 
-    assert_eq!("Foo Bar".to_owned(), git_user_name,
+    assert_eq!(
+        "Foo Bar".to_owned(),
+        git_user_name,
         "Wrong `git config user.name` value"
     );
 
-    assert_eq!("foo@bar.foo.bar".to_owned(), git_user_email,
+    assert_eq!(
+        "foo@bar.foo.bar".to_owned(),
+        git_user_email,
         "Wrong `git config user.email` value"
     );
 

--- a/src/lore_session/tests.rs
+++ b/src/lore_session/tests.rs
@@ -9,7 +9,7 @@ struct FakeLoreAPIClient {
 }
 impl PatchFeedRequest for FakeLoreAPIClient {
     fn request_patch_feed(
-        self: &Self,
+        &self,
         target_list: &str,
         min_index: u32,
     ) -> Result<String, FailedFeedRequest> {
@@ -24,7 +24,7 @@ fn can_initialize_fresh_lore_session() {
     let lore_session: LoreSession = LoreSession::new("some-list".to_string());
 
     assert!(
-        lore_session.get_representative_patches_ids().len() == 0,
+        lore_session.get_representative_patches_ids().is_empty(),
         "`LoreSession` should initialize with an empty vector of representative patches IDs"
     );
 }
@@ -38,9 +38,11 @@ fn should_process_one_representative_patch() {
                 .to_string(),
     };
     let message_id: &str = "http://lore.kernel.org/some-subsystem/1234.567-1-john@johnson.com/";
-    let patch: &Patch;
 
-    if let Ok(_) = lore_session.process_n_representative_patches(&lore_api_client, 1) {};
+    if lore_session
+        .process_n_representative_patches(&lore_api_client, 1)
+        .is_ok()
+    {};
 
     assert_eq!(
         1,
@@ -53,12 +55,12 @@ fn should_process_one_representative_patch() {
         message_id,
         lore_session
             .get_representative_patches_ids()
-            .get(0)
+            .first()
             .unwrap(),
         "Wrong representative patch message ID"
     );
 
-    patch = lore_session.get_processed_patch(message_id).unwrap();
+    let patch = lore_session.get_processed_patch(message_id).unwrap();
     assert_eq!(
         "some/subsystem: Do this and that",
         patch.get_title(),
@@ -97,7 +99,10 @@ fn should_process_multiple_representative_patches() {
     let message_id_2: &str = "http://lore.kernel.org/some-subsystem/first-patch-lima@luma.rs/";
     let message_id_3: &str = "http://lore.kernel.org/some-subsystem/1234.567-1-john@johnson.com/";
 
-    if let Ok(_) = lore_session.process_n_representative_patches(&lore_api_client, 3) {};
+    if lore_session
+        .process_n_representative_patches(&lore_api_client, 3)
+        .is_ok()
+    {};
 
     assert_eq!(
         3,
@@ -110,7 +115,7 @@ fn should_process_multiple_representative_patches() {
         message_id_1,
         lore_session
             .get_representative_patches_ids()
-            .get(0)
+            .first()
             .unwrap(),
         "Wrong representative patch message ID at index 0"
     );
@@ -135,14 +140,12 @@ fn should_process_multiple_representative_patches() {
 #[test]
 fn test_split_patchset_invalid_cases() {
     let ret: Result<Vec<String>, String> = split_patchset("invalid/path");
-    assert_eq!(Err(format!("invalid/path: Path doesn't exist")), ret);
+    assert_eq!(Err("invalid/path: Path doesn't exist".to_string()), ret);
 
     let ret: Result<Vec<String>, String> =
         split_patchset("src/test_samples/lore_session/split_patchset/not_a_file");
     assert_eq!(
-        Err(format!(
-            "src/test_samples/lore_session/split_patchset/not_a_file: Not a file"
-        )),
+        Err("src/test_samples/lore_session/split_patchset/not_a_file: Not a file".to_string()),
         ret
     );
 }
@@ -153,7 +156,7 @@ fn should_split_patchset_without_cover_letter() {
         "src/test_samples/lore_session/split_patchset/patchset_sample_without_cover_letter.mbx",
     );
 
-    if let Err(_) = ret {
+    if ret.is_err() {
         panic!("Should return a `Vec<String>` type");
     }
 
@@ -188,7 +191,7 @@ fn should_split_patchset_complete() {
     let ret: Result<Vec<String>, String> =
         split_patchset("src/test_samples/lore_session/split_patchset/patchset_sample_complete.mbx");
 
-    if let Err(_) = ret {
+    if ret.is_err() {
         panic!("Should return a `Vec<String>` type");
     }
 
@@ -301,7 +304,7 @@ fn should_process_available_lists() {
 
 impl AvailableListsRequest for FakeLoreAPIClient {
     fn request_available_lists(
-        self: &Self,
+        &self,
         min_index: u32,
     ) -> Result<String, FailedAvailableListsRequest> {
         match min_index {
@@ -420,7 +423,7 @@ fn files_eq(path1: &str, path2: &str) -> io::Result<bool> {
 
 impl PatchHTMLRequest for FakeLoreAPIClient {
     fn request_patch_html(
-        self: &Self,
+        &self,
         _target_list: &str,
         message_id: &str,
     ) -> Result<String, FailedPatchHTMLRequest> {
@@ -513,7 +516,7 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
 
     let git_reply_commands = prepare_reply_patchset_with_reviewed_by(
         &lore_api_client,
-        &tmp_dir,
+        tmp_dir,
         "all",
         &patches,
         "Bar Foo <bar@foo.bar.foo>",
@@ -525,7 +528,7 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
         .zip(git_reply_commands.iter())
     {
         assert!(
-            commands_eq(&expected, &actual),
+            commands_eq(expected, actual),
             "Wrong git reply command\nExpected:{:?}\n  Actual:{:?}",
             expected,
             actual

--- a/src/mailing_list.rs
+++ b/src/mailing_list.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;

--- a/src/mailing_list.rs
+++ b/src/mailing_list.rs
@@ -12,28 +12,28 @@ pub struct MailingList {
 impl MailingList {
     pub fn new(name: &str, description: &str) -> Self {
         MailingList {
-            name: format!("{name}"),
-            description: format!("{description}"),
+            name: name.to_string(),
+            description: description.to_string(),
         }
     }
 
-    pub fn get_name(self: &Self) -> &str {
+    pub fn get_name(&self) -> &str {
         &self.name
     }
 
-    pub fn get_description(self: &Self) -> &str {
+    pub fn get_description(&self) -> &str {
         &self.description
     }
 }
 
 impl Ord for MailingList {
-    fn cmp(self: &Self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.name.cmp(&other.name)
     }
 }
 
 impl PartialOrd for MailingList {
-    fn partial_cmp(self: &Self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }

--- a/src/mailing_list/tests.rs
+++ b/src/mailing_list/tests.rs
@@ -2,24 +2,26 @@ use super::*;
 
 #[test]
 fn can_deserialize_mailing_list() {
-    let expected_mailing_list = MailingList::new(
-        "list-name", "List Description"
-    );
+    let expected_mailing_list = MailingList::new("list-name", "List Description");
     let serialized_mailing_list = r#"{"name":"list-name","description":"List Description"}"#;
-    let deserialized_mailing_list: MailingList = serde_json::from_str(serialized_mailing_list).unwrap();
+    let deserialized_mailing_list: MailingList =
+        serde_json::from_str(serialized_mailing_list).unwrap();
 
-    assert_eq!(expected_mailing_list, deserialized_mailing_list,
+    assert_eq!(
+        expected_mailing_list, deserialized_mailing_list,
         "Wrong deserialization of mailing list"
     )
 }
 
 #[test]
 fn can_serialize_mailing_list() {
-    let expected_serialized_mailing_list = r#"{"name":"list-name","description":"List Description"}"#;
+    let expected_serialized_mailing_list =
+        r#"{"name":"list-name","description":"List Description"}"#;
     let mailing_list = MailingList::new("list-name", "List Description");
     let serialized_mailing_list = serde_json::to_string(&mailing_list).unwrap();
 
-    assert_eq!(expected_serialized_mailing_list, serialized_mailing_list,
+    assert_eq!(
+        expected_serialized_mailing_list, serialized_mailing_list,
         "Wrong serialization of mailing list"
     )
 }
@@ -36,19 +38,24 @@ fn should_sort_mailing_list_vec() {
     let mailing_list_vec_for_cmp = mailing_list_vec.clone();
     mailing_list_vec.sort();
 
-    assert_eq!(mailing_list_vec_for_cmp[4], mailing_list_vec[0],
+    assert_eq!(
+        mailing_list_vec_for_cmp[4], mailing_list_vec[0],
         "Wrong mailing list at index 0"
     );
-    assert_eq!(mailing_list_vec_for_cmp[2], mailing_list_vec[1],
+    assert_eq!(
+        mailing_list_vec_for_cmp[2], mailing_list_vec[1],
         "Wrong mailing list at index 1"
     );
-    assert_eq!(mailing_list_vec_for_cmp[0], mailing_list_vec[2],
+    assert_eq!(
+        mailing_list_vec_for_cmp[0], mailing_list_vec[2],
         "Wrong mailing list at index 2"
     );
-    assert_eq!(mailing_list_vec_for_cmp[3], mailing_list_vec[3],
+    assert_eq!(
+        mailing_list_vec_for_cmp[3], mailing_list_vec[3],
         "Wrong mailing list at index 3"
     );
-    assert_eq!(mailing_list_vec_for_cmp[1], mailing_list_vec[4],
+    assert_eq!(
+        mailing_list_vec_for_cmp[1], mailing_list_vec[4],
         "Wrong mailing list at index 4"
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> color_eyre::Result<()> {
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> color_eyre::Result<()> {
     loop {
-        terminal.draw(|f| draw_ui(f, &app))?;
+        terminal.draw(|f| draw_ui(f, app))?;
 
         match app.current_screen {
             CurrentScreen::MailingListSelection => {

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -44,13 +44,24 @@ pub struct MessageID {
     pub href: String,
 }
 
-fn default_version() -> u32 { 1 }
-fn default_number_in_series() -> u32 { 1 }
-fn default_total_in_series() -> u32 { 1 }
+fn default_version() -> u32 {
+    1
+}
+fn default_number_in_series() -> u32 {
+    1
+}
+fn default_total_in_series() -> u32 {
+    1
+}
 
 impl Patch {
-    pub fn new(title: String, author: Author, message_id: MessageID,
-        in_reply_to: Option<MessageID>, updated: String) -> Patch {
+    pub fn new(
+        title: String,
+        author: Author,
+        message_id: MessageID,
+        in_reply_to: Option<MessageID>,
+        updated: String,
+    ) -> Patch {
         Patch {
             title: title,
             author: author,
@@ -117,10 +128,7 @@ impl Patch {
     }
 
     fn remove_patch_tag_from_title(self: &mut Self, patch_tag: &str) {
-        self.title = self.title
-            .replace(patch_tag, "")
-            .trim()
-            .to_string();
+        self.title = self.title.replace(patch_tag, "").trim().to_string();
     }
 
     fn set_version(self: &mut Self, patch_tag: &str, re_patch_version: &Regex) {

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -11,7 +11,7 @@ pub struct PatchFeed {
 }
 
 impl PatchFeed {
-    pub fn get_patches(self: Self) -> Vec<Patch> {
+    pub fn get_patches(self) -> Vec<Patch> {
         self.patches
     }
 }
@@ -63,53 +63,51 @@ impl Patch {
         updated: String,
     ) -> Patch {
         Patch {
-            title: title,
-            author: author,
+            title,
+            author,
             version: 1,
             number_in_series: 1,
             total_in_series: 1,
-            message_id: message_id,
-            in_reply_to: in_reply_to,
-            updated: updated,
+            message_id,
+            in_reply_to,
+            updated,
         }
     }
 
-    pub fn get_title(self: &Self) -> &str {
+    pub fn get_title(&self) -> &str {
         &self.title
     }
 
-    pub fn get_version(self: &Self) -> u32 {
+    pub fn get_version(&self) -> u32 {
         self.version
     }
 
-    pub fn get_number_in_series(self: &Self) -> u32 {
+    pub fn get_number_in_series(&self) -> u32 {
         self.number_in_series
     }
 
-    pub fn get_total_in_series(self: &Self) -> u32 {
+    pub fn get_total_in_series(&self) -> u32 {
         self.total_in_series
     }
 
-    pub fn get_author(self: &Self) -> &Author {
+    pub fn get_author(&self) -> &Author {
         &self.author
     }
 
-    pub fn get_in_reply_to(self: &Self) -> &Option<MessageID> {
+    pub fn get_in_reply_to(&self) -> &Option<MessageID> {
         &self.in_reply_to
     }
 
-    pub fn get_updated(self: &Self) -> &str {
+    pub fn get_updated(&self) -> &str {
         &self.updated
     }
 
-    pub fn get_message_id(self: &Self) -> &MessageID {
+    pub fn get_message_id(&self) -> &MessageID {
         &self.message_id
     }
 
-    pub fn update_patch_metadata(self: &mut Self, patch_regex: &PatchRegex) {
-        let patch_tag: String;
-
-        patch_tag = match self.get_patch_tag(&patch_regex.re_patch_tag) {
+    pub fn update_patch_metadata(&mut self, patch_regex: &PatchRegex) {
+        let patch_tag = match self.get_patch_tag(&patch_regex.re_patch_tag) {
             Some(value) => value.to_string(),
             None => return,
         };
@@ -120,18 +118,18 @@ impl Patch {
         self.set_total_in_series(&patch_tag, &patch_regex.re_patch_series);
     }
 
-    fn get_patch_tag(self: &Self, re_patch_tag: &Regex) -> Option<&str> {
+    fn get_patch_tag(&self, re_patch_tag: &Regex) -> Option<&str> {
         match re_patch_tag.find(&self.title) {
             Some(patch_tag) => Some(patch_tag.as_str()),
             None => None,
         }
     }
 
-    fn remove_patch_tag_from_title(self: &mut Self, patch_tag: &str) {
+    fn remove_patch_tag_from_title(&mut self, patch_tag: &str) {
         self.title = self.title.replace(patch_tag, "").trim().to_string();
     }
 
-    fn set_version(self: &mut Self, patch_tag: &str, re_patch_version: &Regex) {
+    fn set_version(&mut self, patch_tag: &str, re_patch_version: &Regex) {
         if let Some(capture) = re_patch_version.captures(patch_tag) {
             if let Some(version) = capture.get(1) {
                 self.version = version.as_str().parse().unwrap();
@@ -139,7 +137,7 @@ impl Patch {
         }
     }
 
-    fn set_number_in_series(self: &mut Self, patch_tag: &str, re_patch_series: &Regex) {
+    fn set_number_in_series(&mut self, patch_tag: &str, re_patch_series: &Regex) {
         if let Some(capture) = re_patch_series.captures(patch_tag) {
             if let Some(number_in_series) = capture.get(1) {
                 self.number_in_series = number_in_series.as_str().parse().unwrap();
@@ -147,7 +145,7 @@ impl Patch {
         }
     }
 
-    fn set_total_in_series(self: &mut Self, patch_tag: &str, re_patch_series: &Regex) {
+    fn set_total_in_series(&mut self, patch_tag: &str, re_patch_series: &Regex) {
         if let Some(capture) = re_patch_series.captures(patch_tag) {
             if let Some(total_in_series) = capture.get(2) {
                 self.total_in_series = total_in_series.as_str().parse().unwrap();
@@ -173,5 +171,11 @@ impl PatchRegex {
             re_patch_version,
             re_patch_series,
         }
+    }
+}
+
+impl Default for PatchRegex {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/patch/tests.rs
+++ b/src/patch/tests.rs
@@ -5,10 +5,15 @@ use serde_xml_rs::from_str;
 fn can_deserialize_patch_without_in_reply_to() {
     let expected_patch: Patch = Patch::new(
         "[PATCH 0/42] hitchhiker/guide: Complete Collection".to_string(),
-        Author { name: "Foo Bar".to_string(), email: "foo@bar.foo.bar".to_string() },
-        MessageID { href: "http://lore.kernel.org/some-list/1234-1-foo@bar.foo.bar".to_string() },
+        Author {
+            name: "Foo Bar".to_string(),
+            email: "foo@bar.foo.bar".to_string(),
+        },
+        MessageID {
+            href: "http://lore.kernel.org/some-list/1234-1-foo@bar.foo.bar".to_string(),
+        },
         None,
-        "2024-07-06T19:15:48Z".to_string()
+        "2024-07-06T19:15:48Z".to_string(),
     );
     let serialized_patch: &str = r#"
         <entry xmlns:thr="http://purl.org/syndication/thread/1.0">
@@ -27,7 +32,8 @@ fn can_deserialize_patch_without_in_reply_to() {
 
     let actual_patch: Patch = from_str(serialized_patch).unwrap();
 
-    assert_eq!(expected_patch, actual_patch,
+    assert_eq!(
+        expected_patch, actual_patch,
         "An entry from a patch feed should deserialize into"
     )
 }
@@ -36,10 +42,17 @@ fn can_deserialize_patch_without_in_reply_to() {
 fn can_deserialize_patch_with_in_reply_to() {
     let expected_patch: Patch = Patch::new(
         "[PATCH 3/42] hitchhiker/guide: Life, the Universe and Everything".to_string(),
-        Author { name: "Foo Bar".to_string(), email: "foo@bar.foo.bar".to_string() },
-        MessageID { href: "http://lore.kernel.org/some-list/1234-2-foo@bar.foo.bar".to_string() },
-        Some(MessageID { href: "http://lore.kernel.org/some-list/1234-1-foo@bar.foo.bar".to_string() }),
-        "2024-07-06T19:16:53Z".to_string()
+        Author {
+            name: "Foo Bar".to_string(),
+            email: "foo@bar.foo.bar".to_string(),
+        },
+        MessageID {
+            href: "http://lore.kernel.org/some-list/1234-2-foo@bar.foo.bar".to_string(),
+        },
+        Some(MessageID {
+            href: "http://lore.kernel.org/some-list/1234-1-foo@bar.foo.bar".to_string(),
+        }),
+        "2024-07-06T19:16:53Z".to_string(),
     );
     let serialized_patch: &str = r#"
         <entry xmlns:thr="http://purl.org/syndication/thread/1.0">
@@ -61,7 +74,8 @@ fn can_deserialize_patch_with_in_reply_to() {
 
     let actual_patch: Patch = from_str(serialized_patch).unwrap();
 
-    assert_eq!(expected_patch, actual_patch,
+    assert_eq!(
+        expected_patch, actual_patch,
         "An entry from a patch feed should deserialize into"
     )
 }
@@ -71,15 +85,24 @@ fn test_update_patch_metadata() {
     let patch_regex: PatchRegex = PatchRegex::new();
     let mut patch: Patch = Patch::new(
         "[RESEND][v7 PATCH 3/42] hitchhiker/guide: Life, the Universe and Everything".to_string(),
-        Author { name: "Foo Bar".to_string(), email: "foo@bar.foo.bar".to_string() },
-        MessageID { href: "http://lore.kernel.org/some-list/1234-2-foo@bar.foo.bar".to_string() },
-        Some(MessageID { href: "http://lore.kernel.org/some-list/1234-1-foo@bar.foo.bar".to_string() }),
-        "2024-07-06T19:16:53Z".to_string()
+        Author {
+            name: "Foo Bar".to_string(),
+            email: "foo@bar.foo.bar".to_string(),
+        },
+        MessageID {
+            href: "http://lore.kernel.org/some-list/1234-2-foo@bar.foo.bar".to_string(),
+        },
+        Some(MessageID {
+            href: "http://lore.kernel.org/some-list/1234-1-foo@bar.foo.bar".to_string(),
+        }),
+        "2024-07-06T19:16:53Z".to_string(),
     );
 
     patch.update_patch_metadata(&patch_regex);
 
-    assert_eq!("[RESEND] hitchhiker/guide: Life, the Universe and Everything", patch.get_title(),
+    assert_eq!(
+        "[RESEND] hitchhiker/guide: Life, the Universe and Everything",
+        patch.get_title(),
         "The title should have the patch tag `[v7 PATCH 3/42]` stripped"
     );
     assert_eq!(7, patch.get_version(), "Wrong version!");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -24,7 +24,7 @@ pub fn draw_ui(f: &mut Frame, app: &App) {
     render_title(f, chunks[0]);
 
     match app.current_screen {
-        CurrentScreen::MailingListSelection => render_mailing_list_selection(f, &app, chunks[1]),
+        CurrentScreen::MailingListSelection => render_mailing_list_selection(f, app, chunks[1]),
         CurrentScreen::BookmarkedPatchsets => {
             render_bookmarked_patchsets(f, &app.bookmarked_patchsets_state, chunks[1])
         }
@@ -63,7 +63,7 @@ fn render_mailing_list_selection(f: &mut Frame, app: &App, chunk: Rect) {
         list_items.push(ListItem::new(
             Line::from(vec![
                 Span::styled(
-                    format!("{}", mailing_list.get_name()),
+                    mailing_list.get_name().to_string(),
                     Style::default().fg(Color::Magenta),
                 ),
                 Span::styled(
@@ -103,10 +103,9 @@ fn render_bookmarked_patchsets(
     chunk: Rect,
 ) {
     let patchset_index = bookmarked_patchsets_state.patchset_index;
-    let mut index: u32 = 0;
     let mut list_items = Vec::<ListItem>::new();
 
-    for patch in &bookmarked_patchsets_state.bookmarked_patchsets {
+    for (index, patch) in (0_u32..).zip(bookmarked_patchsets_state.bookmarked_patchsets.iter()) {
         let patch_title = format!("{:width$}", patch.get_title(), width = 70);
         let patch_title = format!("{:.width$}", patch_title, width = 70);
         let patch_author = format!("{:width$}", patch.get_author().name, width = 30);
@@ -125,7 +124,6 @@ fn render_bookmarked_patchsets(
             ))
             .centered(),
         ));
-        index += 1;
     }
 
     let list_block = Block::default()
@@ -239,14 +237,14 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
         Line::from(vec![
             Span::styled(r#"  Title: "#, Style::default().fg(Color::Cyan)),
             Span::styled(
-                format!("{}", patchset_details.get_title()),
+                patchset_details.get_title().to_string(),
                 Style::default().fg(Color::White),
             ),
         ]),
         Line::from(vec![
             Span::styled("Author: ", Style::default().fg(Color::Cyan)),
             Span::styled(
-                format!("{}", patchset_details.get_author().name),
+                patchset_details.get_author().name.to_string(),
                 Style::default().fg(Color::White),
             ),
         ]),
@@ -267,7 +265,7 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
         Line::from(vec![
             Span::styled("Last updated: ", Style::default().fg(Color::Cyan)),
             Span::styled(
-                format!("{}", patchset_details.get_updated()),
+                patchset_details.get_updated().to_string(),
                 Style::default().fg(Color::White),
             ),
         ]),
@@ -354,7 +352,7 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
     let mut preview_title = String::from(" Preview ");
     if let Some(successful_indexes) = app.reviewed_patchsets.get(representative_patch_message_id) {
         if successful_indexes.contains(&preview_index) {
-            preview_title = format!(" Preview [REVIEWED] ");
+            preview_title = " Preview [REVIEWED] ".to_string();
         }
     };
 
@@ -369,7 +367,7 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
         .unwrap()
         .patches[preview_index as usize]
         .replace('\t', "        ");
-    let patch_preview = Paragraph::new(Text::from(format!("{patch_preview}")))
+    let patch_preview = Paragraph::new(Text::from(patch_preview.to_string()))
         .block(
             Block::default()
                 .borders(Borders::ALL)
@@ -386,8 +384,7 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
 }
 
 fn render_navi_bar(f: &mut Frame, app: &App, chunk: Rect) {
-    let mode_footer_text: Vec<Span>;
-    match app.current_screen {
+    let mode_footer_text = match app.current_screen {
         CurrentScreen::MailingListSelection => {
             let mut text_area = Span::default();
 
@@ -423,19 +420,19 @@ fn render_navi_bar(f: &mut Frame, app: &App, chunk: Rect) {
                 }
             }
 
-            mode_footer_text = vec![
+            vec![
                 Span::styled("Target List: ", Style::default().fg(Color::Green)),
                 text_area,
             ]
         }
         CurrentScreen::BookmarkedPatchsets => {
-            mode_footer_text = vec![Span::styled(
+            vec![Span::styled(
                 "Bookmarked Patchsets",
                 Style::default().fg(Color::Green),
             )]
         }
         CurrentScreen::LatestPatchsets => {
-            mode_footer_text = vec![Span::styled(
+            vec![Span::styled(
                 format!(
                     "Latest Patchsets from {} (page {})",
                     &app.latest_patchsets_state
@@ -451,12 +448,12 @@ fn render_navi_bar(f: &mut Frame, app: &App, chunk: Rect) {
             )]
         }
         CurrentScreen::PatchsetDetails => {
-            mode_footer_text = vec![Span::styled(
+            vec![Span::styled(
                 "Patchset Details and Actions",
                 Style::default().fg(Color::Green),
             )]
         }
-    }
+    };
     let mode_footer = Paragraph::new(Line::from(mode_footer_text))
         .block(Block::default().borders(Borders::ALL))
         .centered();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -62,15 +62,17 @@ fn render_mailing_list_selection(f: &mut Frame, app: &App, chunk: Rect) {
     for mailing_list in &app.mailing_list_selection_state.possible_mailing_lists {
         list_items.push(ListItem::new(
             Line::from(vec![
-            Span::styled(
-                format!("{}", mailing_list.get_name()),
-                Style::default().fg(Color::Magenta),
-            ),
-            Span::styled(
-                format!(" - {}", mailing_list.get_description()),
-                Style::default().fg(Color::White),
-            ),
-        ]).centered()))
+                Span::styled(
+                    format!("{}", mailing_list.get_name()),
+                    Style::default().fg(Color::Magenta),
+                ),
+                Span::styled(
+                    format!(" - {}", mailing_list.get_description()),
+                    Style::default().fg(Color::White),
+                ),
+            ])
+            .centered(),
+        ))
     }
 
     let list_block = Block::default()
@@ -306,7 +308,10 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
             Span::styled("ookmark", Style::default().fg(Color::Cyan)),
         ]),
         Line::from(vec![
-            if *patchset_actions.get(&PatchsetAction::ReplyWithReviewedBy).unwrap() {
+            if *patchset_actions
+                .get(&PatchsetAction::ReplyWithReviewedBy)
+                .unwrap()
+            {
                 Span::styled("[x] ", Style::default().fg(Color::Green))
             } else {
                 Span::styled("[ ] ", Style::default().fg(Color::Cyan))
@@ -343,7 +348,9 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
         .patchset_details_and_actions_state
         .as_ref()
         .unwrap()
-        .representative_patch.get_message_id().href;
+        .representative_patch
+        .get_message_id()
+        .href;
     let mut preview_title = String::from(" Preview ");
     if let Some(successful_indexes) = app.reviewed_patchsets.get(representative_patch_message_id) {
         if successful_indexes.contains(&preview_index) {
@@ -367,7 +374,9 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
             Block::default()
                 .borders(Borders::ALL)
                 .border_type(ratatui::widgets::BorderType::Double)
-                .title(Line::styled(preview_title, Style::default().fg(Color::Green)).left_aligned())
+                .title(
+                    Line::styled(preview_title, Style::default().fg(Color::Green)).left_aligned(),
+                )
                 .padding(Padding::vertical(1)),
         )
         .left_aligned()
@@ -387,23 +396,29 @@ fn render_navi_bar(f: &mut Frame, app: &App, chunk: Rect) {
                     Span::styled("type the target list", Style::default().fg(Color::DarkGray))
             } else {
                 for mailing_list in &app.mailing_list_selection_state.mailing_lists {
-                    if mailing_list.get_name().eq(&app.mailing_list_selection_state.target_list) {
+                    if mailing_list
+                        .get_name()
+                        .eq(&app.mailing_list_selection_state.target_list)
+                    {
                         text_area = Span::styled(
                             &app.mailing_list_selection_state.target_list,
-                            Style::default().fg(Color::Green)
+                            Style::default().fg(Color::Green),
                         );
                         break;
-                    } else if mailing_list.get_name().starts_with(&app.mailing_list_selection_state.target_list) {
+                    } else if mailing_list
+                        .get_name()
+                        .starts_with(&app.mailing_list_selection_state.target_list)
+                    {
                         text_area = Span::styled(
                             &app.mailing_list_selection_state.target_list,
-                            Style::default().fg(Color::LightCyan)
+                            Style::default().fg(Color::LightCyan),
                         );
                     }
                 }
                 if text_area.content.is_empty() {
                     text_area = Span::styled(
                         &app.mailing_list_selection_state.target_list,
-                        Style::default().fg(Color::Red)
+                        Style::default().fg(Color::Red),
                     );
                 }
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,6 @@
-use std::io::{
-    self, stdout, Stdout
-};
+use color_eyre::{config::HookBuilder, eyre};
+use std::io::{self, stdout, Stdout};
 use std::panic;
-use color_eyre::{
-    config::HookBuilder, eyre
-};
 
 use ratatui::{
     backend::CrosstermBackend,


### PR DESCRIPTION
This PR aims to:

- Setup rust-clippy in `format_and_lint.sh` script
- Update the source code considering clippy suggestions

Closes #32
Contributes to #10 
