### PR TITLE
feat: add log garbage collector

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -12,9 +12,9 @@ use patch_hub::{
 use std::{collections::HashMap, path::Path, process::Command};
 
 mod config;
-pub mod logging;
-
 mod edit_config;
+mod loggc;
+pub mod logging;
 
 pub struct BookmarkedPatchsetsState {
     pub bookmarked_patchsets: Vec<Patch>,
@@ -373,6 +373,7 @@ impl App {
         // Initialize the logger before the app starts
         Logger::init_log_file(&config);
         Logger::info("patch-hub started");
+        loggc::collect_garbage(&config);
 
         App {
             current_screen: CurrentScreen::MailingListSelection,

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -25,6 +25,8 @@ pub struct Config {
     cache_dir: String,
     /// Base directory for all patch-hub cache
     data_dir: String,
+    /// Maximum age of a log file in days
+    max_log_age: u64,
 }
 
 impl Config {
@@ -42,6 +44,7 @@ impl Config {
             git_send_email_options: "--dry-run --suppress-cc=all".to_string(),
             cache_dir,
             data_dir,
+            max_log_age: 0,
         }
     }
 

--- a/src/app/loggc.rs
+++ b/src/app/loggc.rs
@@ -1,0 +1,43 @@
+//! Log Garbage Collector
+//!
+//! This module is responsible for cleaning up the log files.
+use super::{config::Config, logging::Logger};
+
+/// Collects the garbage from the logs directory.
+/// Will check for log files `patch-hub_*.log` and remove them if they are older than the `max_log_age` in the config.
+pub fn collect_garbage(config: &Config) {
+    let now = std::time::SystemTime::now();
+    let logs_path = config.logs_path();
+    let Ok(logs) = std::fs::read_dir(logs_path) else {
+        Logger::error("Failed to read the logs directory during garbage collection");
+        return;
+    };
+
+    for log in logs {
+        let Ok(log) = log else {
+            continue;
+        };
+        let filename = log.file_name();
+
+        if !filename.to_string_lossy().ends_with(".log")
+            || !filename.to_string_lossy().starts_with("patch-hub_")
+        {
+            continue;
+        }
+
+        let Ok(Ok(created_date)) = log.metadata().map(|meta| meta.created()) else {
+            continue;
+        };
+        let Ok(age) = now.duration_since(created_date) else {
+            continue;
+        };
+        let age = age.as_secs() / 60 / 60 / 24;
+
+        if age > *config.max_log_age() && std::fs::remove_file(log.path()).is_err() {
+            Logger::warn(&format!(
+                "Failed to remove the log file: {}",
+                log.path().to_string_lossy()
+            ));
+        }
+    }
+}

--- a/src/app/loggc.rs
+++ b/src/app/loggc.rs
@@ -6,6 +6,10 @@ use super::{config::Config, logging::Logger};
 /// Collects the garbage from the logs directory.
 /// Will check for log files `patch-hub_*.log` and remove them if they are older than the `max_log_age` in the config.
 pub fn collect_garbage(config: &Config) {
+    if config.max_log_age() == &0 {
+        return;
+    }
+
     let now = std::time::SystemTime::now();
     let logs_path = config.logs_path();
     let Ok(logs) = std::fs::read_dir(logs_path) else {

--- a/src/test_samples/app/config/config.json
+++ b/src/test_samples/app/config/config.json
@@ -1,5 +1,6 @@
 {
     "page_size": 1234,
+    "max_log_age": 30,
     "patchsets_cache_dir": "/cachedir/path",
     "bookmarked_patchsets_path": "/bookmarked/patchsets/path",
     "mailing_lists_path": "/mailing/lists/path",


### PR DESCRIPTION
The log garbage collector runs once after building the config. It checks for every file in the logs folder that is named like `patch_hub_*.log` and delete the ones older than `max_log_age` (config option).

This implements what @davidbtadokoro and I discussed offline. Also @lorenzoberts mentioned this idea in #47 