### PR TITLE
feat/refactor: add automock lib and replace FakeLoreAPIClient with automocked BlockingLoreAPIClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +353,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures-channel"
@@ -674,6 +686,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +777,7 @@ dependencies = [
  "chrono",
  "clap",
  "color-eyre",
+ "mockall",
  "ratatui",
  "regex",
  "reqwest",
@@ -792,6 +831,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1267,6 +1332,12 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "patch-hub is a TUI that streamlines the interaction of Linux deve
 
 [dependencies]
 color-eyre = "0.6.3"
+mockall = "0.13.0"
 ratatui = "0.27.0"
 regex = "1.10.5"
 reqwest = { version = "0.12.5", default-features = false, features = ["blocking", "rustls-tls"] }

--- a/src/lore_api_client.rs
+++ b/src/lore_api_client.rs
@@ -1,3 +1,4 @@
+use mockall::automock;
 use reqwest::blocking::Response;
 use reqwest::Error;
 
@@ -28,6 +29,7 @@ impl BlockingLoreAPIClient {
     }
 }
 
+#[automock]
 pub trait PatchFeedRequest {
     fn request_patch_feed(
         &self,
@@ -70,6 +72,7 @@ pub enum FailedAvailableListsRequest {
     StatusNotOk(Response),
 }
 
+#[automock]
 pub trait AvailableListsRequest {
     fn request_available_lists(
         &self,

--- a/src/lore_session/tests.rs
+++ b/src/lore_session/tests.rs
@@ -2,20 +2,31 @@ use io::Read;
 
 use super::*;
 use crate::patch::Author;
+
+use mockall::mock;
 use std::fs;
 
-struct FakeLoreAPIClient {
-    src_path: String,
-}
-impl PatchFeedRequest for FakeLoreAPIClient {
-    fn request_patch_feed(
-        &self,
-        target_list: &str,
-        min_index: usize,
-    ) -> Result<String, FailedFeedRequest> {
-        let _ = min_index;
-        let _ = target_list;
-        Ok(fs::read_to_string(&self.src_path).unwrap())
+mock! {
+    BlockingLoreAPIClient {}
+    impl PatchFeedRequest for BlockingLoreAPIClient {
+        fn request_patch_feed(
+                    &self,
+                    target_list: &str,
+                    min_index: usize,
+                ) -> Result<String, FailedFeedRequest>;
+    }
+    impl AvailableListsRequest for BlockingLoreAPIClient {
+        fn request_available_lists(
+            &self,
+            min_index: usize,
+        ) -> Result<String, FailedAvailableListsRequest>;
+    }
+    impl PatchHTMLRequest for BlockingLoreAPIClient {
+        fn request_patch_html(
+            &self,
+            _target_list: &str,
+            message_id: &str,
+        ) -> Result<String, FailedPatchHTMLRequest>;
     }
 }
 
@@ -31,18 +42,28 @@ fn can_initialize_fresh_lore_session() {
 
 #[test]
 fn should_process_one_representative_patch() {
-    let mut lore_session: LoreSession = LoreSession::new("some-list".to_string());
-    let lore_api_client: FakeLoreAPIClient = FakeLoreAPIClient {
-        src_path:
-            "src/test_samples/lore_session/process_representative_patch/patch_feed_sample_1.xml"
-                .to_string(),
-    };
+    let src_path =
+        "src/test_samples/lore_session/process_representative_patch/patch_feed_sample_1.xml";
+    let target_list = "some-list";
+
+    let mut lore_api_client = MockBlockingLoreAPIClient::new();
+
+    lore_api_client
+        .expect_request_patch_feed()
+        .withf(move |target_list_arg, min_index_arg| {
+            target_list_arg == target_list && *min_index_arg == 0
+        })
+        .times(1)
+        .returning(move |_, _| Ok(fs::read_to_string(src_path).unwrap()));
+
+    let mut lore_session: LoreSession = LoreSession::new(target_list.to_string());
+
     let message_id: &str = "http://lore.kernel.org/some-subsystem/1234.567-1-john@johnson.com/";
 
-    if lore_session
-        .process_n_representative_patches(&lore_api_client, 1)
-        .is_ok()
-    {};
+    let process_n_representative_patches_result =
+        lore_session.process_n_representative_patches(&lore_api_client, 1);
+
+    assert!(process_n_representative_patches_result.is_ok());
 
     assert_eq!(
         1,
@@ -89,20 +110,30 @@ fn should_process_one_representative_patch() {
 
 #[test]
 fn should_process_multiple_representative_patches() {
-    let mut lore_session: LoreSession = LoreSession::new("some-list".to_string());
-    let lore_api_client: FakeLoreAPIClient = FakeLoreAPIClient {
-        src_path:
-            "src/test_samples/lore_session/process_representative_patch/patch_feed_sample_2.xml"
-                .to_string(),
-    };
+    let src_path =
+        "src/test_samples/lore_session/process_representative_patch/patch_feed_sample_2.xml";
+    let target_list = "some-list";
+
+    let mut lore_api_client = MockBlockingLoreAPIClient::new();
+
+    lore_api_client
+        .expect_request_patch_feed()
+        .withf(move |target_list_arg, min_index_arg| {
+            target_list_arg == target_list && *min_index_arg == 0
+        })
+        .times(1)
+        .returning(move |_, _| Ok(fs::read_to_string(src_path).unwrap()));
+
+    let mut lore_session: LoreSession = LoreSession::new(target_list.to_string());
+
     let message_id_1: &str = "http://lore.kernel.org/some-subsystem/1234.567-1-roberto@silva.br/";
     let message_id_2: &str = "http://lore.kernel.org/some-subsystem/first-patch-lima@luma.rs/";
     let message_id_3: &str = "http://lore.kernel.org/some-subsystem/1234.567-1-john@johnson.com/";
 
-    if lore_session
-        .process_n_representative_patches(&lore_api_client, 3)
-        .is_ok()
-    {};
+    let process_n_representative_patches_result =
+        lore_session.process_n_representative_patches(&lore_api_client, 3);
+
+    assert!(process_n_representative_patches_result.is_ok());
 
     assert_eq!(
         3,
@@ -302,25 +333,37 @@ fn should_process_available_lists() {
     );
 }
 
-impl AvailableListsRequest for FakeLoreAPIClient {
-    fn request_available_lists(
-        &self,
-        min_index: usize,
-    ) -> Result<String, FailedAvailableListsRequest> {
-        match min_index {
-            0 => Ok(fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-1.html").unwrap()),
-            200 => Ok(fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-2.html").unwrap()),
-            400 => Ok(fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-3.html").unwrap()),
-            _ => panic!("Should not try other `min_index` other than `0`, `200`, and `400`"),
-        }
-    }
-}
-
 #[test]
 fn should_fetch_all_available_lists() {
-    let lore_api_client = FakeLoreAPIClient {
-        src_path: "".to_string(),
-    };
+    let mut lore_api_client = MockBlockingLoreAPIClient::new();
+
+    lore_api_client.expect_request_available_lists()
+    .withf(|min_index_args| {
+        *min_index_args == 0
+    })
+    .times(1)
+    .returning(|_| {
+        Ok(fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-1.html").unwrap())
+    });
+
+    lore_api_client.expect_request_available_lists()
+    .withf(|min_index_args| {
+        *min_index_args == 200
+    })
+    .times(1)
+    .returning(|_| {
+        Ok(fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-2.html").unwrap())
+    });
+
+    lore_api_client.expect_request_available_lists()
+    .withf(|min_index_args| {
+        *min_index_args == 400
+    })
+    .times(1)
+    .returning(|_| {
+        Ok(fs::read_to_string("src/test_samples/lore_session/process_available_lists/available_lists_response-3.html").unwrap())
+    });
+
     let sorted_available_lists = fetch_available_lists(&lore_api_client).unwrap();
 
     assert_eq!(
@@ -421,25 +464,6 @@ fn files_eq(path1: &str, path2: &str) -> io::Result<bool> {
     Ok(buf1 == buf2)
 }
 
-impl PatchHTMLRequest for FakeLoreAPIClient {
-    fn request_patch_html(
-        &self,
-        _target_list: &str,
-        message_id: &str,
-    ) -> Result<String, FailedPatchHTMLRequest> {
-        let patch_html = "git-send-email(1): ".to_owned();
-        let patch_html = match message_id {
-            "1234.567-0-foo@bar.foo.bar" => patch_html + "git send-email --in-reply-to=1234.567-0-foo@bar.foo.bar --to=foo@bar.foo.bar /path/to/YOUR_REPLY",
-            "1234.567-1-foo@bar.foo.bar" => patch_html + "git send-email --in-reply-to=1234.567-1-foo@bar.foo.bar --to=foo@bar.foo.bar /path/to/YOUR_REPLY",
-            "1234.567-2-foo@bar.foo.bar" => patch_html + "git send-email --in-reply-to=1234.567-2-foo@bar.foo.bar --to=foo@bar.foo.bar /path/to/YOUR_REPLY",
-            "1234.567-3-foo@bar.foo.bar" => patch_html + "git send-email --in-reply-to=1234.567-3-foo@bar.foo.bar --to=foo@bar.foo.bar /path/to/YOUR_REPLY",
-            _ => panic!("Should not try other message-IDs than `1234.567-{{0,1,2,3}}`"),
-        };
-
-        Ok(patch_html.to_owned())
-    }
-}
-
 #[test]
 fn should_prepare_reply_patchset_with_reviewed_by() {
     let tmp_dir = Command::new("mktemp").arg("--directory").output().unwrap();
@@ -497,9 +521,17 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
         expected_git_reply_command_3,
     ];
 
-    let lore_api_client = FakeLoreAPIClient {
-        src_path: "".to_owned(),
-    };
+    let target_list = "all";
+    let mut lore_api_client = MockBlockingLoreAPIClient::new();
+
+    lore_api_client.expect_request_patch_html()
+    .withf(move |target_list_arg, _| {
+        target_list_arg == target_list
+    })
+    .times(4)
+    .returning(|_, message_id| {
+        Ok(format!("git-send-email(1): git send-email --in-reply-to={} --to=foo@bar.foo.bar /path/to/YOUR_REPLY", message_id))
+    });
 
     let patches = vec![
         fs::read_to_string(
@@ -517,7 +549,7 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
     let git_reply_commands = prepare_reply_patchset_with_reviewed_by(
         &lore_api_client,
         tmp_dir,
-        "all",
+        target_list,
         &patches,
         "Bar Foo <bar@foo.bar.foo>",
     )


### PR DESCRIPTION
This PR does two things
1. adds the "automock" library to Cargo.toml, which is used to automatically mock traits and structs, avoiding the need for manual implementation of each trait function just for testing.
2. replaces the FakeLoreAPIClient used in `src/lore_session/tests.rs ` with an "automock" for `BlockingLoreAPIClient`. This way, each test can have an explicit expectation for each of the called functions, facilitating test implementation and improving test quality overall.

Closes: #34