### PR TITLE
refactor: replace get_ methods with derive_getter::Getters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-getters"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6433aac097572ea8ccc60b3f2e756c661c9aeed9225cdd4d0cb119cb7ff6ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +750,7 @@ dependencies = [
  "chrono",
  "clap",
  "color-eyre",
+ "derive-getters",
  "ratatui",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "patch-hub is a TUI that streamlines the interaction of Linux deve
 
 [dependencies]
 color-eyre = "0.6.3"
+derive-getters = "0.4.0"
 ratatui = "0.27.0"
 regex = "1.10.5"
 reqwest = { version = "0.12.5", default-features = false, features = ["blocking", "rustls-tls"] }

--- a/src/lore_api_client/tests.rs
+++ b/src/lore_api_client/tests.rs
@@ -8,7 +8,7 @@ fn blocking_client_can_request_valid_patch_feed() {
 
     let patch_feed = lore_api_client.request_patch_feed("amd-gfx", 0).unwrap();
     let patch_feed: PatchFeed = serde_xml_rs::from_str(&patch_feed).unwrap();
-    let patches = patch_feed.get_patches();
+    let patches = patch_feed.patches();
 
     assert_eq!(
         200,

--- a/src/lore_session.rs
+++ b/src/lore_session.rs
@@ -4,6 +4,7 @@ use crate::lore_api_client::{
 };
 use crate::mailing_list::MailingList;
 use crate::patch::{Patch, PatchFeed, PatchRegex};
+use derive_getters::Getters;
 use regex::Regex;
 use serde_xml_rs::from_str;
 use std::collections::HashMap;
@@ -21,11 +22,16 @@ mod tests;
 
 const LORE_PAGE_SIZE: usize = 200;
 
+#[derive(Getters)]
 pub struct LoreSession {
     representative_patches_ids: Vec<String>,
+    #[getter(skip)]
     processed_patches_map: HashMap<String, Patch>,
+    #[getter(skip)]
     patch_regex: PatchRegex,
+    #[getter(skip)]
     target_list: String,
+    #[getter(skip)]
     min_index: usize,
 }
 
@@ -38,10 +44,6 @@ impl LoreSession {
             patch_regex: PatchRegex::new(),
             min_index: 0,
         }
-    }
-
-    pub fn get_representative_patches_ids(&self) -> &Vec<String> {
-        &self.representative_patches_ids
     }
 
     pub fn get_processed_patch(&self, message_id: &str) -> Option<&Patch> {
@@ -74,16 +76,16 @@ impl LoreSession {
     fn process_patches(&mut self, patch_feed: PatchFeed) -> Vec<String> {
         let mut processed_patches_ids: Vec<String> = Vec::new();
 
-        for mut patch in patch_feed.get_patches() {
+        for mut patch in patch_feed.patches().clone() {
             patch.update_patch_metadata(&self.patch_regex);
 
             if !self
                 .processed_patches_map
-                .contains_key(&patch.get_message_id().href)
+                .contains_key(&patch.message_id().href)
             {
-                processed_patches_ids.push(patch.get_message_id().href.clone());
+                processed_patches_ids.push(patch.message_id().href.clone());
                 self.processed_patches_map
-                    .insert(patch.get_message_id().href.clone(), patch);
+                    .insert(patch.message_id().href.clone(), patch);
             }
         }
 
@@ -96,19 +98,19 @@ impl LoreSession {
 
         for message_id in processed_patches_ids {
             patch = self.processed_patches_map.get(&message_id).unwrap();
-            patch_number_in_series = patch.get_number_in_series();
+            patch_number_in_series = *patch.number_in_series();
 
             if patch_number_in_series > 1 {
                 continue;
             }
 
             if patch_number_in_series == 1 {
-                if let Some(in_reply_to) = &patch.get_in_reply_to() {
+                if let Some(in_reply_to) = &patch.in_reply_to() {
                     if let Some(patch_in_reply_to) =
                         self.processed_patches_map.get(&in_reply_to.href)
                     {
-                        if (patch_in_reply_to.get_number_in_series() == 0)
-                            && (patch.get_version() == patch_in_reply_to.get_version())
+                        if (*patch_in_reply_to.number_in_series() == 0)
+                            && (*patch.version() == *patch_in_reply_to.version())
                         {
                             continue;
                         };
@@ -117,7 +119,7 @@ impl LoreSession {
             }
 
             self.representative_patches_ids
-                .push(patch.get_message_id().href.clone());
+                .push(patch.message_id().href.clone());
         }
     }
 
@@ -148,7 +150,7 @@ impl LoreSession {
 }
 
 pub fn download_patchset(output_dir: &str, patch: &Patch) -> io::Result<String> {
-    let message_id: &str = &patch.get_message_id().href;
+    let message_id: &str = &patch.message_id().href;
     let mbox_name: String = extract_mbox_name_from_message_id(message_id);
 
     if !Path::new(output_dir).exists() {
@@ -161,7 +163,7 @@ pub fn download_patchset(output_dir: &str, patch: &Patch) -> io::Result<String> 
             .arg("--quiet")
             .arg("am")
             .arg("--use-version")
-            .arg(format!("{}", patch.get_version()))
+            .arg(format!("{}", patch.version()))
             .arg(message_id)
             .arg("--outdir")
             .arg(output_dir)

--- a/src/lore_session/tests.rs
+++ b/src/lore_session/tests.rs
@@ -24,7 +24,7 @@ fn can_initialize_fresh_lore_session() {
     let lore_session: LoreSession = LoreSession::new("some-list".to_string());
 
     assert!(
-        lore_session.get_representative_patches_ids().is_empty(),
+        lore_session.representative_patches_ids().is_empty(),
         "`LoreSession` should initialize with an empty vector of representative patches IDs"
     );
 }
@@ -46,24 +46,21 @@ fn should_process_one_representative_patch() {
 
     assert_eq!(
         1,
-        lore_session.get_representative_patches_ids().len(),
+        lore_session.representative_patches_ids().len(),
         "Should have processed exactly 1 representative patches, but processed {}",
-        lore_session.get_representative_patches_ids().len()
+        lore_session.representative_patches_ids().len()
     );
 
     assert_eq!(
         message_id,
-        lore_session
-            .get_representative_patches_ids()
-            .first()
-            .unwrap(),
+        lore_session.representative_patches_ids().first().unwrap(),
         "Wrong representative patch message ID"
     );
 
     let patch: &Patch = lore_session.get_processed_patch(message_id).unwrap();
     assert_eq!(
         "some/subsystem: Do this and that",
-        patch.get_title(),
+        patch.title(),
         "Wrong title of processed patch"
     );
     assert_eq!(
@@ -71,18 +68,18 @@ fn should_process_one_representative_patch() {
             name: "John Johnson".to_string(),
             email: "john@johnson.com".to_string()
         },
-        patch.get_author(),
+        patch.author(),
         "Wrong author of processed patch"
     );
-    assert_eq!(1, patch.get_version(), "Wrong version of processed patch");
+    assert_eq!(1, *patch.version(), "Wrong version of processed patch");
     assert_eq!(
         0,
-        patch.get_number_in_series(),
+        *patch.number_in_series(),
         "Wrong number in series of processed patch"
     );
     assert_eq!(
         2,
-        patch.get_total_in_series(),
+        *patch.total_in_series(),
         "Wrong total in series of processed patch"
     );
 }
@@ -106,33 +103,24 @@ fn should_process_multiple_representative_patches() {
 
     assert_eq!(
         3,
-        lore_session.get_representative_patches_ids().len(),
+        lore_session.representative_patches_ids().len(),
         "Should have processed exactly 3 representative patches, but processed {}",
-        lore_session.get_representative_patches_ids().len()
+        lore_session.representative_patches_ids().len()
     );
 
     assert_eq!(
         message_id_1,
-        lore_session
-            .get_representative_patches_ids()
-            .first()
-            .unwrap(),
+        lore_session.representative_patches_ids().first().unwrap(),
         "Wrong representative patch message ID at index 0"
     );
     assert_eq!(
         message_id_2,
-        lore_session
-            .get_representative_patches_ids()
-            .get(1)
-            .unwrap(),
+        lore_session.representative_patches_ids().get(1).unwrap(),
         "Wrong representative patch message ID at index 1"
     );
     assert_eq!(
         message_id_3,
-        lore_session
-            .get_representative_patches_ids()
-            .get(2)
-            .unwrap(),
+        lore_session.representative_patches_ids().get(2).unwrap(),
         "Wrong representative patch message ID at index 2"
     );
 }
@@ -242,62 +230,62 @@ fn should_process_available_lists() {
 
     assert_eq!(
         "linux-mm".to_string(),
-        available_lists[0].get_name(),
+        available_lists[0].name().to_string(),
         "Wrong list name for index 0"
     );
     assert_eq!(
         "Linux-mm Archive on lore.kernel.org".to_string(),
-        available_lists[0].get_description(),
+        available_lists[0].description().to_string(),
         "Wrong list description for index 0"
     );
     assert_eq!(
         "linux-kselftest".to_string(),
-        available_lists[42].get_name(),
+        available_lists[42].name().to_string(),
         "Wrong list name for index 42"
     );
     assert_eq!(
         "Linux Kernel Selftest development".to_string(),
-        available_lists[42].get_description(),
+        available_lists[42].description().to_string(),
         "Wrong list description for index 42"
     );
     assert_eq!(
         "distributions".to_string(),
-        available_lists[99].get_name(),
+        available_lists[99].name().to_string(),
         "Wrong list name for index 99"
     );
     assert_eq!(
         "Forum for Linux distributions to discuss problems and share PSAs".to_string(),
-        available_lists[99].get_description(),
+        available_lists[99].description().to_string(),
         "Wrong list description for index 99"
     );
     assert_eq!(
         "grub-devel".to_string(),
-        available_lists[135].get_name(),
+        available_lists[135].name().to_string(),
         "Wrong list name for index 135"
     );
     assert_eq!(
         "Grub Development Archive on lore.kernel.org".to_string(),
-        available_lists[135].get_description(),
+        available_lists[135].description().to_string(),
         "Wrong list description for index 135"
     );
     assert_eq!(
         "linux-nilfs".to_string(),
-        available_lists[180].get_name(),
+        available_lists[180].name().to_string(),
         "Wrong list name for index 180"
     );
     assert_eq!(
         "Linux NILFS development".to_string(),
-        available_lists[180].get_description(),
+        available_lists[180].description().to_string(),
         "Wrong list description for index 180"
     );
     assert_eq!(
         "linux-sparse".to_string(),
-        available_lists[198].get_name(),
+        available_lists[198].name().to_string(),
         "Wrong list name for index 198"
     );
     assert_eq!(
         "Linux SPARSE checker discussions".to_string(),
-        available_lists[198].get_description(),
+        available_lists[198].description().to_string(),
         "Wrong list description for index 198"
     );
 }
@@ -325,32 +313,32 @@ fn should_fetch_all_available_lists() {
 
     assert_eq!(
         "accel-config".to_string(),
-        sorted_available_lists[0].get_name(),
+        sorted_available_lists[0].name().to_string(),
         "Wrong list name for index 0"
     );
     assert_eq!(
         "Accel-Config development".to_string(),
-        sorted_available_lists[0].get_description(),
+        sorted_available_lists[0].description().to_string(),
         "Wrong list description for index 0"
     );
     assert_eq!(
         "linux-mediatek".to_string(),
-        sorted_available_lists[159].get_name(),
+        sorted_available_lists[159].name().to_string(),
         "Wrong list name for index 159"
     );
     assert_eq!(
         "Linux-mediatek Archive on lore.kernel.org".to_string(),
-        sorted_available_lists[159].get_description(),
+        sorted_available_lists[159].description().to_string(),
         "Wrong list description for index 159"
     );
     assert_eq!(
         "yocto-toaster".to_string(),
-        sorted_available_lists[319].get_name(),
+        sorted_available_lists[319].name().to_string(),
         "Wrong list name for index 319"
     );
     assert_eq!(
         "Yocto Toaster".to_string(),
-        sorted_available_lists[319].get_description(),
+        sorted_available_lists[319].description().to_string(),
         "Wrong list description for index 319"
     );
 

--- a/src/mailing_list.rs
+++ b/src/mailing_list.rs
@@ -1,9 +1,10 @@
+use derive_getters::Getters;
 use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Getters, Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct MailingList {
     name: String,
     description: String,
@@ -15,14 +16,6 @@ impl MailingList {
             name: name.to_string(),
             description: description.to_string(),
         }
-    }
-
-    pub fn get_name(&self) -> &str {
-        &self.name
-    }
-
-    pub fn get_description(&self) -> &str {
-        &self.description
     }
 }
 

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1,22 +1,17 @@
+use derive_getters::Getters;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Getters, Serialize, Deserialize, Debug, Clone)]
 pub struct PatchFeed {
     #[serde(rename = "entry")]
     patches: Vec<Patch>,
 }
 
-impl PatchFeed {
-    pub fn get_patches(self) -> Vec<Patch> {
-        self.patches
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Getters, Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Patch {
     r#title: String,
     #[serde(default = "default_version")]
@@ -72,38 +67,6 @@ impl Patch {
             in_reply_to,
             updated,
         }
-    }
-
-    pub fn get_title(&self) -> &str {
-        &self.title
-    }
-
-    pub fn get_version(&self) -> usize {
-        self.version
-    }
-
-    pub fn get_number_in_series(&self) -> usize {
-        self.number_in_series
-    }
-
-    pub fn get_total_in_series(&self) -> usize {
-        self.total_in_series
-    }
-
-    pub fn get_author(&self) -> &Author {
-        &self.author
-    }
-
-    pub fn get_in_reply_to(&self) -> &Option<MessageID> {
-        &self.in_reply_to
-    }
-
-    pub fn get_updated(&self) -> &str {
-        &self.updated
-    }
-
-    pub fn get_message_id(&self) -> &MessageID {
-        &self.message_id
     }
 
     pub fn update_patch_metadata(&mut self, patch_regex: &PatchRegex) {

--- a/src/patch/tests.rs
+++ b/src/patch/tests.rs
@@ -102,10 +102,10 @@ fn test_update_patch_metadata() {
 
     assert_eq!(
         "[RESEND] hitchhiker/guide: Life, the Universe and Everything",
-        patch.get_title(),
+        patch.title(),
         "The title should have the patch tag `[v7 PATCH 3/42]` stripped"
     );
-    assert_eq!(7, patch.get_version(), "Wrong version!");
-    assert_eq!(3, patch.get_number_in_series(), "Wrong number in series!");
-    assert_eq!(42, patch.get_total_in_series(), "Wrong total in series!");
+    assert_eq!(7, *patch.version(), "Wrong version!");
+    assert_eq!(3, *patch.number_in_series(), "Wrong number in series!");
+    assert_eq!(42, *patch.total_in_series(), "Wrong total in series!");
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -63,11 +63,11 @@ fn render_mailing_list_selection(f: &mut Frame, app: &App, chunk: Rect) {
         list_items.push(ListItem::new(
             Line::from(vec![
                 Span::styled(
-                    mailing_list.get_name().to_string(),
+                    mailing_list.name().to_string(),
                     Style::default().fg(Color::Magenta),
                 ),
                 Span::styled(
-                    format!(" - {}", mailing_list.get_description()),
+                    format!(" - {}", mailing_list.description()),
                     Style::default().fg(Color::White),
                 ),
             ])
@@ -110,17 +110,17 @@ fn render_bookmarked_patchsets(
         .iter()
         .enumerate()
     {
-        let patch_title = format!("{:width$}", patch.get_title(), width = 70);
+        let patch_title = format!("{:width$}", patch.title(), width = 70);
         let patch_title = format!("{:.width$}", patch_title, width = 70);
-        let patch_author = format!("{:width$}", patch.get_author().name, width = 30);
+        let patch_author = format!("{:width$}", patch.author().name, width = 30);
         let patch_author = format!("{:.width$}", patch_author, width = 30);
         list_items.push(ListItem::new(
             Line::from(Span::styled(
                 format!(
                     "{:03}. V{:02} | #{:02} | {} | {}",
                     index,
-                    patch.get_version(),
-                    patch.get_total_in_series(),
+                    patch.version(),
+                    patch.total_in_series(),
                     patch_title,
                     patch_author
                 ),
@@ -153,16 +153,12 @@ fn render_bookmarked_patchsets(
 }
 
 fn render_list(f: &mut Frame, app: &App, chunk: Rect) {
-    let page_number = app
-        .latest_patchsets_state
-        .as_ref()
-        .unwrap()
-        .get_page_number();
+    let page_number = app.latest_patchsets_state.as_ref().unwrap().page_number();
     let patchset_index = app
         .latest_patchsets_state
         .as_ref()
         .unwrap()
-        .get_patchset_index();
+        .patchset_index();
     let mut list_items = Vec::<ListItem>::new();
 
     let patch_feed_page: Vec<&Patch> = app
@@ -174,17 +170,17 @@ fn render_list(f: &mut Frame, app: &App, chunk: Rect) {
 
     let mut index: usize = (page_number - 1) * app.config.page_size;
     for patch in patch_feed_page {
-        let patch_title = format!("{:width$}", patch.get_title(), width = 70);
+        let patch_title = format!("{:width$}", patch.title(), width = 70);
         let patch_title = format!("{:.width$}", patch_title, width = 70);
-        let patch_author = format!("{:width$}", patch.get_author().name, width = 30);
+        let patch_author = format!("{:width$}", patch.author().name, width = 30);
         let patch_author = format!("{:.width$}", patch_author, width = 30);
         list_items.push(ListItem::new(
             Line::from(Span::styled(
                 format!(
                     "{:03}. V{:02} | #{:02} | {} | {}",
                     index,
-                    patch.get_version(),
-                    patch.get_total_in_series(),
+                    patch.version(),
+                    patch.total_in_series(),
                     patch_title,
                     patch_author
                 ),
@@ -239,35 +235,35 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
         Line::from(vec![
             Span::styled(r#"  Title: "#, Style::default().fg(Color::Cyan)),
             Span::styled(
-                patchset_details.get_title().to_string(),
+                patchset_details.title().to_string(),
                 Style::default().fg(Color::White),
             ),
         ]),
         Line::from(vec![
             Span::styled("Author: ", Style::default().fg(Color::Cyan)),
             Span::styled(
-                patchset_details.get_author().name.to_string(),
+                patchset_details.author().name.to_string(),
                 Style::default().fg(Color::White),
             ),
         ]),
         Line::from(vec![
             Span::styled("Version: ", Style::default().fg(Color::Cyan)),
             Span::styled(
-                format!("{}", patchset_details.get_version()),
+                format!("{}", patchset_details.version()),
                 Style::default().fg(Color::White),
             ),
         ]),
         Line::from(vec![
             Span::styled("Patch count: ", Style::default().fg(Color::Cyan)),
             Span::styled(
-                format!("{}", patchset_details.get_total_in_series()),
+                format!("{}", patchset_details.total_in_series()),
                 Style::default().fg(Color::White),
             ),
         ]),
         Line::from(vec![
             Span::styled("Last updated: ", Style::default().fg(Color::Cyan)),
             Span::styled(
-                patchset_details.get_updated().to_string(),
+                patchset_details.updated().to_string(),
                 Style::default().fg(Color::White),
             ),
         ]),
@@ -349,7 +345,7 @@ fn render_patchset_details_and_actions(f: &mut Frame, app: &App, chunk: Rect) {
         .as_ref()
         .unwrap()
         .representative_patch
-        .get_message_id()
+        .message_id()
         .href;
     let mut preview_title = String::from(" Preview ");
     if let Some(successful_indexes) = app.reviewed_patchsets.get(representative_patch_message_id) {
@@ -396,7 +392,7 @@ fn render_navi_bar(f: &mut Frame, app: &App, chunk: Rect) {
             } else {
                 for mailing_list in &app.mailing_list_selection_state.mailing_lists {
                     if mailing_list
-                        .get_name()
+                        .name()
                         .eq(&app.mailing_list_selection_state.target_list)
                     {
                         text_area = Span::styled(
@@ -405,7 +401,7 @@ fn render_navi_bar(f: &mut Frame, app: &App, chunk: Rect) {
                         );
                         break;
                     } else if mailing_list
-                        .get_name()
+                        .name()
                         .starts_with(&app.mailing_list_selection_state.target_list)
                     {
                         text_area = Span::styled(
@@ -437,14 +433,8 @@ fn render_navi_bar(f: &mut Frame, app: &App, chunk: Rect) {
             vec![Span::styled(
                 format!(
                     "Latest Patchsets from {} (page {})",
-                    &app.latest_patchsets_state
-                        .as_ref()
-                        .unwrap()
-                        .get_target_list(),
-                    &app.latest_patchsets_state
-                        .as_ref()
-                        .unwrap()
-                        .get_page_number()
+                    &app.latest_patchsets_state.as_ref().unwrap().target_list(),
+                    &app.latest_patchsets_state.as_ref().unwrap().page_number()
                 ),
                 Style::default().fg(Color::Green),
             )]


### PR DESCRIPTION
When using the `derive_getter` lib it is not necessary to create one function for each attribute you want to expose with a get_ method. This commit adds the lib to `Cargo.toml `and replaces the existing get_ functions to a `#[derive(Getter)]`

Closes #33