### PR TITLE
Config `create_dirs`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -361,6 +361,7 @@ pub struct App {
 impl App {
     pub fn new() -> App {
         let config: Config = Config::build();
+        config.create_dirs();
 
         let mailing_lists =
             lore_session::load_available_lists(&config.mailing_lists_path).unwrap_or_default();

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -63,9 +63,6 @@ impl Config {
     pub fn create_dirs(&self) {
         let paths = vec![
             &self.patchsets_cache_dir,
-            &self.bookmarked_patchsets_path,
-            &self.mailing_lists_path,
-            &self.reviewed_patchsets_path,
         ];
 
         for path in paths {

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, fs};
 
 pub struct Config {
     pub page_size: u32,
@@ -53,6 +53,26 @@ impl Config {
             bookmarked_patchsets_path,
             mailing_lists_path,
             reviewed_patchsets_path,
+        }
+    }
+
+    /// Creates the needed directories if they don't exist.
+    /// The directories are defined during the Config build.
+    ///
+    /// This function must be called as soon as the Config is built so no other function attempt to use an inexistent folder.
+    pub fn create_dirs(&self) {
+        let paths = vec![
+            &self.patchsets_cache_dir,
+            &self.bookmarked_patchsets_path,
+            &self.mailing_lists_path,
+            &self.reviewed_patchsets_path,
+        ];
+
+        for path in paths {
+            if fs::metadata(path).is_err() {
+                // TODO: Log the folder creation
+                fs::create_dir_all(path).unwrap();
+            }
         }
     }
 }


### PR DESCRIPTION
This PR introduces a function that creates all the needed folders defined in the `Config` so they don't need to be created manually