### PR TITLE
feat: add specific log file to gather current patch-hub execution logs 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ fn main() -> color_eyre::Result<()> {
     run_app(&mut terminal, &mut app)?;
     utils::restore()?;
 
+    Logger::info("patch-hub finished");
     Logger::flush();
 
     Ok(())


### PR DESCRIPTION
This PR makes it easier to debug patch-hub since the developer can always get the current logs by looking at the same file, allowing them to follow the logs as they are generated.

In the future, we could create a specific cargo command to watch the` latest.log` file, but for now, we need to run a command like: `watch -n 0.5 -d cat ~/.local/share/patch_hub/logs/latest.log`.

Thanks to @OJarrisonn for the file name suggestion.

Closes #58 