### PR TITLE
feat: logging: add log_on_error macro

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,7 @@
+use crate::log_on_error;
 use color_eyre::eyre::bail;
 use config::Config;
-use logging::Logger;
+use logging::logger::Logger;
 use patch_hub::{lore_api_client::BlockingLoreAPIClient, lore_session, patch::Patch};
 use screens::{
     bookmarked::BookmarkedPatchsetsState,
@@ -11,8 +12,6 @@ use screens::{
     CurrentScreen,
 };
 use std::collections::HashMap;
-
-use crate::log_on_error;
 
 mod config;
 pub mod logging;
@@ -52,7 +51,7 @@ impl App {
         // Initialize the logger before the app starts
         Logger::init_log_file(&config);
         Logger::info("patch-hub started");
-        logging::log_gc::collect_garbage(&config);
+        logging::garbage_collector::collect_garbage(&config);
 
         App {
             current_screen: CurrentScreen::MailingListSelection,

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,6 +12,8 @@ use screens::{
 };
 use std::collections::HashMap;
 
+use crate::log_on_error;
+
 mod config;
 pub mod logging;
 pub mod patch_renderer;
@@ -121,15 +123,15 @@ impl App {
             screen => bail!(format!("Invalid screen passed as argument {screen:?}")),
         };
 
-        let patchset_path: String = match lore_session::download_patchset(
+        let patchset_path: String = match log_on_error!(lore_session::download_patchset(
             self.config.patchsets_cache_dir(),
             &representative_patch,
-        ) {
+        )) {
             Ok(result) => result,
             Err(io_error) => bail!("{io_error}"),
         };
 
-        match lore_session::split_patchset(&patchset_path) {
+        match log_on_error!(lore_session::split_patchset(&patchset_path)) {
             Ok(patches) => {
                 self.patchset_details_and_actions_state = Some(PatchsetDetailsAndActionsState {
                     representative_patch,

--- a/src/app/logging.rs
+++ b/src/app/logging.rs
@@ -357,3 +357,31 @@ pub mod log_gc {
         }
     }
 }
+
+#[macro_export]
+macro_rules! log_on_error {
+    ($result:expr) => {
+        log_on_error!($crate::app::logging::LogLevel::Error, $result)
+    };
+    ($level:expr, $result:expr) => {
+        match $result {
+            Ok(_) => $result,
+            Err(ref error) => {
+                let error_message =
+                    format!("Error executing {:?}: {}", stringify!($result), &error);
+                match $level {
+                    $crate::app::logging::LogLevel::Info => {
+                        Logger::info(error_message);
+                    }
+                    $crate::app::logging::LogLevel::Warning => {
+                        Logger::warn(error_message);
+                    }
+                    $crate::app::logging::LogLevel::Error => {
+                        Logger::error(error_message);
+                    }
+                }
+                $result
+            }
+        }
+    };
+}

--- a/src/app/logging/garbage_collector.rs
+++ b/src/app/logging/garbage_collector.rs
@@ -1,0 +1,50 @@
+//! Log Garbage Collector
+//!
+//! This module is responsible for cleaning up the log files.
+
+use crate::app::config::Config;
+
+use super::logger::Logger;
+
+/// Collects the garbage from the logs directory.
+/// Will check for log files `patch-hub_*.log` and remove them if they are older than the `max_log_age` in the config.
+pub fn collect_garbage(config: &Config) {
+    if config.max_log_age() == 0 {
+        return;
+    }
+
+    let now = std::time::SystemTime::now();
+    let logs_path = config.logs_path();
+    let Ok(logs) = std::fs::read_dir(logs_path) else {
+        Logger::error("Failed to read the logs directory during garbage collection");
+        return;
+    };
+
+    for log in logs {
+        let Ok(log) = log else {
+            continue;
+        };
+        let filename = log.file_name();
+
+        if !filename.to_string_lossy().ends_with(".log")
+            || !filename.to_string_lossy().starts_with("patch-hub_")
+        {
+            continue;
+        }
+
+        let Ok(Ok(created_date)) = log.metadata().map(|meta| meta.created()) else {
+            continue;
+        };
+        let Ok(age) = now.duration_since(created_date) else {
+            continue;
+        };
+        let age = age.as_secs() / 60 / 60 / 24;
+
+        if age as usize > config.max_log_age() && std::fs::remove_file(log.path()).is_err() {
+            Logger::warn(format!(
+                "Failed to remove the log file: {}",
+                log.path().to_string_lossy()
+            ));
+        }
+    }
+}

--- a/src/app/logging/log_on_error.rs
+++ b/src/app/logging/log_on_error.rs
@@ -1,0 +1,27 @@
+#[macro_export]
+macro_rules! log_on_error {
+    ($result:expr) => {
+        log_on_error!($crate::app::logging::logger::LogLevel::Error, $result)
+    };
+    ($level:expr, $result:expr) => {
+        match $result {
+            Ok(_) => $result,
+            Err(ref error) => {
+                let error_message =
+                    format!("Error executing {:?}: {}", stringify!($result), &error);
+                match $level {
+                    $crate::app::logging::logger::LogLevel::Info => {
+                        Logger::info(error_message);
+                    }
+                    $crate::app::logging::logger::LogLevel::Warning => {
+                        Logger::warn(error_message);
+                    }
+                    $crate::app::logging::logger::LogLevel::Error => {
+                        Logger::error(error_message);
+                    }
+                }
+                $result
+            }
+        }
+    };
+}

--- a/src/app/logging/logger.rs
+++ b/src/app/logging/logger.rs
@@ -4,8 +4,9 @@ use std::{
     io::Write,
 };
 
-use super::config::Config;
 use chrono::Local;
+
+use crate::app::config::Config;
 
 const LATEST_LOG_FILENAME: &str = "latest.log";
 
@@ -303,85 +304,4 @@ impl Display for LogLevel {
             LogLevel::Error => write!(f, "ERROR"),
         }
     }
-}
-
-pub mod log_gc {
-    //! Log Garbage Collector
-    //!
-    //! This module is responsible for cleaning up the log files.
-
-    use crate::app::config::Config;
-
-    use super::Logger;
-
-    /// Collects the garbage from the logs directory.
-    /// Will check for log files `patch-hub_*.log` and remove them if they are older than the `max_log_age` in the config.
-    pub fn collect_garbage(config: &Config) {
-        if config.max_log_age() == 0 {
-            return;
-        }
-
-        let now = std::time::SystemTime::now();
-        let logs_path = config.logs_path();
-        let Ok(logs) = std::fs::read_dir(logs_path) else {
-            Logger::error("Failed to read the logs directory during garbage collection");
-            return;
-        };
-
-        for log in logs {
-            let Ok(log) = log else {
-                continue;
-            };
-            let filename = log.file_name();
-
-            if !filename.to_string_lossy().ends_with(".log")
-                || !filename.to_string_lossy().starts_with("patch-hub_")
-            {
-                continue;
-            }
-
-            let Ok(Ok(created_date)) = log.metadata().map(|meta| meta.created()) else {
-                continue;
-            };
-            let Ok(age) = now.duration_since(created_date) else {
-                continue;
-            };
-            let age = age.as_secs() / 60 / 60 / 24;
-
-            if age as usize > config.max_log_age() && std::fs::remove_file(log.path()).is_err() {
-                Logger::warn(format!(
-                    "Failed to remove the log file: {}",
-                    log.path().to_string_lossy()
-                ));
-            }
-        }
-    }
-}
-
-#[macro_export]
-macro_rules! log_on_error {
-    ($result:expr) => {
-        log_on_error!($crate::app::logging::LogLevel::Error, $result)
-    };
-    ($level:expr, $result:expr) => {
-        match $result {
-            Ok(_) => $result,
-            Err(ref error) => {
-                let error_message =
-                    format!("Error executing {:?}: {}", stringify!($result), &error);
-                match $level {
-                    $crate::app::logging::LogLevel::Info => {
-                        Logger::info(error_message);
-                    }
-                    $crate::app::logging::LogLevel::Warning => {
-                        Logger::warn(error_message);
-                    }
-                    $crate::app::logging::LogLevel::Error => {
-                        Logger::error(error_message);
-                    }
-                }
-                $result
-            }
-        }
-    };
 }

--- a/src/app/logging/mod.rs
+++ b/src/app/logging/mod.rs
@@ -1,0 +1,3 @@
+pub mod garbage_collector;
+pub mod log_on_error;
+pub mod logger;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use app::logging::Logger;
+use app::logging::logger::Logger;
 use clap::Parser;
 use cli::Cli;
 use handler::run_app;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,7 +10,7 @@ use ratatui::{
 };
 use render_patchset::render_patch_preview;
 
-use crate::app::{self, logging::Logger, App};
+use crate::app::{self, logging::logger::Logger, App};
 use app::screens::{bookmarked::BookmarkedPatchsetsState, details::PatchsetAction, CurrentScreen};
 
 mod render_edit_config;

--- a/src/ui/render_patchset.rs
+++ b/src/ui/render_patchset.rs
@@ -6,7 +6,7 @@ use std::{
 use ansi_to_tui::IntoText;
 use ratatui::text::Text;
 
-use crate::app::{logging::Logger, patch_renderer::PatchRenderer};
+use crate::app::{logging::logger::Logger, patch_renderer::PatchRenderer};
 
 pub fn render_patch_preview(
     raw: &str,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,7 +13,7 @@ use ratatui::{
     Terminal,
 };
 
-use crate::app::logging::Logger;
+use crate::app::logging::logger::Logger;
 
 /// A type alias for the terminal type used in this application
 pub type Tui = Terminal<CrosstermBackend<Stdout>>;


### PR DESCRIPTION
This PR creates a macro to log if a result is an error, as discussed in #47 . To exemplify its use case, I applied it to two functions:  `download_patchset()` returns error if `b4` is not installed and `split_patchset()` returns error if there's a problem with the patch set path. Obviously this macro can be applied to multiple existing calls, but the focus of this PR is only adding the macro, so I restricted its usage to these two examples.
Below are three examples of how the logs appear in the log file. Note that in the last one I changed the LogLevel to Warning just for creating the example.
![Captura de tela de 2024-10-13 16-16-57](https://github.com/user-attachments/assets/9e8d1a92-b3e9-40cd-b024-43e7fd11a5f3)
![Captura de tela de 2024-10-13 16-13-52](https://github.com/user-attachments/assets/b5910d26-cb6a-43f9-908a-8dec9c759db9)
![Captura de tela de 2024-10-13 16-41-36](https://github.com/user-attachments/assets/d08c5f98-b3d8-4b1a-8e69-07c97f6fe58b)

Besides creating the macro, this PR also reorganizes logging-related elements into separate files (and a dedicated directory) because I felt the logging.rs was getting too large and with things which, in my opinion, would fit better in different files. If you don't think this is necessary, we can simply drop the second commit.