### PR TITLE
refactor: change names and use Getters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "derive-getters"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6433aac097572ea8ccc60b3f2e756c661c9aeed9225cdd4d0cb119cb7ff6ba"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "patch-hub is a TUI that streamlines the interaction of Linux deve
 
 [dependencies]
 color-eyre = "0.6.3"
-derive-getters = "0.4.0"
+derive-getters = { version = "0.5.0", features = ["auto_copy_getters"] }
 ratatui = "0.27.0"
 regex = "1.10.5"
 reqwest = { version = "0.12.5", default-features = false, features = ["blocking", "rustls-tls"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -544,16 +544,16 @@ impl App {
     pub fn consolidate_edit_config(&mut self) {
         // TODO: Handle invalid values!
         if let Some(edit_config) = &mut self.edit_config_state {
-            if let Ok(page_size) = edit_config.extract_page_size() {
+            if let Ok(page_size) = edit_config.page_size() {
                 self.config.set_page_size(page_size)
             }
-            if let Ok(cache_dir) = edit_config.extract_cache_dir() {
+            if let Ok(cache_dir) = edit_config.cache_dir() {
                 self.config.set_cache_dir(cache_dir)
             }
-            if let Ok(data_dir) = edit_config.extract_data_dir() {
+            if let Ok(data_dir) = edit_config.data_dir() {
                 self.config.set_data_dir(data_dir)
             }
-            if let Ok(git_send_email_option) = edit_config.extract_git_send_email_option() {
+            if let Ok(git_send_email_option) = edit_config.git_send_email_option() {
                 self.config.set_git_send_email_option(git_send_email_option)
             }
         }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -45,7 +45,10 @@ impl Config {
         }
     }
 
-    fn detect_patch_hub_config_file() -> Option<Config> {
+    /// Loads the configuration for patch-hub from the config file.
+    ///
+    /// Returns `None` if the config file is not found or if it's not a valid JSON.
+    fn load() -> Option<Config> {
         if let Ok(config_path) = env::var("PATCH_HUB_CONFIG_PATH") {
             if Path::new(&config_path).is_file() {
                 let file_contents = fs::read_to_string(&config_path).unwrap_or(String::new());
@@ -90,7 +93,7 @@ impl Config {
     pub fn build() -> Self {
         let mut config = Self::default();
 
-        if let Some(config_from_file) = Self::detect_patch_hub_config_file() {
+        if let Some(config_from_file) = Self::load() {
             config = config_from_file;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,18 +254,18 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> color_eyre:
                             match edit_config_state.is_editing() {
                                 true => match key.code {
                                     KeyCode::Esc => {
-                                        edit_config_state.clear_editing_val();
+                                        edit_config_state.clear_edit();
                                         edit_config_state.toggle_editing();
                                     }
                                     KeyCode::Backspace => {
-                                        edit_config_state.remove_char_from_editing_val();
+                                        edit_config_state.backspace_edit();
                                     }
                                     KeyCode::Char(ch) => {
-                                        edit_config_state.add_char_to_editing_val(ch);
+                                        edit_config_state.append_edit(ch);
                                     }
                                     KeyCode::Enter => {
-                                        edit_config_state.push_editing_val_to_buffer();
-                                        edit_config_state.clear_editing_val();
+                                        edit_config_state.save_edit();
+                                        edit_config_state.clear_edit();
                                         edit_config_state.toggle_editing();
                                     }
                                     _ => {}
@@ -279,10 +279,10 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> color_eyre:
                                         edit_config_state.toggle_editing();
                                     }
                                     KeyCode::Char('j') | KeyCode::Down => {
-                                        edit_config_state.highlight_below_entry();
+                                        edit_config_state.highlight_next();
                                     }
                                     KeyCode::Char('k') | KeyCode::Up => {
-                                        edit_config_state.highlight_above_entry();
+                                        edit_config_state.highlight_prev();
                                     }
                                     KeyCode::Enter => {
                                         app.consolidate_edit_config();

--- a/src/ui/render_edit_config.rs
+++ b/src/ui/render_edit_config.rs
@@ -21,20 +21,17 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
         .constraints(constraints)
         .split(chunk);
 
-    let highlighted_entry = edit_config_state.get_highlighted_entry();
-    for i in 0..edit_config_state.get_number_of_configs() {
+    let highlighted_entry = edit_config_state.highlighted();
+    for i in 0..edit_config_state.config_count() {
         if i + 1 > config_chunks.len() {
             break;
         }
 
-        let (config, value) = edit_config_state.get_config_by_index(i);
+        let (config, value) = edit_config_state.config(i);
         let value = Line::from(
             if edit_config_state.is_editing() && i == highlighted_entry {
                 vec![
-                    Span::styled(
-                        edit_config_state.get_editing_val().to_string(),
-                        Style::default(),
-                    ),
+                    Span::styled(edit_config_state.edit().to_string(), Style::default()),
                     Span::styled(" ", Style::default().bg(Color::White)),
                 ]
             } else {


### PR DESCRIPTION
In this PR I did a lot of naming refactoring to use less verbose names and documented the functions. Also used the `derive_getters` crate with the helpful `auto_copy_getters` feature that will create copy getters for any value that is Copy, rather than a reference getter.