### PR TITLE
Save default config

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -86,11 +86,11 @@ impl Config {
     }
 
     pub fn build() -> Self {
-        let mut config = Self::default();
-
-        if let Some(config_from_file) = Self::detect_patch_hub_config_file() {
-            config = config_from_file;
-        }
+        let mut config = Self::detect_patch_hub_config_file().unwrap_or_else(|| {
+            let config = Self::default();
+            let _ = config.save_patch_hub_config();
+            config
+        });
 
         config.override_with_env_vars();
 


### PR DESCRIPTION
This PR introduces a basic feature. If no config file is found we create one with the default config.