### PR TITLE
Standarize the use of usize for unsigned integers by refactoring

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -103,12 +103,7 @@ impl LatestPatchsetsState {
     }
 
     pub fn increment_page(&mut self) {
-        let patchsets_processed: usize = self
-            .lore_session
-            .get_representative_patches_ids()
-            .len()
-            .try_into()
-            .unwrap();
+        let patchsets_processed: usize = self.lore_session.get_representative_patches_ids().len();
         if self.page_size * self.page_number > patchsets_processed {
             return;
         }
@@ -399,7 +394,6 @@ impl App {
         let target_list = self.mailing_list_selection_state.possible_mailing_lists[list_index]
             .get_name()
             .to_string();
-
         self.latest_patchsets_state = Some(LatestPatchsetsState::new(
             target_list,
             self.config.page_size,

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,12 +12,12 @@ mod config;
 
 pub struct BookmarkedPatchsetsState {
     pub bookmarked_patchsets: Vec<Patch>,
-    pub patchset_index: u32,
+    pub patchset_index: usize,
 }
 
 impl BookmarkedPatchsetsState {
     pub fn select_below_patchset(&mut self) {
-        if (self.patchset_index as usize) + 1 < self.bookmarked_patchsets.len() {
+        if self.patchset_index + 1 < self.bookmarked_patchsets.len() {
             self.patchset_index += 1;
         }
     }
@@ -28,7 +28,7 @@ impl BookmarkedPatchsetsState {
 
     fn get_selected_patchset(&self) -> Patch {
         self.bookmarked_patchsets
-            .get(self.patchset_index as usize)
+            .get(self.patchset_index)
             .unwrap()
             .clone()
     }
@@ -54,13 +54,13 @@ pub struct LatestPatchsetsState {
     lore_session: LoreSession,
     lore_api_client: BlockingLoreAPIClient,
     target_list: String,
-    page_number: u32,
-    patchset_index: u32,
-    page_size: u32,
+    page_number: usize,
+    patchset_index: usize,
+    page_size: usize,
 }
 
 impl LatestPatchsetsState {
-    pub fn new(target_list: String, page_size: u32) -> LatestPatchsetsState {
+    pub fn new(target_list: String, page_size: usize) -> LatestPatchsetsState {
         LatestPatchsetsState {
             lore_session: LoreSession::new(target_list.clone()),
             lore_api_client: BlockingLoreAPIClient::new(),
@@ -86,8 +86,7 @@ impl LatestPatchsetsState {
     }
 
     pub fn select_below_patchset(&mut self) {
-        if (self.patchset_index as usize) + 1
-            < self.lore_session.get_representative_patches_ids().len()
+        if self.patchset_index + 1 < self.lore_session.get_representative_patches_ids().len()
             && self.patchset_index + 1 < self.page_size * self.page_number
         {
             self.patchset_index += 1;
@@ -104,7 +103,7 @@ impl LatestPatchsetsState {
     }
 
     pub fn increment_page(&mut self) {
-        let patchsets_processed: u32 = self
+        let patchsets_processed: usize = self
             .lore_session
             .get_representative_patches_ids()
             .len()
@@ -129,11 +128,11 @@ impl LatestPatchsetsState {
         &self.target_list
     }
 
-    pub fn get_page_number(&self) -> u32 {
+    pub fn get_page_number(&self) -> usize {
         self.page_number
     }
 
-    pub fn get_patchset_index(&self) -> u32 {
+    pub fn get_patchset_index(&self) -> usize {
         self.patchset_index
     }
 
@@ -141,7 +140,7 @@ impl LatestPatchsetsState {
         let message_id: &str = self
             .lore_session
             .get_representative_patches_ids()
-            .get(self.patchset_index as usize)
+            .get(self.patchset_index)
             .unwrap();
 
         self.lore_session
@@ -159,8 +158,8 @@ impl LatestPatchsetsState {
 pub struct PatchsetDetailsAndActionsState {
     pub representative_patch: Patch,
     pub patches: Vec<String>,
-    pub preview_index: u32,
-    pub preview_scroll_offset: u32,
+    pub preview_index: usize,
+    pub preview_scroll_offset: usize,
     pub patchset_actions: HashMap<PatchsetAction, bool>,
     pub last_screen: CurrentScreen,
 }
@@ -173,28 +172,28 @@ pub enum PatchsetAction {
 
 impl PatchsetDetailsAndActionsState {
     pub fn preview_next_patch(&mut self) {
-        if ((self.preview_index as usize) + 1) < self.patches.len() {
+        if (self.preview_index + 1) < self.patches.len() {
             self.preview_index += 1;
             self.preview_scroll_offset = 0;
         }
     }
 
     pub fn preview_previous_patch(&mut self) {
-        if (self.preview_index as usize) > 0 {
+        if self.preview_index > 0 {
             self.preview_index -= 1;
             self.preview_scroll_offset = 0;
         }
     }
 
     pub fn preview_scroll_down(&mut self) {
-        let number_of_lines = self.patches[self.preview_index as usize].lines().count();
-        if ((self.preview_scroll_offset as usize) + 1) <= number_of_lines {
+        let number_of_lines = self.patches[self.preview_index].lines().count();
+        if (self.preview_scroll_offset + 1) <= number_of_lines {
             self.preview_scroll_offset += 1;
         }
     }
 
     pub fn preview_scroll_up(&mut self) {
-        if (self.preview_scroll_offset as usize) > 0 {
+        if self.preview_scroll_offset > 0 {
             self.preview_scroll_offset -= 1;
         }
     }
@@ -223,7 +222,7 @@ impl PatchsetDetailsAndActionsState {
     pub fn reply_patchset_with_reviewed_by(
         &self,
         target_list: &str,
-    ) -> color_eyre::Result<Vec<u32>> {
+    ) -> color_eyre::Result<Vec<usize>> {
         let lore_api_client = BlockingLoreAPIClient::new();
         let (git_user_name, git_user_email) = lore_session::get_git_signature("");
         let mut successful_indexes = Vec::new();
@@ -253,7 +252,7 @@ impl PatchsetDetailsAndActionsState {
             let mut child = command.spawn().unwrap();
             let exit_status = child.wait().unwrap();
             if exit_status.success() {
-                successful_indexes.push(index as u32);
+                successful_indexes.push(index);
             }
         }
 
@@ -265,7 +264,7 @@ pub struct MailingListSelectionState {
     pub mailing_lists: Vec<MailingList>,
     pub target_list: String,
     pub possible_mailing_lists: Vec<MailingList>,
-    pub highlighted_list_index: u32,
+    pub highlighted_list_index: usize,
     pub mailing_lists_path: String,
 }
 
@@ -320,7 +319,7 @@ impl MailingListSelectionState {
     }
 
     pub fn highlight_below_list(&mut self) {
-        if (self.highlighted_list_index as usize) + 1 < self.possible_mailing_lists.len() {
+        if self.highlighted_list_index + 1 < self.possible_mailing_lists.len() {
             self.highlighted_list_index += 1;
         }
     }
@@ -331,7 +330,7 @@ impl MailingListSelectionState {
 
     pub fn has_valid_target_list(&self) -> bool {
         let list_length = self.possible_mailing_lists.len(); // Possible mailing list length
-        let list_index = self.highlighted_list_index as usize; // Index of the selected mailing list
+        let list_index = self.highlighted_list_index; // Index of the selected mailing list
 
         if list_index < list_length {
             return true;
@@ -354,7 +353,7 @@ pub struct App {
     pub bookmarked_patchsets_state: BookmarkedPatchsetsState,
     pub latest_patchsets_state: Option<LatestPatchsetsState>,
     pub patchset_details_and_actions_state: Option<PatchsetDetailsAndActionsState>,
-    pub reviewed_patchsets: HashMap<String, Vec<u32>>,
+    pub reviewed_patchsets: HashMap<String, Vec<usize>>,
     pub config: Config,
 }
 
@@ -396,7 +395,7 @@ impl App {
     pub fn init_latest_patchsets_state(&mut self) {
         // the target mailing list for "latest patchsets" is the highlighted
         // entry in the possible lists of "mailing list selection"
-        let list_index = self.mailing_list_selection_state.highlighted_list_index as usize;
+        let list_index = self.mailing_list_selection_state.highlighted_list_index;
         let target_list = self.mailing_list_selection_state.possible_mailing_lists[list_index]
             .get_name()
             .to_string();

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 pub struct Config {
-    pub page_size: u32,
+    pub page_size: usize,
     pub patchsets_cache_dir: String,
     pub bookmarked_patchsets_path: String,
     pub mailing_lists_path: String,
@@ -10,7 +10,7 @@ pub struct Config {
 
 impl Config {
     pub fn build() -> Self {
-        let page_size: u32 = match env::var("PATCH_HUB_PAGE_SIZE") {
+        let page_size: usize = match env::var("PATCH_HUB_PAGE_SIZE") {
             Ok(value) => value.parse().unwrap(),
             Err(_) => 30,
         };

--- a/src/lore_api_client.rs
+++ b/src/lore_api_client.rs
@@ -32,7 +32,7 @@ pub trait PatchFeedRequest {
     fn request_patch_feed(
         &self,
         target_list: &str,
-        min_index: u32,
+        min_index: usize,
     ) -> Result<String, FailedFeedRequest>;
 }
 
@@ -40,7 +40,7 @@ impl PatchFeedRequest for BlockingLoreAPIClient {
     fn request_patch_feed(
         &self,
         target_list: &str,
-        min_index: u32,
+        min_index: usize,
     ) -> Result<String, FailedFeedRequest> {
         let feed_request: String =
             format!("{LORE_DOMAIN}/{target_list}/{BASE_QUERY_FOR_FEED_REQUEST}&o={min_index}");
@@ -73,14 +73,14 @@ pub enum FailedAvailableListsRequest {
 pub trait AvailableListsRequest {
     fn request_available_lists(
         &self,
-        min_index: u32,
+        min_index: usize,
     ) -> Result<String, FailedAvailableListsRequest>;
 }
 
 impl AvailableListsRequest for BlockingLoreAPIClient {
     fn request_available_lists(
         &self,
-        min_index: u32,
+        min_index: usize,
     ) -> Result<String, FailedAvailableListsRequest> {
         let available_lists_request: String = format!("{LORE_DOMAIN}/?&o={min_index}");
 

--- a/src/lore_session.rs
+++ b/src/lore_session.rs
@@ -123,10 +123,7 @@ impl LoreSession {
 
     pub fn get_patch_feed_page(&self, page_size: usize, page_number: usize) -> Option<Vec<&Patch>> {
         let mut patch_feed_page: Vec<&Patch> = Vec::new();
-            let representative_patches_ids_max_index: usize = (self.representative_patches_ids.len()
-                - 1)
-            .try_into()
-            .unwrap();
+        let representative_patches_ids_max_index: usize = self.representative_patches_ids.len() - 1;
         let lower_end: usize = page_size * (page_number - 1);
         let mut upper_end: usize = page_size * page_number;
 

--- a/src/lore_session/tests.rs
+++ b/src/lore_session/tests.rs
@@ -11,7 +11,7 @@ impl PatchFeedRequest for FakeLoreAPIClient {
     fn request_patch_feed(
         &self,
         target_list: &str,
-        min_index: u32,
+        min_index: usize,
     ) -> Result<String, FailedFeedRequest> {
         let _ = min_index;
         let _ = target_list;
@@ -305,7 +305,7 @@ fn should_process_available_lists() {
 impl AvailableListsRequest for FakeLoreAPIClient {
     fn request_available_lists(
         &self,
-        min_index: u32,
+        min_index: usize,
     ) -> Result<String, FailedAvailableListsRequest> {
         match min_index {
             0 => Ok(fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-1.html").unwrap()),

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -20,11 +20,11 @@ impl PatchFeed {
 pub struct Patch {
     r#title: String,
     #[serde(default = "default_version")]
-    version: u32,
+    version: usize,
     #[serde(default = "default_number_in_series")]
-    number_in_series: u32,
+    number_in_series: usize,
     #[serde(default = "default_total_in_series")]
-    total_in_series: u32,
+    total_in_series: usize,
     author: Author,
     #[serde(rename = "link")]
     message_id: MessageID,
@@ -44,13 +44,13 @@ pub struct MessageID {
     pub href: String,
 }
 
-fn default_version() -> u32 {
+fn default_version() -> usize {
     1
 }
-fn default_number_in_series() -> u32 {
+fn default_number_in_series() -> usize {
     1
 }
-fn default_total_in_series() -> u32 {
+fn default_total_in_series() -> usize {
     1
 }
 
@@ -78,15 +78,15 @@ impl Patch {
         &self.title
     }
 
-    pub fn get_version(&self) -> u32 {
+    pub fn get_version(&self) -> usize {
         self.version
     }
 
-    pub fn get_number_in_series(&self) -> u32 {
+    pub fn get_number_in_series(&self) -> usize {
         self.number_in_series
     }
 
-    pub fn get_total_in_series(&self) -> u32 {
+    pub fn get_total_in_series(&self) -> usize {
         self.total_in_series
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -92,7 +92,7 @@ fn render_mailing_list_selection(f: &mut Frame, app: &App, chunk: Rect) {
         .highlight_spacing(HighlightSpacing::Always);
 
     let mut list_state = ListState::default();
-    list_state.select(Some(highlighted_list_index as usize));
+    list_state.select(Some(highlighted_list_index));
 
     f.render_stateful_widget(list, chunk, &mut list_state);
 }
@@ -147,7 +147,7 @@ fn render_bookmarked_patchsets(
         .highlight_spacing(HighlightSpacing::Always);
 
     let mut list_state = ListState::default();
-    list_state.select(Some(patchset_index as usize));
+    list_state.select(Some(patchset_index));
 
     f.render_stateful_widget(list, chunk, &mut list_state);
 }
@@ -172,7 +172,7 @@ fn render_list(f: &mut Frame, app: &App, chunk: Rect) {
         .get_current_patch_feed_page()
         .unwrap();
 
-    let mut index: u32 = (page_number - 1) * app.config.page_size;
+    let mut index: usize = (page_number - 1) * app.config.page_size;
     for patch in patch_feed_page {
         let patch_title = format!("{:width$}", patch.get_title(), width = 70);
         let patch_title = format!("{:.width$}", patch_title, width = 70);
@@ -369,7 +369,7 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
         .patchset_details_and_actions_state
         .as_ref()
         .unwrap()
-        .patches[preview_index as usize]
+        .patches[preview_index]
         .replace('\t', "        ");
     let patch_preview = Paragraph::new(Text::from(patch_preview.to_string()))
         .block(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -213,9 +213,7 @@ fn render_list(f: &mut Frame, app: &App, chunk: Rect) {
 
     let mut list_state = ListState::default();
     list_state.select(Some(
-        (patchset_index - (page_number - 1) * app.config.page_size)
-            .try_into()
-            .unwrap(),
+        patchset_index - (page_number - 1) * app.config.page_size,
     ));
 
     f.render_stateful_widget(list, chunk, &mut list_state);


### PR DESCRIPTION
usize is used in a lot of places in the code by cast os as u32. To standarize the usage of unsigned integers, usize is going to be used in detriment of u32.

Closes #35