### PR TITLE
refactor: extract LatestPatchsets condition handling from key events

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -153,6 +153,10 @@ impl LatestPatchsetsState {
         self.lore_session
             .get_patch_feed_page(self.page_size, self.page_number)
     }
+
+    pub fn get_number_of_processed_patchsets(&self) -> usize {
+        self.lore_session.get_representative_patches_ids().len()
+    }
 }
 
 pub struct PatchsetDetailsAndActionsState {


### PR DESCRIPTION
To keep handling key events separated from handling conditions independent from events, extracting the LatestPatchset screen change  it to this match when the number of processed patchsets is empty.

Closes #29