### PR TITLE
Cargo.toml linting

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+lint = "clippy --all-targets --all-features"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,11 @@ installers = []
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
+
+[lints.rust]
+warnings = "deny"
+unconditional_recursion = "deny"
+
+[lints.clippy]
+too-many-arguments = "allow"
+map_unwrap_or = "deny"


### PR DESCRIPTION
This PR is a continuation of what were done in #38 

Here i'm reinforcing the rules in the `format_and_lint` workflow in Cargo.toml. This feature is really helpful since every rule will now be enforced at compile time rather than at "pull request time". Also for those who use a LSP/IDE the rules will be enforced at code editing time.

Just by adding this section to the Cargo.toml a lot of overhead with PRs being refused just by formatting reasons will be avoided