### PR TITLE
feat: add throbber for loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ dependencies = [
  "serde-xml-rs",
  "serde_json",
  "thiserror",
+ "throbber-widgets-tui",
 ]
 
 [[package]]
@@ -1455,6 +1456,16 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "throbber-widgets-tui"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad9e055cadd9da8b4a67662b962e3e67e96af491ae9cec7e88aaff92e7c3666"
+dependencies = [
+ "rand",
+ "ratatui",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "patch-hub"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ansi-to-tui",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "patch-hub"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 repository = "https://github.com/kworkflow/patch-hub"
 description = "patch-hub is a TUI that streamlines the interaction of Linux developers with patches archived on lore.kernel.org"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "1.0.37"
 clap = { version = "4.5.13", features = ["derive"] }
 chrono = "0.4.38"
 ansi-to-tui = "6.0.0"
+throbber-widgets-tui = "0.7.0"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use screens::{
     mail_list::MailingListSelectionState,
     CurrentScreen,
 };
+use throbber_widgets_tui::ThrobberState;
 use std::collections::HashMap;
 
 mod config;
@@ -27,6 +28,8 @@ pub struct App {
     pub reviewed_patchsets: HashMap<String, Vec<usize>>,
     pub config: Config,
     pub lore_api_client: BlockingLoreAPIClient,
+    pub throbber_state: ThrobberState, 
+    pub loading: bool, 
 }
 
 impl App {
@@ -72,8 +75,16 @@ impl App {
             reviewed_patchsets,
             config,
             lore_api_client,
+            throbber_state: ThrobberState::default(), 
+            loading: false, 
         }
     }
+
+    // pub fn on_tick(&mut self) {
+    //     if self.loading {
+    //         self.throbber_state.calc_next(); 
+    //     }
+    // }
 
     pub fn init_latest_patchsets_state(&mut self) {
         // the target mailing list for "latest patchsets" is the highlighted

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,10 +4,12 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
     widgets::{
-        Block, Borders, HighlightSpacing, List, ListItem, ListState, Padding, Paragraph, Wrap,
+        Block, Borders, HighlightSpacing, List, ListItem, ListState, Padding, Paragraph, Wrap
     },
     Frame,
 };
+use throbber_widgets_tui::Throbber;
+
 use render_patchset::render_patch_preview;
 
 use crate::app::{self, logging::Logger, App};
@@ -16,7 +18,7 @@ use app::screens::{bookmarked::BookmarkedPatchsetsState, details::PatchsetAction
 mod render_edit_config;
 mod render_patchset;
 
-pub fn draw_ui(f: &mut Frame, app: &App) {
+pub fn draw_ui(f: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -27,6 +29,15 @@ pub fn draw_ui(f: &mut Frame, app: &App) {
         .split(f.area());
 
     render_title(f, chunks[0]);
+
+    if app.loading {
+        let throbber = Throbber::default()
+            .label("Loading...")  // Set label directly
+            .throbber_style(Style::default().fg(Color::Yellow));
+
+        let area = centered_rect(30, 10, f.area());
+        f.render_stateful_widget(throbber, area, &mut app.throbber_state);
+    }
 
     match app.current_screen {
         CurrentScreen::MailingListSelection => render_mailing_list_selection(f, app, chunks[1]),


### PR DESCRIPTION
Imported throbber from throbber widget( docs.rs/throbber-widgets-tui/latest/throbber_widgets_tui/ ).
Added throbber_state and loading in app strcut, to control when the throbber should be showed and how.
Added function On_tick() to process the next iteration of the throbber animation.

Signed-off-by: Gabriel Alves<alvesgabriel@usp.br>

