### PR TITLE
feat: add `--show-configs` option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,38 @@
+use std::ops::ControlFlow;
+
 use clap::Parser;
+use color_eyre::eyre::eyre;
+use ratatui::{prelude::Backend, Terminal};
+
+use crate::{app::{logging::Logger, App}, utils};
 
 #[derive(Debug, Parser)]
 #[command(version, about)]
-pub struct Cli;
+pub struct Cli {
+    #[clap(long, action)]
+    /// Prints the current configurations to the terminal with the applied overrides
+    pub show_configs: bool,
+}
+
+impl Cli {
+    /// Resolves the command line arguments and applies the necessary changes to the terminal and app
+    /// 
+    /// Some arguments may finish the program early (returning `ControlFlow::Break`)
+    pub fn resolve<B: Backend>(&self, terminal: Terminal<B>, app: &mut App) -> ControlFlow<color_eyre::Result<()>, Terminal<B>> {
+        if self.show_configs {
+            Logger::info("Printing current configurations");
+            drop(terminal);
+            if let Err(err) = utils::restore() {
+                return ControlFlow::Break(Err(eyre!(err)));
+            }
+            match serde_json::to_string_pretty(&app.config) {
+                Err(err) => return ControlFlow::Break(Err(eyre!(err))),
+                Ok(config) => println!("{}", config),
+            }
+                        
+            return ControlFlow::Break(Ok(()));
+        }
+
+        ControlFlow::Continue(terminal)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::ops::ControlFlow;
+
 use crate::app::App;
 use app::logging::Logger;
 use clap::Parser;
@@ -11,12 +13,17 @@ mod ui;
 mod utils;
 
 fn main() -> color_eyre::Result<()> {
-    // We use an unused var because we only parse for `-h|--help` and `-V|--version`
-    let _args = Cli::parse();
+    let args = Cli::parse();
 
     utils::install_hooks()?;
     let mut terminal = utils::init()?;
     let mut app = App::new();
+
+    match args.resolve(terminal, &mut app) {
+        ControlFlow::Break(b) => return b,
+        ControlFlow::Continue(t) => terminal = t,
+    }
+
     run_app(&mut terminal, &mut app)?;
     utils::restore()?;
 


### PR DESCRIPTION
This introduces a new `--show-configs` option to patch-hub.

This flag will simply print the config options patch-hub would use to the terminal as a json string and exit the application.

Closes: #60 