### PR TITLE
Add formatting and linting

### DIFF
--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -1,0 +1,57 @@
+name: Format and Lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+    paths:
+      - src/**
+  push:
+    paths:
+      - src/**
+    branches: 
+      - master
+      - unstable
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: '!github.event.pull_request.draft'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update rustup and install rustfmt
+        shell: bash
+        run: |
+          rustup update
+          rustup component add rustfmt
+          rustup install stable
+
+      - name: Check rustfmt errors
+        shell: bash
+        run: |
+          cargo fmt --all -- --check
+
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: '!github.event.pull_request.draft'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update rustup and install clippy
+        shell: bash
+        run: |
+          rustup update
+          rustup component add clippy
+          rustup install stable
+
+      - name: Check clippy errors
+        shell: bash
+        run: |
+          cargo clippy --all-features --all-targets --tests -- --allow=clippy::too-many-arguments --deny=warnings --deny=clippy::map_unwrap_or --deny=unconditional_recursion

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: local
+    hooks:
+      # Formatter
+      - id: rustfmt
+        name: rustfmt
+        language: rust
+        entry: cargo fmt
+        args: ["--all"]
+        types: [rust]
+        pass_filenames: false
+      # Linter
+      - id: clippy
+        name: clippy
+        language: rust
+        entry: cargo clippy
+        args: [
+          "--all-features", "--all-targets", "--tests",
+          "--", "--allow=clippy::too-many-arguments", "--deny=warnings",
+          "--deny=clippy::map_unwrap_or", "--deny=unconditional_recursion"
+        ]
+        types: [rust]
+        pass_filenames: false

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,16 +1,12 @@
-use std::{collections::HashMap, path::Path, process::Command};
 use color_eyre::eyre::bail;
 use config::Config;
 use patch_hub::{
-    lore_session::{
-        self, LoreSession
-    },
-    lore_api_client::{
-        BlockingLoreAPIClient, FailedFeedRequest
-    },
+    lore_api_client::{BlockingLoreAPIClient, FailedFeedRequest},
+    lore_session::{self, LoreSession},
     mailing_list::MailingList,
-    patch::Patch
+    patch::Patch,
 };
+use std::{collections::HashMap, path::Path, process::Command};
 
 mod config;
 
@@ -44,9 +40,11 @@ impl BookmarkedPatchsetsState {
     }
 
     fn unbookmark_selected_patch(&mut self, patch_to_unbookmark: &Patch) {
-        if let Some(index) = self.bookmarked_patchsets.iter().position(
-            |r| r == patch_to_unbookmark
-        ) {
+        if let Some(index) = self
+            .bookmarked_patchsets
+            .iter()
+            .position(|r| r == patch_to_unbookmark)
+        {
             self.bookmarked_patchsets.remove(index);
         }
     }
@@ -74,8 +72,10 @@ impl LatestPatchsetsState {
     }
 
     pub fn fetch_current_page(&mut self) -> color_eyre::Result<()> {
-        if let Err(failed_feed_request) = self
-            .lore_session.process_n_representative_patches(&self.lore_api_client, self.page_size * self.page_number) {
+        if let Err(failed_feed_request) = self.lore_session.process_n_representative_patches(
+            &self.lore_api_client,
+            self.page_size * self.page_number,
+        ) {
             match failed_feed_request {
                 FailedFeedRequest::UnknownError(error) => bail!("[FailedFeedRequest::UnknownError]\n*\tFailed to request feed\n*\t{error:#?}"),
                 FailedFeedRequest::StatusNotOk(feed_response) => bail!("[FailedFeedRequest::StatusNotOk]\n*\tRequest returned with non-OK status\n*\t{feed_response:#?}"),
@@ -86,7 +86,8 @@ impl LatestPatchsetsState {
     }
 
     pub fn select_below_patchset(&mut self) {
-        if self.patchset_index + 1 < self.lore_session.get_representative_patches_ids().len() as u32 {
+        if self.patchset_index + 1 < self.lore_session.get_representative_patches_ids().len() as u32
+        {
             self.patchset_index += 1;
         }
     }
@@ -101,19 +102,24 @@ impl LatestPatchsetsState {
     }
 
     pub fn increment_page(&mut self) {
-        let patchsets_processed: u32 = self.lore_session.get_representative_patches_ids().len().try_into().unwrap();
+        let patchsets_processed: u32 = self
+            .lore_session
+            .get_representative_patches_ids()
+            .len()
+            .try_into()
+            .unwrap();
         if self.page_size * self.page_number > patchsets_processed {
             return;
         }
-        self.page_number += 1; 
+        self.page_number += 1;
         self.patchset_index = self.page_size * (&self.page_number - 1);
     }
 
     pub fn decrement_page(&mut self) {
         if self.page_number == 1 {
             return;
-        } 
-        self.page_number -= 1; 
+        }
+        self.page_number -= 1;
         self.patchset_index = self.page_size * (&self.page_number - 1);
     }
 
@@ -130,7 +136,8 @@ impl LatestPatchsetsState {
     }
 
     pub fn get_selected_patchset(&self) -> Patch {
-        let message_id: &str = self.lore_session
+        let message_id: &str = self
+            .lore_session
             .get_representative_patches_ids()
             .get(self.patchset_index as usize)
             .unwrap();
@@ -142,7 +149,8 @@ impl LatestPatchsetsState {
     }
 
     pub fn get_current_patch_feed_page(&self) -> Option<Vec<&Patch>> {
-        self.lore_session.get_patch_feed_page(self.page_size, self.page_number)
+        self.lore_session
+            .get_patch_feed_page(self.page_size, self.page_number)
     }
 }
 
@@ -199,14 +207,21 @@ impl PatchsetDetailsAndActionsState {
 
     fn toggle_action(&mut self, patchset_action: PatchsetAction) {
         let current_value = *self.patchset_actions.get(&patchset_action).unwrap();
-        self.patchset_actions.insert(patchset_action, !current_value);
+        self.patchset_actions
+            .insert(patchset_action, !current_value);
     }
 
     pub fn actions_require_user_io(&self) -> bool {
-        *self.patchset_actions.get(&PatchsetAction::ReplyWithReviewedBy).unwrap()
+        *self
+            .patchset_actions
+            .get(&PatchsetAction::ReplyWithReviewedBy)
+            .unwrap()
     }
 
-    pub fn reply_patchset_with_reviewed_by(&self, target_list: &str) -> color_eyre::Result<Vec<u32>> {
+    pub fn reply_patchset_with_reviewed_by(
+        &self,
+        target_list: &str,
+    ) -> color_eyre::Result<Vec<u32>> {
         let lore_api_client = BlockingLoreAPIClient::new();
         let (git_user_name, git_user_email) = lore_session::get_git_signature("");
         let mut successful_indexes = Vec::new();
@@ -216,22 +231,20 @@ impl PatchsetDetailsAndActionsState {
             return Ok(successful_indexes);
         }
 
-        let tmp_dir = Command::new("mktemp")
-            .arg("--directory")
-            .output()
-            .unwrap();
-        let tmp_dir = Path::new(
-            std::str::from_utf8(&tmp_dir.stdout).unwrap().trim()
-        );
+        let tmp_dir = Command::new("mktemp").arg("--directory").output().unwrap();
+        let tmp_dir = Path::new(std::str::from_utf8(&tmp_dir.stdout).unwrap().trim());
 
         let git_reply_commands = match lore_session::prepare_reply_patchset_with_reviewed_by(
-            &lore_api_client, tmp_dir, target_list,
-            &self.patches, &format!("{git_user_name} <{git_user_email}>")
+            &lore_api_client,
+            tmp_dir,
+            target_list,
+            &self.patches,
+            &format!("{git_user_name} <{git_user_email}>"),
         ) {
             Ok(commands_vector) => commands_vector,
             Err(failed_patch_html_request) => {
                 bail!(format!("{failed_patch_html_request:#?}"));
-            },
+            }
         };
 
         for (index, mut command) in git_reply_commands.into_iter().enumerate() {
@@ -261,22 +274,18 @@ impl MailingListSelectionState {
         match lore_session::fetch_available_lists(&lore_api_client) {
             Ok(available_mailing_lists) => {
                 self.mailing_lists = available_mailing_lists;
-            },
+            }
             Err(failed_available_lists_request) => {
                 bail!(format!("{failed_available_lists_request:#?}"));
-            },
+            }
         };
 
         self.clear_target_list();
 
-        lore_session::save_available_lists(
-            &self.mailing_lists,
-            &self.mailing_lists_path
-        )?;
+        lore_session::save_available_lists(&self.mailing_lists, &self.mailing_lists_path)?;
 
         Ok(())
     }
-
 
     pub fn remove_last_target_list_char(&mut self) {
         if !self.target_list.is_empty() {
@@ -351,11 +360,16 @@ impl App {
     pub fn new() -> App {
         let config: Config = Config::build();
 
-        let mailing_lists = lore_session::load_available_lists(&config.mailing_lists_path).unwrap_or_default();
+        let mailing_lists =
+            lore_session::load_available_lists(&config.mailing_lists_path).unwrap_or_default();
 
-        let bookmarked_patchsets = lore_session::load_bookmarked_patchsets(&config.bookmarked_patchsets_path).unwrap_or_default();
+        let bookmarked_patchsets =
+            lore_session::load_bookmarked_patchsets(&config.bookmarked_patchsets_path)
+                .unwrap_or_default();
 
-        let reviewed_patchsets = lore_session::load_reviewed_patchsets(&config.reviewed_patchsets_path).unwrap_or_default();
+        let reviewed_patchsets =
+            lore_session::load_reviewed_patchsets(&config.reviewed_patchsets_path)
+                .unwrap_or_default();
 
         App {
             current_screen: CurrentScreen::MailingListSelection,
@@ -373,68 +387,79 @@ impl App {
                 patchset_index: 0,
             },
             reviewed_patchsets,
-            config
+            config,
         }
     }
 
     pub fn init_latest_patchsets_state(&mut self) {
         // the target mailing list for "latest patchsets" is the highlighted
         // entry in the possible lists of "mailing list selection"
-        let list_index = self.mailing_list_selection_state
-            .highlighted_list_index as usize;
-        let target_list = self.mailing_list_selection_state
-            .possible_mailing_lists[list_index]
-            .get_name().to_string();
+        let list_index = self.mailing_list_selection_state.highlighted_list_index as usize;
+        let target_list = self.mailing_list_selection_state.possible_mailing_lists[list_index]
+            .get_name()
+            .to_string();
 
-        self.latest_patchsets_state = Some(
-            LatestPatchsetsState::new(target_list, self.config.page_size)
-        );
+        self.latest_patchsets_state = Some(LatestPatchsetsState::new(
+            target_list,
+            self.config.page_size,
+        ));
     }
 
     pub fn reset_latest_patchsets_state(&mut self) {
         self.latest_patchsets_state = None;
     }
 
-    pub fn init_patchset_details_and_actions_state(&mut self, current_screen: CurrentScreen) -> color_eyre::Result<()> {
+    pub fn init_patchset_details_and_actions_state(
+        &mut self,
+        current_screen: CurrentScreen,
+    ) -> color_eyre::Result<()> {
         let representative_patch: Patch;
         let mut is_patchset_bookmarked = true;
-        
 
         match current_screen {
             CurrentScreen::BookmarkedPatchsets => {
                 representative_patch = self.bookmarked_patchsets_state.get_selected_patchset();
-            },
+            }
             CurrentScreen::LatestPatchsets => {
-                representative_patch = self.latest_patchsets_state.as_ref().unwrap().get_selected_patchset();
-                if !self.bookmarked_patchsets_state.bookmarked_patchsets.contains(&representative_patch) {
+                representative_patch = self
+                    .latest_patchsets_state
+                    .as_ref()
+                    .unwrap()
+                    .get_selected_patchset();
+                if !self
+                    .bookmarked_patchsets_state
+                    .bookmarked_patchsets
+                    .contains(&representative_patch)
+                {
                     is_patchset_bookmarked = false;
                 }
-            },
-            screen => bail!(format!("Invalid screen passed as argument {screen:?}"))
+            }
+            screen => bail!(format!("Invalid screen passed as argument {screen:?}")),
         };
 
-        let patchset_path: String = match lore_session::download_patchset(&self.config.patchsets_cache_dir, &representative_patch) {
+        let patchset_path: String = match lore_session::download_patchset(
+            &self.config.patchsets_cache_dir,
+            &representative_patch,
+        ) {
             Ok(result) => result,
             Err(io_error) => bail!("{io_error}"),
         };
 
         match lore_session::split_patchset(&patchset_path) {
             Ok(patches) => {
-                self.patchset_details_and_actions_state = Some(
-                    PatchsetDetailsAndActionsState {
-                        representative_patch,
-                        patches,
-                        preview_index: 0,
-                        preview_scroll_offset: 0,
-                        patchset_actions: HashMap::from([
-                            (PatchsetAction::Bookmark, is_patchset_bookmarked),
-                            (PatchsetAction::ReplyWithReviewedBy, false),
-                        ]),
-                        last_screen: current_screen,
-                    }
-                );
+                self.patchset_details_and_actions_state = Some(PatchsetDetailsAndActionsState {
+                    representative_patch,
+                    patches,
+                    preview_index: 0,
+                    preview_scroll_offset: 0,
+                    patchset_actions: HashMap::from([
+                        (PatchsetAction::Bookmark, is_patchset_bookmarked),
+                        (PatchsetAction::ReplyWithReviewedBy, false),
+                    ]),
+                    last_screen: current_screen,
+                });
                 Ok(())
-            },
+            }
             Err(message) => bail!(message),
         }
     }
@@ -444,29 +469,42 @@ impl App {
     }
 
     pub fn consolidate_patchset_actions(&mut self) -> color_eyre::Result<()> {
-        let representative_patch = &self.patchset_details_and_actions_state
+        let representative_patch = &self
+            .patchset_details_and_actions_state
             .as_ref()
             .unwrap()
             .representative_patch;
 
         let should_bookmark_patchset = *self
-            .patchset_details_and_actions_state.as_ref().unwrap()
-            .patchset_actions.get(&PatchsetAction::Bookmark).unwrap();
+            .patchset_details_and_actions_state
+            .as_ref()
+            .unwrap()
+            .patchset_actions
+            .get(&PatchsetAction::Bookmark)
+            .unwrap();
         if should_bookmark_patchset {
-            self.bookmarked_patchsets_state.bookmark_selected_patch(representative_patch);
+            self.bookmarked_patchsets_state
+                .bookmark_selected_patch(representative_patch);
         } else {
-            self.bookmarked_patchsets_state.unbookmark_selected_patch(representative_patch);
+            self.bookmarked_patchsets_state
+                .unbookmark_selected_patch(representative_patch);
         }
 
         lore_session::save_bookmarked_patchsets(
-            &self.bookmarked_patchsets_state.bookmarked_patchsets, &self.config.bookmarked_patchsets_path
+            &self.bookmarked_patchsets_state.bookmarked_patchsets,
+            &self.config.bookmarked_patchsets_path,
         )?;
 
         let should_reply_with_reviewed_by = *self
-            .patchset_details_and_actions_state.as_ref().unwrap()
-            .patchset_actions.get(&PatchsetAction::ReplyWithReviewedBy).unwrap();
+            .patchset_details_and_actions_state
+            .as_ref()
+            .unwrap()
+            .patchset_actions
+            .get(&PatchsetAction::ReplyWithReviewedBy)
+            .unwrap();
         if should_reply_with_reviewed_by {
-            let successful_indexes = self.patchset_details_and_actions_state
+            let successful_indexes = self
+                .patchset_details_and_actions_state
                 .as_ref()
                 .unwrap()
                 .reply_patchset_with_reviewed_by("all")?;
@@ -479,7 +517,7 @@ impl App {
 
                 lore_session::save_reviewed_patchsets(
                     &self.reviewed_patchsets,
-                    &self.config.reviewed_patchsets_path
+                    &self.config.reviewed_patchsets_path,
                 )?;
             }
 
@@ -488,7 +526,7 @@ impl App {
                 .unwrap()
                 .toggle_action(PatchsetAction::ReplyWithReviewedBy);
         }
-        
+
         Ok(())
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,30 +20,30 @@ pub struct BookmarkedPatchsetsState {
 }
 
 impl BookmarkedPatchsetsState {
-    pub fn select_below_patchset(self: &mut Self) {
+    pub fn select_below_patchset(&mut self) {
         if (self.patchset_index as usize) + 1 < self.bookmarked_patchsets.len() {
             self.patchset_index += 1;
         }
     }
 
-    pub fn select_above_patchset(self: &mut Self) {
+    pub fn select_above_patchset(&mut self) {
         self.patchset_index = self.patchset_index.saturating_sub(1);
     }
 
-    fn get_selected_patchset(self: &Self) -> Patch {
+    fn get_selected_patchset(&self) -> Patch {
         self.bookmarked_patchsets
             .get(self.patchset_index as usize)
             .unwrap()
             .clone()
     }
 
-    fn bookmark_selected_patch(self: &mut Self, patch_to_bookmark: &Patch) {
+    fn bookmark_selected_patch(&mut self, patch_to_bookmark: &Patch) {
         if !self.bookmarked_patchsets.contains(patch_to_bookmark) {
             self.bookmarked_patchsets.push(patch_to_bookmark.clone());
         }
     }
 
-    fn unbookmark_selected_patch(self: &mut Self, patch_to_unbookmark: &Patch) {
+    fn unbookmark_selected_patch(&mut self, patch_to_unbookmark: &Patch) {
         if let Some(index) = self.bookmarked_patchsets.iter().position(
             |r| r == patch_to_unbookmark
         ) {
@@ -73,9 +73,9 @@ impl LatestPatchsetsState {
         }
     }
 
-    pub fn fetch_current_page(self: &mut Self) -> color_eyre::Result<()> {
+    pub fn fetch_current_page(&mut self) -> color_eyre::Result<()> {
         if let Err(failed_feed_request) = self
-            .lore_session.process_n_representative_patches(&self.lore_api_client, self.page_size * &self.page_number) {
+            .lore_session.process_n_representative_patches(&self.lore_api_client, self.page_size * self.page_number) {
             match failed_feed_request {
                 FailedFeedRequest::UnknownError(error) => bail!("[FailedFeedRequest::UnknownError]\n*\tFailed to request feed\n*\t{error:#?}"),
                 FailedFeedRequest::StatusNotOk(feed_response) => bail!("[FailedFeedRequest::StatusNotOk]\n*\tRequest returned with non-OK status\n*\t{feed_response:#?}"),
@@ -85,22 +85,22 @@ impl LatestPatchsetsState {
         Ok(())
     }
 
-    pub fn select_below_patchset(self: &mut Self) {
+    pub fn select_below_patchset(&mut self) {
         if self.patchset_index + 1 < self.lore_session.get_representative_patches_ids().len() as u32 {
             self.patchset_index += 1;
         }
     }
 
-    pub fn select_above_patchset(self: &mut Self) {
+    pub fn select_above_patchset(&mut self) {
         if self.patchset_index == 0 {
             return;
         }
-        if self.patchset_index - 1 >= self.page_size * (&self.page_number - 1) {
+        if self.patchset_index > self.page_size * (&self.page_number - 1) {
             self.patchset_index -= 1;
         }
     }
 
-    pub fn increment_page(self: &mut Self) {
+    pub fn increment_page(&mut self) {
         let patchsets_processed: u32 = self.lore_session.get_representative_patches_ids().len().try_into().unwrap();
         if self.page_size * self.page_number > patchsets_processed {
             return;
@@ -109,7 +109,7 @@ impl LatestPatchsetsState {
         self.patchset_index = self.page_size * (&self.page_number - 1);
     }
 
-    pub fn decrement_page(self: &mut Self) {
+    pub fn decrement_page(&mut self) {
         if self.page_number == 1 {
             return;
         } 
@@ -117,19 +117,19 @@ impl LatestPatchsetsState {
         self.patchset_index = self.page_size * (&self.page_number - 1);
     }
 
-    pub fn get_target_list(self: &Self) -> &str {
+    pub fn get_target_list(&self) -> &str {
         &self.target_list
     }
 
-    pub fn get_page_number(self: &Self) -> u32 {
+    pub fn get_page_number(&self) -> u32 {
         self.page_number
     }
 
-    pub fn get_patchset_index(self: &Self) -> u32 {
+    pub fn get_patchset_index(&self) -> u32 {
         self.patchset_index
     }
 
-    pub fn get_selected_patchset(self: &Self) -> Patch {
+    pub fn get_selected_patchset(&self) -> Patch {
         let message_id: &str = self.lore_session
             .get_representative_patches_ids()
             .get(self.patchset_index as usize)
@@ -141,7 +141,7 @@ impl LatestPatchsetsState {
             .clone()
     }
 
-    pub fn get_current_patch_feed_page(self: &Self) -> Option<Vec<&Patch>> {
+    pub fn get_current_patch_feed_page(&self) -> Option<Vec<&Patch>> {
         self.lore_session.get_patch_feed_page(self.page_size, self.page_number)
     }
 }
@@ -162,51 +162,51 @@ pub enum PatchsetAction {
 }
 
 impl PatchsetDetailsAndActionsState {
-    pub fn preview_next_patch(self: &mut Self) {
+    pub fn preview_next_patch(&mut self) {
         if ((self.preview_index as usize) + 1) < self.patches.len() {
             self.preview_index += 1;
             self.preview_scroll_offset = 0;
         }
     }
 
-    pub fn preview_previous_patch(self: &mut Self) {
+    pub fn preview_previous_patch(&mut self) {
         if (self.preview_index as usize) > 0 {
             self.preview_index -= 1;
             self.preview_scroll_offset = 0;
         }
     }
 
-    pub fn preview_scroll_down(self: &mut Self) {
+    pub fn preview_scroll_down(&mut self) {
         let number_of_lines = self.patches[self.preview_index as usize].lines().count();
         if ((self.preview_scroll_offset as usize) + 1) <= number_of_lines {
             self.preview_scroll_offset += 1;
         }
     }
 
-    pub fn preview_scroll_up(self: &mut Self) {
+    pub fn preview_scroll_up(&mut self) {
         if (self.preview_scroll_offset as usize) > 0 {
             self.preview_scroll_offset -= 1;
         }
     }
 
-    pub fn toggle_bookmark_action(self: &mut Self) {
+    pub fn toggle_bookmark_action(&mut self) {
         self.toggle_action(PatchsetAction::Bookmark);
     }
 
-    pub fn toggle_reply_with_reviewed_by_action(self: &mut Self) {
+    pub fn toggle_reply_with_reviewed_by_action(&mut self) {
         self.toggle_action(PatchsetAction::ReplyWithReviewedBy);
     }
 
-    fn toggle_action(self: &mut Self, patchset_action: PatchsetAction) {
+    fn toggle_action(&mut self, patchset_action: PatchsetAction) {
         let current_value = *self.patchset_actions.get(&patchset_action).unwrap();
         self.patchset_actions.insert(patchset_action, !current_value);
     }
 
-    pub fn actions_require_user_io(self: &Self) -> bool {
+    pub fn actions_require_user_io(&self) -> bool {
         *self.patchset_actions.get(&PatchsetAction::ReplyWithReviewedBy).unwrap()
     }
 
-    pub fn reply_patchset_with_reviewed_by(self: &Self, target_list: &str) -> color_eyre::Result<Vec<u32>> {
+    pub fn reply_patchset_with_reviewed_by(&self, target_list: &str) -> color_eyre::Result<Vec<u32>> {
         let lore_api_client = BlockingLoreAPIClient::new();
         let (git_user_name, git_user_email) = lore_session::get_git_signature("");
         let mut successful_indexes = Vec::new();
@@ -255,7 +255,7 @@ pub struct MailingListSelectionState {
 }
 
 impl MailingListSelectionState {
-    pub fn refresh_available_mailing_lists(self: &mut Self) -> color_eyre::Result<()> {
+    pub fn refresh_available_mailing_lists(&mut self) -> color_eyre::Result<()> {
         let lore_api_client = BlockingLoreAPIClient::new();
 
         match lore_session::fetch_available_lists(&lore_api_client) {
@@ -278,24 +278,24 @@ impl MailingListSelectionState {
     }
 
 
-    pub fn remove_last_target_list_char(self: &mut Self) {
+    pub fn remove_last_target_list_char(&mut self) {
         if !self.target_list.is_empty() {
             self.target_list.pop();
             self.process_possible_mailing_lists();
         }
     }
 
-    pub fn push_char_to_target_list(self: &mut Self, ch: char) {
+    pub fn push_char_to_target_list(&mut self, ch: char) {
         self.target_list.push(ch);
         self.process_possible_mailing_lists();
     }
 
-    pub fn clear_target_list(self: &mut Self) {
+    pub fn clear_target_list(&mut self) {
         self.target_list.clear();
         self.process_possible_mailing_lists();
     }
 
-    fn process_possible_mailing_lists(self: &mut Self) {
+    fn process_possible_mailing_lists(&mut self) {
         let mut possible_mailing_lists: Vec<MailingList> = Vec::new();
 
         for mailing_list in &self.mailing_lists {
@@ -308,24 +308,24 @@ impl MailingListSelectionState {
         self.highlighted_list_index = 0;
     }
 
-    pub fn highlight_below_list(self: &mut Self) {
+    pub fn highlight_below_list(&mut self) {
         if (self.highlighted_list_index as usize) + 1 < self.possible_mailing_lists.len() {
             self.highlighted_list_index += 1;
         }
     }
 
-    pub fn highlight_above_list(self: &mut Self) {
+    pub fn highlight_above_list(&mut self) {
         self.highlighted_list_index = self.highlighted_list_index.saturating_sub(1);
     }
 
-    pub fn has_valid_target_list(self: &Self) -> bool {
+    pub fn has_valid_target_list(&self) -> bool {
         let list_length = self.possible_mailing_lists.len(); // Possible mailing list length
         let list_index = self.highlighted_list_index as usize; // Index of the selected mailing list
 
-        if list_index <= list_length - 1 {
+        if list_index < list_length {
             return true;
         }
-        return false;
+        false
     }
 }
 
@@ -349,25 +349,13 @@ pub struct App {
 
 impl App {
     pub fn new() -> App {
-        let mailing_lists: Vec<MailingList>;
-        let bookmarked_patchsets: Vec<Patch>;
-        let reviewed_patchsets: HashMap<String, Vec<u32>>;
         let config: Config = Config::build();
 
-        match lore_session::load_available_lists(&config.mailing_lists_path) {
-            Ok(vec_of_mailing_lists) => mailing_lists = vec_of_mailing_lists,
-            Err(_) => mailing_lists = Vec::new(),
-        }
+        let mailing_lists = lore_session::load_available_lists(&config.mailing_lists_path).unwrap_or_default();
 
-        match lore_session::load_bookmarked_patchsets(&config.bookmarked_patchsets_path) {
-            Ok(vec_of_patchsets) => bookmarked_patchsets = vec_of_patchsets,
-            Err(_) => bookmarked_patchsets = Vec::new(),
-        }
+        let bookmarked_patchsets = lore_session::load_bookmarked_patchsets(&config.bookmarked_patchsets_path).unwrap_or_default();
 
-        match lore_session::load_reviewed_patchsets(&config.reviewed_patchsets_path) {
-            Ok(vec_of_patchsets) => reviewed_patchsets = vec_of_patchsets,
-            Err(_) => reviewed_patchsets = HashMap::new(),
-        }
+        let reviewed_patchsets = lore_session::load_reviewed_patchsets(&config.reviewed_patchsets_path).unwrap_or_default();
 
         App {
             current_screen: CurrentScreen::MailingListSelection,
@@ -389,7 +377,7 @@ impl App {
         }
     }
 
-    pub fn init_latest_patchsets_state(self: &mut Self) {
+    pub fn init_latest_patchsets_state(&mut self) {
         // the target mailing list for "latest patchsets" is the highlighted
         // entry in the possible lists of "mailing list selection"
         let list_index = self.mailing_list_selection_state
@@ -403,14 +391,14 @@ impl App {
         );
     }
 
-    pub fn reset_latest_patchsets_state(self: &mut Self) {
+    pub fn reset_latest_patchsets_state(&mut self) {
         self.latest_patchsets_state = None;
     }
 
-    pub fn init_patchset_details_and_actions_state(self: &mut Self, current_screen: CurrentScreen) -> color_eyre::Result<()> {
+    pub fn init_patchset_details_and_actions_state(&mut self, current_screen: CurrentScreen) -> color_eyre::Result<()> {
         let representative_patch: Patch;
         let mut is_patchset_bookmarked = true;
-        let patchset_path: String;
+        
 
         match current_screen {
             CurrentScreen::BookmarkedPatchsets => {
@@ -425,10 +413,10 @@ impl App {
             screen => bail!(format!("Invalid screen passed as argument {screen:?}"))
         };
 
-        match lore_session::download_patchset(&self.config.patchsets_cache_dir, &representative_patch) {
-            Ok(result) => patchset_path = result,
+        let patchset_path: String = match lore_session::download_patchset(&self.config.patchsets_cache_dir, &representative_patch) {
+            Ok(result) => result,
             Err(io_error) => bail!("{io_error}"),
-        }
+        };
 
         match lore_session::split_patchset(&patchset_path) {
             Ok(patches) => {
@@ -451,11 +439,11 @@ impl App {
         }
     }
 
-    pub fn reset_patchset_details_and_actions_state(self: &mut Self) {
+    pub fn reset_patchset_details_and_actions_state(&mut self) {
         self.patchset_details_and_actions_state = None;
     }
 
-    pub fn consolidate_patchset_actions(self: &mut Self) -> color_eyre::Result<()> {
+    pub fn consolidate_patchset_actions(&mut self) -> color_eyre::Result<()> {
         let representative_patch = &self.patchset_details_and_actions_state
             .as_ref()
             .unwrap()
@@ -504,7 +492,7 @@ impl App {
         Ok(())
     }
 
-    pub fn set_current_screen(self: &mut Self, new_current_screen: CurrentScreen) {
+    pub fn set_current_screen(&mut self, new_current_screen: CurrentScreen) {
         self.current_screen = new_current_screen;
     }
 }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -10,12 +10,6 @@ pub struct Config {
 
 impl Config {
     pub fn build() -> Self {
-        
-        
-        
-        
-        
-
         let page_size: u32 = match env::var("PATCH_HUB_PAGE_SIZE") {
             Ok(value) => value.parse().unwrap(),
             Err(_) => 30,
@@ -23,22 +17,34 @@ impl Config {
 
         let patchsets_cache_dir: String = match env::var("KW_CACHE_DIR") {
             Ok(value) => format!("{value}/patch_hub/patchsets"),
-            Err(_) => format!("{}/.cache/kw/patch_hub/patchsets", env::var("HOME").unwrap()),
+            Err(_) => format!(
+                "{}/.cache/kw/patch_hub/patchsets",
+                env::var("HOME").unwrap()
+            ),
         };
 
         let bookmarked_patchsets_path: String = match env::var("KW_DATA_DIR") {
             Ok(value) => format!("{value}/patch_hub/bookmarked_patchsets.json"),
-            Err(_) => format!("{}/.local/share/kw/patch_hub/bookmarked_patchsets.json", env::var("HOME").unwrap()),
+            Err(_) => format!(
+                "{}/.local/share/kw/patch_hub/bookmarked_patchsets.json",
+                env::var("HOME").unwrap()
+            ),
         };
 
         let mailing_lists_path: String = match env::var("KW_DATA_DIR") {
             Ok(value) => format!("{value}/patch_hub/mailing_lists.json"),
-            Err(_) => format!("{}/.local/share/kw/patch_hub/mailing_lists.json", env::var("HOME").unwrap()),
+            Err(_) => format!(
+                "{}/.local/share/kw/patch_hub/mailing_lists.json",
+                env::var("HOME").unwrap()
+            ),
         };
 
         let reviewed_patchsets_path: String = match env::var("KW_DATA_DIR") {
             Ok(value) => format!("{value}/patch_hub/reviewed_patchsets.json"),
-            Err(_) => format!("{}/.local/share/kw/patch_hub/reviewed_patchsets.json", env::var("HOME").unwrap()),
+            Err(_) => format!(
+                "{}/.local/share/kw/patch_hub/reviewed_patchsets.json",
+                env::var("HOME").unwrap()
+            ),
         };
 
         Config {

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -10,33 +10,33 @@ pub struct Config {
 
 impl Config {
     pub fn build() -> Self {
-        let page_size: u32;
-        let patchsets_cache_dir: String;
-        let bookmarked_patchsets_path: String;
-        let mailing_lists_path: String;
-        let reviewed_patchsets_path: String;
+        
+        
+        
+        
+        
 
-        page_size = match env::var("PATCH_HUB_PAGE_SIZE") {
+        let page_size: u32 = match env::var("PATCH_HUB_PAGE_SIZE") {
             Ok(value) => value.parse().unwrap(),
             Err(_) => 30,
         };
 
-        patchsets_cache_dir = match env::var("KW_CACHE_DIR") {
+        let patchsets_cache_dir: String = match env::var("KW_CACHE_DIR") {
             Ok(value) => format!("{value}/patch_hub/patchsets"),
             Err(_) => format!("{}/.cache/kw/patch_hub/patchsets", env::var("HOME").unwrap()),
         };
 
-        bookmarked_patchsets_path = match env::var("KW_DATA_DIR") {
+        let bookmarked_patchsets_path: String = match env::var("KW_DATA_DIR") {
             Ok(value) => format!("{value}/patch_hub/bookmarked_patchsets.json"),
             Err(_) => format!("{}/.local/share/kw/patch_hub/bookmarked_patchsets.json", env::var("HOME").unwrap()),
         };
 
-        mailing_lists_path = match env::var("KW_DATA_DIR") {
+        let mailing_lists_path: String = match env::var("KW_DATA_DIR") {
             Ok(value) => format!("{value}/patch_hub/mailing_lists.json"),
             Err(_) => format!("{}/.local/share/kw/patch_hub/mailing_lists.json", env::var("HOME").unwrap()),
         };
 
-        reviewed_patchsets_path = match env::var("KW_DATA_DIR") {
+        let reviewed_patchsets_path: String = match env::var("KW_DATA_DIR") {
             Ok(value) => format!("{value}/patch_hub/reviewed_patchsets.json"),
             Err(_) => format!("{}/.local/share/kw/patch_hub/reviewed_patchsets.json", env::var("HOME").unwrap()),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod lore_session;
 pub mod lore_api_client;
+pub mod lore_session;
 pub mod mailing_list;
 pub mod patch;

--- a/src/lore_api_client.rs
+++ b/src/lore_api_client.rs
@@ -29,20 +29,25 @@ impl BlockingLoreAPIClient {
 }
 
 pub trait PatchFeedRequest {
-    fn request_patch_feed(&self, target_list: &str, min_index: u32) -> Result<String, FailedFeedRequest>;
+    fn request_patch_feed(
+        &self,
+        target_list: &str,
+        min_index: u32,
+    ) -> Result<String, FailedFeedRequest>;
 }
 
 impl PatchFeedRequest for BlockingLoreAPIClient {
-    fn request_patch_feed(&self, target_list: &str, min_index: u32) -> Result<String, FailedFeedRequest> {
-        
-        
-        
-        
-        let feed_request: String = format!("{LORE_DOMAIN}/{target_list}/{BASE_QUERY_FOR_FEED_REQUEST}&o={min_index}");
+    fn request_patch_feed(
+        &self,
+        target_list: &str,
+        min_index: u32,
+    ) -> Result<String, FailedFeedRequest> {
+        let feed_request: String =
+            format!("{LORE_DOMAIN}/{target_list}/{BASE_QUERY_FOR_FEED_REQUEST}&o={min_index}");
 
         let feed_response: Response = match reqwest::blocking::get(feed_request) {
             Ok(response) => response,
-            Err(error) =>  return Err(FailedFeedRequest::UnknownError(error)),
+            Err(error) => return Err(FailedFeedRequest::UnknownError(error)),
         };
 
         match feed_response.status().as_u16() {
@@ -66,19 +71,22 @@ pub enum FailedAvailableListsRequest {
 }
 
 pub trait AvailableListsRequest {
-    fn request_available_lists(&self, min_index: u32) -> Result<String, FailedAvailableListsRequest>;
+    fn request_available_lists(
+        &self,
+        min_index: u32,
+    ) -> Result<String, FailedAvailableListsRequest>;
 }
 
 impl AvailableListsRequest for BlockingLoreAPIClient {
-    fn request_available_lists(&self, min_index: u32) -> Result<String, FailedAvailableListsRequest> {
-        
-        
-        
+    fn request_available_lists(
+        &self,
+        min_index: u32,
+    ) -> Result<String, FailedAvailableListsRequest> {
         let available_lists_request: String = format!("{LORE_DOMAIN}/?&o={min_index}");
 
         let available_lists: Response = match reqwest::blocking::get(available_lists_request) {
             Ok(response) => response,
-            Err(error) =>  return Err(FailedAvailableListsRequest::UnknownError(error)),
+            Err(error) => return Err(FailedAvailableListsRequest::UnknownError(error)),
         };
 
         match available_lists.status().as_u16() {
@@ -97,19 +105,24 @@ pub enum FailedPatchHTMLRequest {
 }
 
 pub trait PatchHTMLRequest {
-    fn request_patch_html(&self, target_list: &str, message_id: &str) -> Result<String, FailedPatchHTMLRequest>;
+    fn request_patch_html(
+        &self,
+        target_list: &str,
+        message_id: &str,
+    ) -> Result<String, FailedPatchHTMLRequest>;
 }
 
 impl PatchHTMLRequest for BlockingLoreAPIClient {
-    fn request_patch_html(&self, target_list: &str, message_id: &str) -> Result<String, FailedPatchHTMLRequest> {
-        
-        
-
+    fn request_patch_html(
+        &self,
+        target_list: &str,
+        message_id: &str,
+    ) -> Result<String, FailedPatchHTMLRequest> {
         let patch_html_request: String = format!("{LORE_DOMAIN}/{target_list}/{message_id}/");
 
         let patch_html: Response = match reqwest::blocking::get(patch_html_request) {
             Ok(response) => response,
-            Err(error) =>  return Err(FailedPatchHTMLRequest::UnknownError(error)),
+            Err(error) => return Err(FailedPatchHTMLRequest::UnknownError(error)),
         };
 
         match patch_html.status().as_u16() {

--- a/src/lore_api_client.rs
+++ b/src/lore_api_client.rs
@@ -16,6 +16,12 @@ pub enum FailedFeedRequest {
 
 pub struct BlockingLoreAPIClient {}
 
+impl Default for BlockingLoreAPIClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BlockingLoreAPIClient {
     pub fn new() -> BlockingLoreAPIClient {
         BlockingLoreAPIClient {}
@@ -23,19 +29,19 @@ impl BlockingLoreAPIClient {
 }
 
 pub trait PatchFeedRequest {
-    fn request_patch_feed(self: &Self, target_list: &str, min_index: u32) -> Result<String, FailedFeedRequest>;
+    fn request_patch_feed(&self, target_list: &str, min_index: u32) -> Result<String, FailedFeedRequest>;
 }
 
 impl PatchFeedRequest for BlockingLoreAPIClient {
-    fn request_patch_feed(self: &Self, target_list: &str, min_index: u32) -> Result<String, FailedFeedRequest> {
-        let feed_request: String;
-        let feed_response: Response;
-        let feed_response_body: String;
+    fn request_patch_feed(&self, target_list: &str, min_index: u32) -> Result<String, FailedFeedRequest> {
         
-        feed_request = format!("{LORE_DOMAIN}/{target_list}/{BASE_QUERY_FOR_FEED_REQUEST}&o={min_index}");
+        
+        
+        
+        let feed_request: String = format!("{LORE_DOMAIN}/{target_list}/{BASE_QUERY_FOR_FEED_REQUEST}&o={min_index}");
 
-        match reqwest::blocking::get(feed_request) {
-            Ok(response) => feed_response = response,
+        let feed_response: Response = match reqwest::blocking::get(feed_request) {
+            Ok(response) => response,
             Err(error) =>  return Err(FailedFeedRequest::UnknownError(error)),
         };
 
@@ -44,7 +50,7 @@ impl PatchFeedRequest for BlockingLoreAPIClient {
             _ => return Err(FailedFeedRequest::StatusNotOk(feed_response)),
         };
 
-        feed_response_body = feed_response.text().unwrap();
+        let feed_response_body: String = feed_response.text().unwrap();
         if feed_response_body.eq(r"</feed>") {
             return Err(FailedFeedRequest::EndOfFeed);
         };
@@ -60,18 +66,18 @@ pub enum FailedAvailableListsRequest {
 }
 
 pub trait AvailableListsRequest {
-    fn request_available_lists(self: &Self, min_index: u32) -> Result<String, FailedAvailableListsRequest>;
+    fn request_available_lists(&self, min_index: u32) -> Result<String, FailedAvailableListsRequest>;
 }
 
 impl AvailableListsRequest for BlockingLoreAPIClient {
-    fn request_available_lists(self: &Self, min_index: u32) -> Result<String, FailedAvailableListsRequest> {
-        let available_lists_request: String;
-        let available_lists: Response;
+    fn request_available_lists(&self, min_index: u32) -> Result<String, FailedAvailableListsRequest> {
         
-        available_lists_request = format!("{LORE_DOMAIN}/?&o={min_index}");
+        
+        
+        let available_lists_request: String = format!("{LORE_DOMAIN}/?&o={min_index}");
 
-        match reqwest::blocking::get(available_lists_request) {
-            Ok(response) => available_lists = response,
+        let available_lists: Response = match reqwest::blocking::get(available_lists_request) {
+            Ok(response) => response,
             Err(error) =>  return Err(FailedAvailableListsRequest::UnknownError(error)),
         };
 
@@ -91,18 +97,18 @@ pub enum FailedPatchHTMLRequest {
 }
 
 pub trait PatchHTMLRequest {
-    fn request_patch_html(self: &Self, target_list: &str, message_id: &str) -> Result<String, FailedPatchHTMLRequest>;
+    fn request_patch_html(&self, target_list: &str, message_id: &str) -> Result<String, FailedPatchHTMLRequest>;
 }
 
 impl PatchHTMLRequest for BlockingLoreAPIClient {
-    fn request_patch_html(self: &Self, target_list: &str, message_id: &str) -> Result<String, FailedPatchHTMLRequest> {
-        let patch_html_request: String;
-        let patch_html: Response;
+    fn request_patch_html(&self, target_list: &str, message_id: &str) -> Result<String, FailedPatchHTMLRequest> {
+        
+        
 
-        patch_html_request = format!("{LORE_DOMAIN}/{target_list}/{message_id}/");
+        let patch_html_request: String = format!("{LORE_DOMAIN}/{target_list}/{message_id}/");
 
-        match reqwest::blocking::get(patch_html_request) {
-            Ok(response) => patch_html = response,
+        let patch_html: Response = match reqwest::blocking::get(patch_html_request) {
+            Ok(response) => response,
             Err(error) =>  return Err(FailedPatchHTMLRequest::UnknownError(error)),
         };
 

--- a/src/lore_api_client/tests.rs
+++ b/src/lore_api_client/tests.rs
@@ -10,7 +10,9 @@ fn blocking_client_can_request_valid_patch_feed() {
     let patch_feed: PatchFeed = serde_xml_rs::from_str(&patch_feed).unwrap();
     let patches = patch_feed.get_patches();
 
-    assert_eq!(200, patches.len(),
+    assert_eq!(
+        200,
+        patches.len(),
         "Should successfully request patch feed with 200 patches"
     );
 }
@@ -23,7 +25,9 @@ fn blocking_client_should_detect_failed_patch_feed_request() {
     if let Err(failed_feed_request) = lore_api_client.request_patch_feed("invalid-list", 0) {
         match failed_feed_request {
             FailedFeedRequest::StatusNotOk(_) => (),
-            _ => panic!("Invalid request should return non 200 OK status.\n{failed_feed_request:#?}")
+            _ => {
+                panic!("Invalid request should return non 200 OK status.\n{failed_feed_request:#?}")
+            }
         }
     } else {
         panic!("Invalid request shouldn't be successful");
@@ -32,7 +36,9 @@ fn blocking_client_should_detect_failed_patch_feed_request() {
     if let Err(failed_feed_request) = lore_api_client.request_patch_feed("amd-gfx", 300000) {
         match failed_feed_request {
             FailedFeedRequest::EndOfFeed => (),
-            _ => panic!("Out-of-bounds request should return end of feed.\n{failed_feed_request:#?}")
+            _ => {
+                panic!("Out-of-bounds request should return end of feed.\n{failed_feed_request:#?}")
+            }
         }
     } else {
         panic!("Out-of-bounds request shouldn't be successful");
@@ -54,7 +60,10 @@ fn blocking_client_can_request_valid_available_lists() {
 fn blocking_client_can_request_valid_patch_html() {
     let lore_api_client = BlockingLoreAPIClient::new();
 
-    if lore_api_client.request_patch_html("all", "Pine.LNX.4.58.0507282031180.3307@g5.osdl.org").is_err() {
+    if lore_api_client
+        .request_patch_html("all", "Pine.LNX.4.58.0507282031180.3307@g5.osdl.org")
+        .is_err()
+    {
         panic!("Valid request should be successful");
     }
 }

--- a/src/lore_api_client/tests.rs
+++ b/src/lore_api_client/tests.rs
@@ -44,7 +44,7 @@ fn blocking_client_should_detect_failed_patch_feed_request() {
 fn blocking_client_can_request_valid_available_lists() {
     let lore_api_client = BlockingLoreAPIClient::new();
 
-    if let Err(_) = lore_api_client.request_available_lists(0) {
+    if lore_api_client.request_available_lists(0).is_err() {
         panic!("Valid request should be successful");
     }
 }
@@ -54,7 +54,7 @@ fn blocking_client_can_request_valid_available_lists() {
 fn blocking_client_can_request_valid_patch_html() {
     let lore_api_client = BlockingLoreAPIClient::new();
 
-    if let Err(_) = lore_api_client.request_patch_html("all", "Pine.LNX.4.58.0507282031180.3307@g5.osdl.org") {
+    if lore_api_client.request_patch_html("all", "Pine.LNX.4.58.0507282031180.3307@g5.osdl.org").is_err() {
         panic!("Valid request should be successful");
     }
 }

--- a/src/lore_session/tests.rs
+++ b/src/lore_session/tests.rs
@@ -4,9 +4,15 @@ use super::*;
 use crate::patch::Author;
 use std::fs;
 
-struct FakeLoreAPIClient { src_path: String }
+struct FakeLoreAPIClient {
+    src_path: String,
+}
 impl PatchFeedRequest for FakeLoreAPIClient {
-    fn request_patch_feed(&self, target_list: &str, min_index: u32) -> Result<String, FailedFeedRequest> {
+    fn request_patch_feed(
+        &self,
+        target_list: &str,
+        min_index: u32,
+    ) -> Result<String, FailedFeedRequest> {
         let _ = min_index;
         let _ = target_list;
         Ok(fs::read_to_string(&self.src_path).unwrap())
@@ -17,7 +23,8 @@ impl PatchFeedRequest for FakeLoreAPIClient {
 fn can_initialize_fresh_lore_session() {
     let lore_session: LoreSession = LoreSession::new("some-list".to_string());
 
-    assert!(lore_session.get_representative_patches_ids().is_empty(),
+    assert!(
+        lore_session.get_representative_patches_ids().is_empty(),
         "`LoreSession` should initialize with an empty vector of representative patches IDs"
     );
 }
@@ -25,35 +32,57 @@ fn can_initialize_fresh_lore_session() {
 #[test]
 fn should_process_one_representative_patch() {
     let mut lore_session: LoreSession = LoreSession::new("some-list".to_string());
-    let lore_api_client: FakeLoreAPIClient = FakeLoreAPIClient { src_path: "src/test_samples/lore_session/process_representative_patch/patch_feed_sample_1.xml".to_string() };
+    let lore_api_client: FakeLoreAPIClient = FakeLoreAPIClient {
+        src_path:
+            "src/test_samples/lore_session/process_representative_patch/patch_feed_sample_1.xml"
+                .to_string(),
+    };
     let message_id: &str = "http://lore.kernel.org/some-subsystem/1234.567-1-john@johnson.com/";
-    
 
-    if lore_session.process_n_representative_patches(&lore_api_client, 1).is_ok() {};
+    if lore_session
+        .process_n_representative_patches(&lore_api_client, 1)
+        .is_ok()
+    {};
 
-    assert_eq!(1, lore_session.get_representative_patches_ids().len(),
+    assert_eq!(
+        1,
+        lore_session.get_representative_patches_ids().len(),
         "Should have processed exactly 1 representative patches, but processed {}",
         lore_session.get_representative_patches_ids().len()
     );
 
-    assert_eq!(message_id, lore_session.get_representative_patches_ids().first().unwrap(),
+    assert_eq!(
+        message_id,
+        lore_session
+            .get_representative_patches_ids()
+            .first()
+            .unwrap(),
         "Wrong representative patch message ID"
     );
 
     let patch: &Patch = lore_session.get_processed_patch(message_id).unwrap();
-    assert_eq!("some/subsystem: Do this and that", patch.get_title(),
+    assert_eq!(
+        "some/subsystem: Do this and that",
+        patch.get_title(),
         "Wrong title of processed patch"
     );
-    assert_eq!(&Author { name: "John Johnson".to_string(), email: "john@johnson.com".to_string() }, patch.get_author(),
+    assert_eq!(
+        &Author {
+            name: "John Johnson".to_string(),
+            email: "john@johnson.com".to_string()
+        },
+        patch.get_author(),
         "Wrong author of processed patch"
     );
-    assert_eq!(1, patch.get_version(),
-        "Wrong version of processed patch"
-    );
-    assert_eq!(0, patch.get_number_in_series(),
+    assert_eq!(1, patch.get_version(), "Wrong version of processed patch");
+    assert_eq!(
+        0,
+        patch.get_number_in_series(),
         "Wrong number in series of processed patch"
     );
-    assert_eq!(2, patch.get_total_in_series(),
+    assert_eq!(
+        2,
+        patch.get_total_in_series(),
         "Wrong total in series of processed patch"
     );
 }
@@ -61,25 +90,49 @@ fn should_process_one_representative_patch() {
 #[test]
 fn should_process_multiple_representative_patches() {
     let mut lore_session: LoreSession = LoreSession::new("some-list".to_string());
-    let lore_api_client: FakeLoreAPIClient = FakeLoreAPIClient { src_path: "src/test_samples/lore_session/process_representative_patch/patch_feed_sample_2.xml".to_string() };
+    let lore_api_client: FakeLoreAPIClient = FakeLoreAPIClient {
+        src_path:
+            "src/test_samples/lore_session/process_representative_patch/patch_feed_sample_2.xml"
+                .to_string(),
+    };
     let message_id_1: &str = "http://lore.kernel.org/some-subsystem/1234.567-1-roberto@silva.br/";
     let message_id_2: &str = "http://lore.kernel.org/some-subsystem/first-patch-lima@luma.rs/";
     let message_id_3: &str = "http://lore.kernel.org/some-subsystem/1234.567-1-john@johnson.com/";
 
-    if lore_session.process_n_representative_patches(&lore_api_client, 3).is_ok() {};
+    if lore_session
+        .process_n_representative_patches(&lore_api_client, 3)
+        .is_ok()
+    {};
 
-    assert_eq!(3, lore_session.get_representative_patches_ids().len(),
+    assert_eq!(
+        3,
+        lore_session.get_representative_patches_ids().len(),
         "Should have processed exactly 3 representative patches, but processed {}",
         lore_session.get_representative_patches_ids().len()
     );
 
-    assert_eq!(message_id_1 , lore_session.get_representative_patches_ids().first().unwrap(),
+    assert_eq!(
+        message_id_1,
+        lore_session
+            .get_representative_patches_ids()
+            .first()
+            .unwrap(),
         "Wrong representative patch message ID at index 0"
     );
-    assert_eq!(message_id_2 , lore_session.get_representative_patches_ids().get(1).unwrap(),
+    assert_eq!(
+        message_id_2,
+        lore_session
+            .get_representative_patches_ids()
+            .get(1)
+            .unwrap(),
         "Wrong representative patch message ID at index 1"
     );
-    assert_eq!(message_id_3 , lore_session.get_representative_patches_ids().get(2).unwrap(),
+    assert_eq!(
+        message_id_3,
+        lore_session
+            .get_representative_patches_ids()
+            .get(2)
+            .unwrap(),
         "Wrong representative patch message ID at index 2"
     );
 }
@@ -89,130 +142,171 @@ fn test_split_patchset_invalid_cases() {
     let ret: Result<Vec<String>, String> = split_patchset("invalid/path");
     assert_eq!(Err("invalid/path: Path doesn't exist".to_string()), ret);
 
-    let ret: Result<Vec<String>, String> = split_patchset("src/test_samples/lore_session/split_patchset/not_a_file");
-    assert_eq!(Err("src/test_samples/lore_session/split_patchset/not_a_file: Not a file".to_string()), ret);
+    let ret: Result<Vec<String>, String> =
+        split_patchset("src/test_samples/lore_session/split_patchset/not_a_file");
+    assert_eq!(
+        Err("src/test_samples/lore_session/split_patchset/not_a_file: Not a file".to_string()),
+        ret
+    );
 }
 
 #[test]
 fn should_split_patchset_without_cover_letter() {
     let ret: Result<Vec<String>, String> = split_patchset(
-        "src/test_samples/lore_session/split_patchset/patchset_sample_without_cover_letter.mbx"
+        "src/test_samples/lore_session/split_patchset/patchset_sample_without_cover_letter.mbx",
     );
 
     if ret.is_err() {
         panic!("Should return a `Vec<String>` type");
     }
-    
+
     let patches = ret.unwrap();
 
-    assert_eq!(
-        3, patches.len(),
-        "Wrong number of patches"
-    );
+    assert_eq!(3, patches.len(), "Wrong number of patches");
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_1.mbx").unwrap(), patches[0],
+        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_1.mbx")
+            .unwrap(),
+        patches[0],
         "Wrong patch number 1"
     );
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_2.mbx").unwrap(), patches[1],
+        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_2.mbx")
+            .unwrap(),
+        patches[1],
         "Wrong patch number 2"
     );
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_3.mbx").unwrap(), patches[2],
+        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_3.mbx")
+            .unwrap(),
+        patches[2],
         "Wrong patch number 3"
     );
 }
 
 #[test]
 fn should_split_patchset_complete() {
-    let ret: Result<Vec<String>, String> = split_patchset(
-        "src/test_samples/lore_session/split_patchset/patchset_sample_complete.mbx"
-    );
+    let ret: Result<Vec<String>, String> =
+        split_patchset("src/test_samples/lore_session/split_patchset/patchset_sample_complete.mbx");
 
     if ret.is_err() {
         panic!("Should return a `Vec<String>` type");
     }
-    
+
     let patches = ret.unwrap();
 
-    assert_eq!(
-        4, patches.len(),
-        "Wrong number of patches"
-    );
+    assert_eq!(4, patches.len(), "Wrong number of patches");
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_cover_letter.cover").unwrap(), patches[0],
+        fs::read_to_string(
+            "src/test_samples/lore_session/split_patchset/expected_cover_letter.cover"
+        )
+        .unwrap(),
+        patches[0],
         "Wrong cover letter"
     );
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_1.mbx").unwrap(), patches[1],
+        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_1.mbx")
+            .unwrap(),
+        patches[1],
         "Wrong patch number 1"
     );
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_2.mbx").unwrap(), patches[2],
+        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_2.mbx")
+            .unwrap(),
+        patches[2],
         "Wrong patch number 2"
     );
 
     assert_eq!(
-        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_3.mbx").unwrap(), patches[3],
+        fs::read_to_string("src/test_samples/lore_session/split_patchset/expected_patch_3.mbx")
+            .unwrap(),
+        patches[3],
         "Wrong patch number 3"
     );
 }
 
 #[test]
 fn should_process_available_lists() {
-    let available_lists_response = fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-1.html").unwrap();
+    let available_lists_response = fs::read_to_string(
+        "src/test_samples/lore_session/process_available_lists/available_lists_response-1.html",
+    )
+    .unwrap();
     let available_lists = process_available_lists(available_lists_response);
 
-    assert_eq!(199, available_lists.len(),
-        "Should've processed 199 lists"
-    );
+    assert_eq!(199, available_lists.len(), "Should've processed 199 lists");
 
-    assert_eq!("linux-mm".to_string(), available_lists[0].get_name(),
+    assert_eq!(
+        "linux-mm".to_string(),
+        available_lists[0].get_name(),
         "Wrong list name for index 0"
     );
-    assert_eq!("Linux-mm Archive on lore.kernel.org".to_string(), available_lists[0].get_description(),
+    assert_eq!(
+        "Linux-mm Archive on lore.kernel.org".to_string(),
+        available_lists[0].get_description(),
         "Wrong list description for index 0"
     );
-    assert_eq!("linux-kselftest".to_string(), available_lists[42].get_name(),
+    assert_eq!(
+        "linux-kselftest".to_string(),
+        available_lists[42].get_name(),
         "Wrong list name for index 42"
     );
-    assert_eq!("Linux Kernel Selftest development".to_string(), available_lists[42].get_description(),
+    assert_eq!(
+        "Linux Kernel Selftest development".to_string(),
+        available_lists[42].get_description(),
         "Wrong list description for index 42"
     );
-    assert_eq!("distributions".to_string(), available_lists[99].get_name(),
+    assert_eq!(
+        "distributions".to_string(),
+        available_lists[99].get_name(),
         "Wrong list name for index 99"
     );
-    assert_eq!("Forum for Linux distributions to discuss problems and share PSAs".to_string(), available_lists[99].get_description(),
+    assert_eq!(
+        "Forum for Linux distributions to discuss problems and share PSAs".to_string(),
+        available_lists[99].get_description(),
         "Wrong list description for index 99"
     );
-    assert_eq!("grub-devel".to_string(), available_lists[135].get_name(),
+    assert_eq!(
+        "grub-devel".to_string(),
+        available_lists[135].get_name(),
         "Wrong list name for index 135"
     );
-    assert_eq!("Grub Development Archive on lore.kernel.org".to_string(), available_lists[135].get_description(),
+    assert_eq!(
+        "Grub Development Archive on lore.kernel.org".to_string(),
+        available_lists[135].get_description(),
         "Wrong list description for index 135"
     );
-    assert_eq!("linux-nilfs".to_string(), available_lists[180].get_name(),
+    assert_eq!(
+        "linux-nilfs".to_string(),
+        available_lists[180].get_name(),
         "Wrong list name for index 180"
     );
-    assert_eq!("Linux NILFS development".to_string(), available_lists[180].get_description(),
+    assert_eq!(
+        "Linux NILFS development".to_string(),
+        available_lists[180].get_description(),
         "Wrong list description for index 180"
     );
-    assert_eq!("linux-sparse".to_string(), available_lists[198].get_name(),
+    assert_eq!(
+        "linux-sparse".to_string(),
+        available_lists[198].get_name(),
         "Wrong list name for index 198"
     );
-    assert_eq!("Linux SPARSE checker discussions".to_string(), available_lists[198].get_description(),
+    assert_eq!(
+        "Linux SPARSE checker discussions".to_string(),
+        available_lists[198].get_description(),
         "Wrong list description for index 198"
     );
 }
 
 impl AvailableListsRequest for FakeLoreAPIClient {
-    fn request_available_lists(&self, min_index: u32) -> Result<String, FailedAvailableListsRequest> {
+    fn request_available_lists(
+        &self,
+        min_index: u32,
+    ) -> Result<String, FailedAvailableListsRequest> {
         match min_index {
             0 => Ok(fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-1.html").unwrap()),
             200 => Ok(fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-2.html").unwrap()),
@@ -224,25 +318,39 @@ impl AvailableListsRequest for FakeLoreAPIClient {
 
 #[test]
 fn should_fetch_all_available_lists() {
-    let lore_api_client = FakeLoreAPIClient { src_path: "".to_string() };
+    let lore_api_client = FakeLoreAPIClient {
+        src_path: "".to_string(),
+    };
     let sorted_available_lists = fetch_available_lists(&lore_api_client).unwrap();
 
-    assert_eq!("accel-config".to_string(), sorted_available_lists[0].get_name(),
+    assert_eq!(
+        "accel-config".to_string(),
+        sorted_available_lists[0].get_name(),
         "Wrong list name for index 0"
     );
-    assert_eq!("Accel-Config development".to_string(), sorted_available_lists[0].get_description(),
+    assert_eq!(
+        "Accel-Config development".to_string(),
+        sorted_available_lists[0].get_description(),
         "Wrong list description for index 0"
     );
-    assert_eq!("linux-mediatek".to_string(), sorted_available_lists[159].get_name(),
+    assert_eq!(
+        "linux-mediatek".to_string(),
+        sorted_available_lists[159].get_name(),
         "Wrong list name for index 159"
     );
-    assert_eq!("Linux-mediatek Archive on lore.kernel.org".to_string(), sorted_available_lists[159].get_description(),
+    assert_eq!(
+        "Linux-mediatek Archive on lore.kernel.org".to_string(),
+        sorted_available_lists[159].get_description(),
         "Wrong list description for index 159"
     );
-    assert_eq!("yocto-toaster".to_string(), sorted_available_lists[319].get_name(),
+    assert_eq!(
+        "yocto-toaster".to_string(),
+        sorted_available_lists[319].get_name(),
         "Wrong list name for index 319"
     );
-    assert_eq!("Yocto Toaster".to_string(), sorted_available_lists[319].get_description(),
+    assert_eq!(
+        "Yocto Toaster".to_string(),
+        sorted_available_lists[319].get_description(),
         "Wrong list description for index 319"
     );
 
@@ -251,25 +359,34 @@ fn should_fetch_all_available_lists() {
 
 #[test]
 fn should_generate_patch_reply_template() {
-    let patch_sample = fs::read_to_string("src/test_samples/lore_session/generate_patch_reply_template/patch_sample.mbx").unwrap();
-    let expected_reply_template = fs::read_to_string("src/test_samples/lore_session/generate_patch_reply_template/expected_reply_template.mbx").unwrap();
+    let patch_sample = fs::read_to_string(
+        "src/test_samples/lore_session/generate_patch_reply_template/patch_sample.mbx",
+    )
+    .unwrap();
+    let expected_reply_template = fs::read_to_string(
+        "src/test_samples/lore_session/generate_patch_reply_template/expected_reply_template.mbx",
+    )
+    .unwrap();
 
     let reply_template = generate_patch_reply_template(&patch_sample);
 
-    assert_eq!(expected_reply_template, reply_template,
+    assert_eq!(
+        expected_reply_template, reply_template,
         "Reply template wasn't correctly generated"
     )
 }
 
 fn commands_eq(cmd1: &Command, cmd2: &Command) -> bool {
-    cmd1.get_program() == cmd2.get_program() &&
-    cmd1.get_args().collect::<Vec<_>>() == cmd2.get_args().collect::<Vec<_>>()
+    cmd1.get_program() == cmd2.get_program()
+        && cmd1.get_args().collect::<Vec<_>>() == cmd2.get_args().collect::<Vec<_>>()
 }
 
 #[test]
-fn should_extract_git_reply_command_from_patch_html()
-{
-    let patch_html = fs::read_to_string("src/test_samples/lore_session/extract_git_reply_command/patch_lore_sample.html").unwrap();
+fn should_extract_git_reply_command_from_patch_html() {
+    let patch_html = fs::read_to_string(
+        "src/test_samples/lore_session/extract_git_reply_command/patch_lore_sample.html",
+    )
+    .unwrap();
     let mut expected_git_reply_command = Command::new("git");
     expected_git_reply_command
         .arg("send-email")
@@ -283,8 +400,11 @@ fn should_extract_git_reply_command_from_patch_html()
 
     let git_reply_command = extract_git_reply_command(&patch_html);
 
-    assert!(commands_eq(&expected_git_reply_command, &git_reply_command),
-        "Wrong git reply command\nExpected:{:?}\n  Actual:{:?}", expected_git_reply_command, git_reply_command
+    assert!(
+        commands_eq(&expected_git_reply_command, &git_reply_command),
+        "Wrong git reply command\nExpected:{:?}\n  Actual:{:?}",
+        expected_git_reply_command,
+        git_reply_command
     );
 }
 
@@ -302,7 +422,11 @@ fn files_eq(path1: &str, path2: &str) -> io::Result<bool> {
 }
 
 impl PatchHTMLRequest for FakeLoreAPIClient {
-    fn request_patch_html(&self, _target_list: &str, message_id: &str) -> Result<String, FailedPatchHTMLRequest> {
+    fn request_patch_html(
+        &self,
+        _target_list: &str,
+        message_id: &str,
+    ) -> Result<String, FailedPatchHTMLRequest> {
         let patch_html = "git-send-email(1): ".to_owned();
         let patch_html = match message_id {
             "1234.567-0-foo@bar.foo.bar" => patch_html + "git send-email --in-reply-to=1234.567-0-foo@bar.foo.bar --to=foo@bar.foo.bar /path/to/YOUR_REPLY",
@@ -318,13 +442,8 @@ impl PatchHTMLRequest for FakeLoreAPIClient {
 
 #[test]
 fn should_prepare_reply_patchset_with_reviewed_by() {
-    let tmp_dir = Command::new("mktemp")
-        .arg("--directory")
-        .output()
-        .unwrap();
-    let tmp_dir = Path::new(
-        std::str::from_utf8(&tmp_dir.stdout).unwrap().trim()
-    );
+    let tmp_dir = Command::new("mktemp").arg("--directory").output().unwrap();
+    let tmp_dir = Path::new(std::str::from_utf8(&tmp_dir.stdout).unwrap().trim());
 
     let mut expected_git_reply_command_0 = Command::new("git");
     expected_git_reply_command_0
@@ -333,7 +452,10 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
         .arg("--suppress-cc=all")
         .arg("--in-reply-to=1234.567-0-foo@bar.foo.bar")
         .arg("--to=foo@bar.foo.bar")
-        .arg(format!("{}/1234.567-0-foo@bar.foo.bar-reply.mbx", tmp_dir.display()));
+        .arg(format!(
+            "{}/1234.567-0-foo@bar.foo.bar-reply.mbx",
+            tmp_dir.display()
+        ));
     let mut expected_git_reply_command_1 = Command::new("git");
     expected_git_reply_command_1
         .arg("send-email")
@@ -341,7 +463,10 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
         .arg("--suppress-cc=all")
         .arg("--in-reply-to=1234.567-1-foo@bar.foo.bar")
         .arg("--to=foo@bar.foo.bar")
-        .arg(format!("{}/1234.567-1-foo@bar.foo.bar-reply.mbx", tmp_dir.display()));
+        .arg(format!(
+            "{}/1234.567-1-foo@bar.foo.bar-reply.mbx",
+            tmp_dir.display()
+        ));
     let mut expected_git_reply_command_2 = Command::new("git");
     expected_git_reply_command_2
         .arg("send-email")
@@ -349,7 +474,10 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
         .arg("--suppress-cc=all")
         .arg("--in-reply-to=1234.567-2-foo@bar.foo.bar")
         .arg("--to=foo@bar.foo.bar")
-        .arg(format!("{}/1234.567-2-foo@bar.foo.bar-reply.mbx", tmp_dir.display()));
+        .arg(format!(
+            "{}/1234.567-2-foo@bar.foo.bar-reply.mbx",
+            tmp_dir.display()
+        ));
     let mut expected_git_reply_command_3 = Command::new("git");
     expected_git_reply_command_3
         .arg("send-email")
@@ -357,42 +485,73 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
         .arg("--suppress-cc=all")
         .arg("--in-reply-to=1234.567-3-foo@bar.foo.bar")
         .arg("--to=foo@bar.foo.bar")
-        .arg(format!("{}/1234.567-3-foo@bar.foo.bar-reply.mbx", tmp_dir.display()));
+        .arg(format!(
+            "{}/1234.567-3-foo@bar.foo.bar-reply.mbx",
+            tmp_dir.display()
+        ));
 
     let expected_git_reply_commands = vec![
         expected_git_reply_command_0,
         expected_git_reply_command_1,
         expected_git_reply_command_2,
-        expected_git_reply_command_3
+        expected_git_reply_command_3,
     ];
 
-    let lore_api_client = FakeLoreAPIClient{ src_path: "".to_owned() };
+    let lore_api_client = FakeLoreAPIClient {
+        src_path: "".to_owned(),
+    };
 
     let patches = vec![
-        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/cover_letter.cover").unwrap(),
-        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/patch_1.mbx").unwrap(),
-        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/patch_2.mbx").unwrap(),
-        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/patch_3.mbx").unwrap(),
+        fs::read_to_string(
+            "src/test_samples/lore_session/prepare_reply_w_reviewed_by/cover_letter.cover",
+        )
+        .unwrap(),
+        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/patch_1.mbx")
+            .unwrap(),
+        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/patch_2.mbx")
+            .unwrap(),
+        fs::read_to_string("src/test_samples/lore_session/prepare_reply_w_reviewed_by/patch_3.mbx")
+            .unwrap(),
     ];
 
     let git_reply_commands = prepare_reply_patchset_with_reviewed_by(
-        &lore_api_client, tmp_dir, "all", &patches, "Bar Foo <bar@foo.bar.foo>"
-    ).unwrap();
+        &lore_api_client,
+        tmp_dir,
+        "all",
+        &patches,
+        "Bar Foo <bar@foo.bar.foo>",
+    )
+    .unwrap();
 
-    for (expected, actual) in expected_git_reply_commands.iter().zip(git_reply_commands.iter()) {
-        assert!(commands_eq(expected, actual),
-            "Wrong git reply command\nExpected:{:?}\n  Actual:{:?}", expected, actual 
+    for (expected, actual) in expected_git_reply_commands
+        .iter()
+        .zip(git_reply_commands.iter())
+    {
+        assert!(
+            commands_eq(expected, actual),
+            "Wrong git reply command\nExpected:{:?}\n  Actual:{:?}",
+            expected,
+            actual
         );
-
     }
 
     for i in 0..=3 {
-        let expected_path = format!("src/test_samples/lore_session/prepare_reply_w_reviewed_by/expected_patch_{}-reply.mbx", i);
-        let actual_path = format!("{}/1234.567-{}-foo@bar.foo.bar-reply.mbx", tmp_dir.display(), i);
-        assert!(files_eq(&expected_path, &actual_path).unwrap(),
+        let expected_path = format!(
+            "src/test_samples/lore_session/prepare_reply_w_reviewed_by/expected_patch_{}-reply.mbx",
+            i
+        );
+        let actual_path = format!(
+            "{}/1234.567-{}-foo@bar.foo.bar-reply.mbx",
+            tmp_dir.display(),
+            i
+        );
+        assert!(
+            files_eq(&expected_path, &actual_path).unwrap(),
             "Wrong reply with reviewed-by generated\nExpected ({}):\n{}\n  Actual({}):\n{}\n",
-            &expected_path, &fs::read_to_string(&expected_path).unwrap(),
-            &actual_path, &fs::read_to_string(&actual_path).unwrap()
+            &expected_path,
+            &fs::read_to_string(&expected_path).unwrap(),
+            &actual_path,
+            &fs::read_to_string(&actual_path).unwrap()
         );
     }
 
@@ -401,22 +560,17 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
 
 #[test]
 fn should_get_local_git_signature() {
-    let mocked_git_repo = Command::new("mktemp")
-        .arg("--directory")
-        .output()
-        .unwrap();
-    let mocked_git_repo = Path::new(
-        std::str::from_utf8(&mocked_git_repo.stdout).unwrap().trim()
-    );
+    let mocked_git_repo = Command::new("mktemp").arg("--directory").output().unwrap();
+    let mocked_git_repo = Path::new(std::str::from_utf8(&mocked_git_repo.stdout).unwrap().trim());
 
-    let _ =Command::new("git")
+    let _ = Command::new("git")
         .arg("-C")
         .arg(format!("{}", mocked_git_repo.display()))
         .arg("init")
         .output()
         .unwrap();
 
-    let _ =Command::new("git")
+    let _ = Command::new("git")
         .arg("-C")
         .arg(format!("{}", mocked_git_repo.display()))
         .arg("config")
@@ -426,7 +580,7 @@ fn should_get_local_git_signature() {
         .output()
         .unwrap();
 
-    let _ =Command::new("git")
+    let _ = Command::new("git")
         .arg("-C")
         .arg(format!("{}", mocked_git_repo.display()))
         .arg("config")
@@ -438,11 +592,15 @@ fn should_get_local_git_signature() {
 
     let (git_user_name, git_user_email) = get_git_signature(mocked_git_repo.to_str().unwrap());
 
-    assert_eq!("Foo Bar".to_owned(), git_user_name,
+    assert_eq!(
+        "Foo Bar".to_owned(),
+        git_user_name,
         "Wrong `git config user.name` value"
     );
 
-    assert_eq!("foo@bar.foo.bar".to_owned(), git_user_email,
+    assert_eq!(
+        "foo@bar.foo.bar".to_owned(),
+        git_user_email,
         "Wrong `git config user.email` value"
     );
 

--- a/src/mailing_list.rs
+++ b/src/mailing_list.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;

--- a/src/mailing_list.rs
+++ b/src/mailing_list.rs
@@ -12,28 +12,28 @@ pub struct MailingList {
 impl MailingList {
     pub fn new(name: &str, description: &str) -> Self {
         MailingList {
-            name: format!("{name}"),
-            description: format!("{description}"),
+            name: name.to_string(),
+            description: description.to_string(),
         }
     }
 
-    pub fn get_name(self: &Self) -> &str {
+    pub fn get_name(&self) -> &str {
         &self.name
     }
 
-    pub fn get_description(self: &Self) -> &str {
+    pub fn get_description(&self) -> &str {
         &self.description
     }
 }
 
 impl Ord for MailingList {
-    fn cmp(self: &Self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.name.cmp(&other.name)
     }
 }
 
 impl PartialOrd for MailingList {
-    fn partial_cmp(self: &Self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }

--- a/src/mailing_list/tests.rs
+++ b/src/mailing_list/tests.rs
@@ -2,24 +2,26 @@ use super::*;
 
 #[test]
 fn can_deserialize_mailing_list() {
-    let expected_mailing_list = MailingList::new(
-        "list-name", "List Description"
-    );
+    let expected_mailing_list = MailingList::new("list-name", "List Description");
     let serialized_mailing_list = r#"{"name":"list-name","description":"List Description"}"#;
-    let deserialized_mailing_list: MailingList = serde_json::from_str(serialized_mailing_list).unwrap();
+    let deserialized_mailing_list: MailingList =
+        serde_json::from_str(serialized_mailing_list).unwrap();
 
-    assert_eq!(expected_mailing_list, deserialized_mailing_list,
+    assert_eq!(
+        expected_mailing_list, deserialized_mailing_list,
         "Wrong deserialization of mailing list"
     )
 }
 
 #[test]
 fn can_serialize_mailing_list() {
-    let expected_serialized_mailing_list = r#"{"name":"list-name","description":"List Description"}"#;
+    let expected_serialized_mailing_list =
+        r#"{"name":"list-name","description":"List Description"}"#;
     let mailing_list = MailingList::new("list-name", "List Description");
     let serialized_mailing_list = serde_json::to_string(&mailing_list).unwrap();
 
-    assert_eq!(expected_serialized_mailing_list, serialized_mailing_list,
+    assert_eq!(
+        expected_serialized_mailing_list, serialized_mailing_list,
         "Wrong serialization of mailing list"
     )
 }
@@ -36,19 +38,24 @@ fn should_sort_mailing_list_vec() {
     let mailing_list_vec_for_cmp = mailing_list_vec.clone();
     mailing_list_vec.sort();
 
-    assert_eq!(mailing_list_vec_for_cmp[4], mailing_list_vec[0],
+    assert_eq!(
+        mailing_list_vec_for_cmp[4], mailing_list_vec[0],
         "Wrong mailing list at index 0"
     );
-    assert_eq!(mailing_list_vec_for_cmp[2], mailing_list_vec[1],
+    assert_eq!(
+        mailing_list_vec_for_cmp[2], mailing_list_vec[1],
         "Wrong mailing list at index 1"
     );
-    assert_eq!(mailing_list_vec_for_cmp[0], mailing_list_vec[2],
+    assert_eq!(
+        mailing_list_vec_for_cmp[0], mailing_list_vec[2],
         "Wrong mailing list at index 2"
     );
-    assert_eq!(mailing_list_vec_for_cmp[3], mailing_list_vec[3],
+    assert_eq!(
+        mailing_list_vec_for_cmp[3], mailing_list_vec[3],
         "Wrong mailing list at index 3"
     );
-    assert_eq!(mailing_list_vec_for_cmp[1], mailing_list_vec[4],
+    assert_eq!(
+        mailing_list_vec_for_cmp[1], mailing_list_vec[4],
         "Wrong mailing list at index 4"
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> color_eyre::Result<()> {
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> color_eyre::Result<()> {
     loop {
-        terminal.draw(|f| draw_ui(f, &app))?;
+        terminal.draw(|f| draw_ui(f, app))?;
 
         match app.current_screen {
             CurrentScreen::MailingListSelection => {

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -11,7 +11,7 @@ pub struct PatchFeed {
 }
 
 impl PatchFeed {
-    pub fn get_patches(self: Self) -> Vec<Patch> {
+    pub fn get_patches(self) -> Vec<Patch> {
         self.patches
     }
 }
@@ -52,53 +52,53 @@ impl Patch {
     pub fn new(title: String, author: Author, message_id: MessageID,
         in_reply_to: Option<MessageID>, updated: String) -> Patch {
         Patch {
-            title: title,
-            author: author,
+            title,
+            author,
             version: 1,
             number_in_series: 1,
             total_in_series: 1,
-            message_id: message_id,
-            in_reply_to: in_reply_to,
-            updated: updated,
+            message_id,
+            in_reply_to,
+            updated,
         }
     }
 
-    pub fn get_title(self: &Self) -> &str {
+    pub fn get_title(&self) -> &str {
         &self.title
     }
 
-    pub fn get_version(self: &Self) -> u32 {
+    pub fn get_version(&self) -> u32 {
         self.version
     }
 
-    pub fn get_number_in_series(self: &Self) -> u32 {
+    pub fn get_number_in_series(&self) -> u32 {
         self.number_in_series
     }
 
-    pub fn get_total_in_series(self: &Self) -> u32 {
+    pub fn get_total_in_series(&self) -> u32 {
         self.total_in_series
     }
 
-    pub fn get_author(self: &Self) -> &Author {
+    pub fn get_author(&self) -> &Author {
         &self.author
     }
 
-    pub fn get_in_reply_to(self: &Self) -> &Option<MessageID> {
+    pub fn get_in_reply_to(&self) -> &Option<MessageID> {
         &self.in_reply_to
     }
 
-    pub fn get_updated(self: &Self) -> &str {
+    pub fn get_updated(&self) -> &str {
         &self.updated
     }
 
-    pub fn get_message_id(self: &Self) -> &MessageID {
+    pub fn get_message_id(&self) -> &MessageID {
         &self.message_id
     }
 
-    pub fn update_patch_metadata(self: &mut Self, patch_regex: &PatchRegex) {
-        let patch_tag: String;
+    pub fn update_patch_metadata(&mut self, patch_regex: &PatchRegex) {
+        
 
-        patch_tag = match self.get_patch_tag(&patch_regex.re_patch_tag) {
+        let patch_tag: String = match self.get_patch_tag(&patch_regex.re_patch_tag) {
             Some(value) => value.to_string(),
             None => return,
         };
@@ -109,21 +109,21 @@ impl Patch {
         self.set_total_in_series(&patch_tag, &patch_regex.re_patch_series);
     }
 
-    fn get_patch_tag(self: &Self, re_patch_tag: &Regex) -> Option<&str> {
+    fn get_patch_tag(&self, re_patch_tag: &Regex) -> Option<&str> {
         match re_patch_tag.find(&self.title) {
             Some(patch_tag) => Some(patch_tag.as_str()),
             None => None,
         }
     }
 
-    fn remove_patch_tag_from_title(self: &mut Self, patch_tag: &str) {
+    fn remove_patch_tag_from_title(&mut self, patch_tag: &str) {
         self.title = self.title
             .replace(patch_tag, "")
             .trim()
             .to_string();
     }
 
-    fn set_version(self: &mut Self, patch_tag: &str, re_patch_version: &Regex) {
+    fn set_version(&mut self, patch_tag: &str, re_patch_version: &Regex) {
         if let Some(capture) = re_patch_version.captures(patch_tag) {
             if let Some(version) = capture.get(1) {
                 self.version = version.as_str().parse().unwrap();
@@ -131,7 +131,7 @@ impl Patch {
         }
     }
 
-    fn set_number_in_series(self: &mut Self, patch_tag: &str, re_patch_series: &Regex) {
+    fn set_number_in_series(&mut self, patch_tag: &str, re_patch_series: &Regex) {
         if let Some(capture) = re_patch_series.captures(patch_tag) {
             if let Some(number_in_series) = capture.get(1) {
                 self.number_in_series = number_in_series.as_str().parse().unwrap();
@@ -139,7 +139,7 @@ impl Patch {
         }
     }
 
-    fn set_total_in_series(self: &mut Self, patch_tag: &str, re_patch_series: &Regex) {
+    fn set_total_in_series(&mut self, patch_tag: &str, re_patch_series: &Regex) {
         if let Some(capture) = re_patch_series.captures(patch_tag) {
             if let Some(total_in_series) = capture.get(2) {
                 self.total_in_series = total_in_series.as_str().parse().unwrap();
@@ -152,6 +152,12 @@ pub struct PatchRegex {
     pub re_patch_tag: Regex,
     pub re_patch_version: Regex,
     pub re_patch_series: Regex,
+}
+
+impl Default for PatchRegex {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl PatchRegex {

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -44,13 +44,24 @@ pub struct MessageID {
     pub href: String,
 }
 
-fn default_version() -> u32 { 1 }
-fn default_number_in_series() -> u32 { 1 }
-fn default_total_in_series() -> u32 { 1 }
+fn default_version() -> u32 {
+    1
+}
+fn default_number_in_series() -> u32 {
+    1
+}
+fn default_total_in_series() -> u32 {
+    1
+}
 
 impl Patch {
-    pub fn new(title: String, author: Author, message_id: MessageID,
-        in_reply_to: Option<MessageID>, updated: String) -> Patch {
+    pub fn new(
+        title: String,
+        author: Author,
+        message_id: MessageID,
+        in_reply_to: Option<MessageID>,
+        updated: String,
+    ) -> Patch {
         Patch {
             title,
             author,
@@ -96,8 +107,6 @@ impl Patch {
     }
 
     pub fn update_patch_metadata(&mut self, patch_regex: &PatchRegex) {
-        
-
         let patch_tag: String = match self.get_patch_tag(&patch_regex.re_patch_tag) {
             Some(value) => value.to_string(),
             None => return,
@@ -117,10 +126,7 @@ impl Patch {
     }
 
     fn remove_patch_tag_from_title(&mut self, patch_tag: &str) {
-        self.title = self.title
-            .replace(patch_tag, "")
-            .trim()
-            .to_string();
+        self.title = self.title.replace(patch_tag, "").trim().to_string();
     }
 
     fn set_version(&mut self, patch_tag: &str, re_patch_version: &Regex) {

--- a/src/patch/tests.rs
+++ b/src/patch/tests.rs
@@ -5,10 +5,15 @@ use serde_xml_rs::from_str;
 fn can_deserialize_patch_without_in_reply_to() {
     let expected_patch: Patch = Patch::new(
         "[PATCH 0/42] hitchhiker/guide: Complete Collection".to_string(),
-        Author { name: "Foo Bar".to_string(), email: "foo@bar.foo.bar".to_string() },
-        MessageID { href: "http://lore.kernel.org/some-list/1234-1-foo@bar.foo.bar".to_string() },
+        Author {
+            name: "Foo Bar".to_string(),
+            email: "foo@bar.foo.bar".to_string(),
+        },
+        MessageID {
+            href: "http://lore.kernel.org/some-list/1234-1-foo@bar.foo.bar".to_string(),
+        },
         None,
-        "2024-07-06T19:15:48Z".to_string()
+        "2024-07-06T19:15:48Z".to_string(),
     );
     let serialized_patch: &str = r#"
         <entry xmlns:thr="http://purl.org/syndication/thread/1.0">
@@ -27,7 +32,8 @@ fn can_deserialize_patch_without_in_reply_to() {
 
     let actual_patch: Patch = from_str(serialized_patch).unwrap();
 
-    assert_eq!(expected_patch, actual_patch,
+    assert_eq!(
+        expected_patch, actual_patch,
         "An entry from a patch feed should deserialize into"
     )
 }
@@ -36,10 +42,17 @@ fn can_deserialize_patch_without_in_reply_to() {
 fn can_deserialize_patch_with_in_reply_to() {
     let expected_patch: Patch = Patch::new(
         "[PATCH 3/42] hitchhiker/guide: Life, the Universe and Everything".to_string(),
-        Author { name: "Foo Bar".to_string(), email: "foo@bar.foo.bar".to_string() },
-        MessageID { href: "http://lore.kernel.org/some-list/1234-2-foo@bar.foo.bar".to_string() },
-        Some(MessageID { href: "http://lore.kernel.org/some-list/1234-1-foo@bar.foo.bar".to_string() }),
-        "2024-07-06T19:16:53Z".to_string()
+        Author {
+            name: "Foo Bar".to_string(),
+            email: "foo@bar.foo.bar".to_string(),
+        },
+        MessageID {
+            href: "http://lore.kernel.org/some-list/1234-2-foo@bar.foo.bar".to_string(),
+        },
+        Some(MessageID {
+            href: "http://lore.kernel.org/some-list/1234-1-foo@bar.foo.bar".to_string(),
+        }),
+        "2024-07-06T19:16:53Z".to_string(),
     );
     let serialized_patch: &str = r#"
         <entry xmlns:thr="http://purl.org/syndication/thread/1.0">
@@ -61,7 +74,8 @@ fn can_deserialize_patch_with_in_reply_to() {
 
     let actual_patch: Patch = from_str(serialized_patch).unwrap();
 
-    assert_eq!(expected_patch, actual_patch,
+    assert_eq!(
+        expected_patch, actual_patch,
         "An entry from a patch feed should deserialize into"
     )
 }
@@ -71,15 +85,24 @@ fn test_update_patch_metadata() {
     let patch_regex: PatchRegex = PatchRegex::new();
     let mut patch: Patch = Patch::new(
         "[RESEND][v7 PATCH 3/42] hitchhiker/guide: Life, the Universe and Everything".to_string(),
-        Author { name: "Foo Bar".to_string(), email: "foo@bar.foo.bar".to_string() },
-        MessageID { href: "http://lore.kernel.org/some-list/1234-2-foo@bar.foo.bar".to_string() },
-        Some(MessageID { href: "http://lore.kernel.org/some-list/1234-1-foo@bar.foo.bar".to_string() }),
-        "2024-07-06T19:16:53Z".to_string()
+        Author {
+            name: "Foo Bar".to_string(),
+            email: "foo@bar.foo.bar".to_string(),
+        },
+        MessageID {
+            href: "http://lore.kernel.org/some-list/1234-2-foo@bar.foo.bar".to_string(),
+        },
+        Some(MessageID {
+            href: "http://lore.kernel.org/some-list/1234-1-foo@bar.foo.bar".to_string(),
+        }),
+        "2024-07-06T19:16:53Z".to_string(),
     );
 
     patch.update_patch_metadata(&patch_regex);
 
-    assert_eq!("[RESEND] hitchhiker/guide: Life, the Universe and Everything", patch.get_title(),
+    assert_eq!(
+        "[RESEND] hitchhiker/guide: Life, the Universe and Everything",
+        patch.get_title(),
         "The title should have the patch tag `[v7 PATCH 3/42]` stripped"
     );
     assert_eq!(7, patch.get_version(), "Wrong version!");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -62,15 +62,17 @@ fn render_mailing_list_selection(f: &mut Frame, app: &App, chunk: Rect) {
     for mailing_list in &app.mailing_list_selection_state.possible_mailing_lists {
         list_items.push(ListItem::new(
             Line::from(vec![
-            Span::styled(
-                mailing_list.get_name().to_string(),
-                Style::default().fg(Color::Magenta),
-            ),
-            Span::styled(
-                format!(" - {}", mailing_list.get_description()),
-                Style::default().fg(Color::White),
-            ),
-        ]).centered()))
+                Span::styled(
+                    mailing_list.get_name().to_string(),
+                    Style::default().fg(Color::Magenta),
+                ),
+                Span::styled(
+                    format!(" - {}", mailing_list.get_description()),
+                    Style::default().fg(Color::White),
+                ),
+            ])
+            .centered(),
+        ))
     }
 
     let list_block = Block::default()
@@ -103,7 +105,11 @@ fn render_bookmarked_patchsets(
     let patchset_index = bookmarked_patchsets_state.patchset_index;
     let mut list_items = Vec::<ListItem>::new();
 
-    for (index, patch) in bookmarked_patchsets_state.bookmarked_patchsets.iter().enumerate() {
+    for (index, patch) in bookmarked_patchsets_state
+        .bookmarked_patchsets
+        .iter()
+        .enumerate()
+    {
         let patch_title = format!("{:width$}", patch.get_title(), width = 70);
         let patch_title = format!("{:.width$}", patch_title, width = 70);
         let patch_author = format!("{:width$}", patch.get_author().name, width = 30);
@@ -304,7 +310,10 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
             Span::styled("ookmark", Style::default().fg(Color::Cyan)),
         ]),
         Line::from(vec![
-            if *patchset_actions.get(&PatchsetAction::ReplyWithReviewedBy).unwrap() {
+            if *patchset_actions
+                .get(&PatchsetAction::ReplyWithReviewedBy)
+                .unwrap()
+            {
                 Span::styled("[x] ", Style::default().fg(Color::Green))
             } else {
                 Span::styled("[ ] ", Style::default().fg(Color::Cyan))
@@ -341,7 +350,9 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
         .patchset_details_and_actions_state
         .as_ref()
         .unwrap()
-        .representative_patch.get_message_id().href;
+        .representative_patch
+        .get_message_id()
+        .href;
     let mut preview_title = String::from(" Preview ");
     if let Some(successful_indexes) = app.reviewed_patchsets.get(representative_patch_message_id) {
         if successful_indexes.contains(&preview_index) {
@@ -365,7 +376,9 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
             Block::default()
                 .borders(Borders::ALL)
                 .border_type(ratatui::widgets::BorderType::Double)
-                .title(Line::styled(preview_title, Style::default().fg(Color::Green)).left_aligned())
+                .title(
+                    Line::styled(preview_title, Style::default().fg(Color::Green)).left_aligned(),
+                )
                 .padding(Padding::vertical(1)),
         )
         .left_aligned()
@@ -384,23 +397,29 @@ fn render_navi_bar(f: &mut Frame, app: &App, chunk: Rect) {
                     Span::styled("type the target list", Style::default().fg(Color::DarkGray))
             } else {
                 for mailing_list in &app.mailing_list_selection_state.mailing_lists {
-                    if mailing_list.get_name().eq(&app.mailing_list_selection_state.target_list) {
+                    if mailing_list
+                        .get_name()
+                        .eq(&app.mailing_list_selection_state.target_list)
+                    {
                         text_area = Span::styled(
                             &app.mailing_list_selection_state.target_list,
-                            Style::default().fg(Color::Green)
+                            Style::default().fg(Color::Green),
                         );
                         break;
-                    } else if mailing_list.get_name().starts_with(&app.mailing_list_selection_state.target_list) {
+                    } else if mailing_list
+                        .get_name()
+                        .starts_with(&app.mailing_list_selection_state.target_list)
+                    {
                         text_area = Span::styled(
                             &app.mailing_list_selection_state.target_list,
-                            Style::default().fg(Color::LightCyan)
+                            Style::default().fg(Color::LightCyan),
                         );
                     }
                 }
                 if text_area.content.is_empty() {
                     text_area = Span::styled(
                         &app.mailing_list_selection_state.target_list,
-                        Style::default().fg(Color::Red)
+                        Style::default().fg(Color::Red),
                     );
                 }
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -24,7 +24,7 @@ pub fn draw_ui(f: &mut Frame, app: &App) {
     render_title(f, chunks[0]);
 
     match app.current_screen {
-        CurrentScreen::MailingListSelection => render_mailing_list_selection(f, &app, chunks[1]),
+        CurrentScreen::MailingListSelection => render_mailing_list_selection(f, app, chunks[1]),
         CurrentScreen::BookmarkedPatchsets => {
             render_bookmarked_patchsets(f, &app.bookmarked_patchsets_state, chunks[1])
         }
@@ -63,7 +63,7 @@ fn render_mailing_list_selection(f: &mut Frame, app: &App, chunk: Rect) {
         list_items.push(ListItem::new(
             Line::from(vec![
             Span::styled(
-                format!("{}", mailing_list.get_name()),
+                mailing_list.get_name().to_string(),
                 Style::default().fg(Color::Magenta),
             ),
             Span::styled(
@@ -101,10 +101,9 @@ fn render_bookmarked_patchsets(
     chunk: Rect,
 ) {
     let patchset_index = bookmarked_patchsets_state.patchset_index;
-    let mut index: u32 = 0;
     let mut list_items = Vec::<ListItem>::new();
 
-    for patch in &bookmarked_patchsets_state.bookmarked_patchsets {
+    for (index, patch) in bookmarked_patchsets_state.bookmarked_patchsets.iter().enumerate() {
         let patch_title = format!("{:width$}", patch.get_title(), width = 70);
         let patch_title = format!("{:.width$}", patch_title, width = 70);
         let patch_author = format!("{:width$}", patch.get_author().name, width = 30);
@@ -123,7 +122,6 @@ fn render_bookmarked_patchsets(
             ))
             .centered(),
         ));
-        index += 1;
     }
 
     let list_block = Block::default()
@@ -237,14 +235,14 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
         Line::from(vec![
             Span::styled(r#"  Title: "#, Style::default().fg(Color::Cyan)),
             Span::styled(
-                format!("{}", patchset_details.get_title()),
+                patchset_details.get_title().to_string(),
                 Style::default().fg(Color::White),
             ),
         ]),
         Line::from(vec![
             Span::styled("Author: ", Style::default().fg(Color::Cyan)),
             Span::styled(
-                format!("{}", patchset_details.get_author().name),
+                patchset_details.get_author().name.to_string(),
                 Style::default().fg(Color::White),
             ),
         ]),
@@ -265,7 +263,7 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
         Line::from(vec![
             Span::styled("Last updated: ", Style::default().fg(Color::Cyan)),
             Span::styled(
-                format!("{}", patchset_details.get_updated()),
+                patchset_details.get_updated().to_string(),
                 Style::default().fg(Color::White),
             ),
         ]),
@@ -347,7 +345,7 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
     let mut preview_title = String::from(" Preview ");
     if let Some(successful_indexes) = app.reviewed_patchsets.get(representative_patch_message_id) {
         if successful_indexes.contains(&preview_index) {
-            preview_title = format!(" Preview [REVIEWED] ");
+            preview_title = " Preview [REVIEWED] ".to_string();
         }
     };
 
@@ -362,7 +360,7 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
         .unwrap()
         .patches[preview_index as usize]
         .replace('\t', "        ");
-    let patch_preview = Paragraph::new(Text::from(format!("{patch_preview}")))
+    let patch_preview = Paragraph::new(Text::from(patch_preview.to_string()))
         .block(
             Block::default()
                 .borders(Borders::ALL)
@@ -377,8 +375,7 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
 }
 
 fn render_navi_bar(f: &mut Frame, app: &App, chunk: Rect) {
-    let mode_footer_text: Vec<Span>;
-    match app.current_screen {
+    let mode_footer_text = match app.current_screen {
         CurrentScreen::MailingListSelection => {
             let mut text_area = Span::default();
 
@@ -408,19 +405,19 @@ fn render_navi_bar(f: &mut Frame, app: &App, chunk: Rect) {
                 }
             }
 
-            mode_footer_text = vec![
+            vec![
                 Span::styled("Target List: ", Style::default().fg(Color::Green)),
                 text_area,
             ]
         }
         CurrentScreen::BookmarkedPatchsets => {
-            mode_footer_text = vec![Span::styled(
+            vec![Span::styled(
                 "Bookmarked Patchsets",
                 Style::default().fg(Color::Green),
             )]
         }
         CurrentScreen::LatestPatchsets => {
-            mode_footer_text = vec![Span::styled(
+            vec![Span::styled(
                 format!(
                     "Latest Patchsets from {} (page {})",
                     &app.latest_patchsets_state
@@ -436,12 +433,12 @@ fn render_navi_bar(f: &mut Frame, app: &App, chunk: Rect) {
             )]
         }
         CurrentScreen::PatchsetDetails => {
-            mode_footer_text = vec![Span::styled(
+            vec![Span::styled(
                 "Patchset Details and Actions",
                 Style::default().fg(Color::Green),
             )]
         }
-    }
+    };
     let mode_footer = Paragraph::new(Line::from(mode_footer_text))
         .block(Block::default().borders(Borders::ALL))
         .centered();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,6 @@
-use std::io::{
-    self, stdout, Stdout
-};
+use color_eyre::{config::HookBuilder, eyre};
+use std::io::{self, stdout, Stdout};
 use std::panic;
-use color_eyre::{
-    config::HookBuilder, eyre
-};
 
 use ratatui::{
     backend::CrosstermBackend,


### PR DESCRIPTION
As a result of offline conversations with @lorenzoberts and @OJarrisonn, this PR inherits PRs #30 and #31.

This PR does three things:

1. Add a CI pipeline for formatting with `cargo fmt` and linting with `cargo clippy` in GitHub Actions (first commit)
2. Add pre-commit hooks for formatting and linting (second commit)
3. Enforce linting and formatting (third and fourth commits, respectively).

@lorenzoberts, as we discussed, see if you can review this PR (sorry for the huge delay). A code review would be sufficient (don't bother with commits number 3 and 4), but if you can, try to test it too by pulling this branch and running some workflows on the tool (e.g., select lists, navigate through the flow of patchsets, consult a patchset and run some actions).

**Obs.:** If you wish to test this PR, pull the branch with

```
git checkout -b <some-arbitrary-branch-name> unstable               
git pull --rebase https://github.com/davidbtadokoro/patch-hub.git feat-add-formatting-and-linting
```