### PR TITLE
Add reply w/ `Reviewed-by` tag of subset of patches from a series

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -192,12 +192,14 @@ impl App {
                     patches_preview
                         .push(format!("{}---\n{}", rendered_cover, rendered_patch).into_text()?);
                 }
+                let has_cover_letter = representative_patch.number_in_series() == 0;
                 let patches_to_reply = vec![false; raw_patches.len()];
                 self.details_actions = Some(DetailsActions {
                     representative_patch,
                     raw_patches,
                     patches_preview,
                     patches_to_reply,
+                    has_cover_letter,
                     preview_index: 0,
                     preview_scroll_offset: 0,
                     preview_pan: 0,

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -106,8 +106,16 @@ impl DetailsActions {
         self.toggle_action(PatchsetAction::Bookmark);
     }
 
-    pub fn toggle_reply_with_reviewed_by_action(&mut self) {
-        if let Some(entry) = self.patches_to_reply.get_mut(self.preview_index) {
+    pub fn toggle_reply_with_reviewed_by_action(&mut self, all: bool) {
+        if all {
+            if self.patches_to_reply.contains(&false) {
+                // If there is at least one patch not to be replied, set all to be
+                self.patches_to_reply = vec![true; self.patches_to_reply.len()];
+            } else {
+                // If all patches are set to be replied, set none to be
+                self.patches_to_reply = vec![false; self.patches_to_reply.len()];
+            }
+        } else if let Some(entry) = self.patches_to_reply.get_mut(self.preview_index) {
             *entry = !*entry;
         }
 

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -14,6 +14,8 @@ pub struct DetailsActions {
     pub raw_patches: Vec<String>,
     /// Patches in the format to be displayed as preview
     pub patches_preview: Vec<Text<'static>>,
+    /// Indicates if patchset has a cover letter
+    pub has_cover_letter: bool,
     /// Which patches to reply
     pub patches_to_reply: Vec<bool>,
     pub preview_index: usize,

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -1,6 +1,7 @@
 use super::CurrentScreen;
 use ::patch_hub::lore::{lore_api_client::BlockingLoreAPIClient, lore_session, patch::Patch};
 use color_eyre::eyre::bail;
+use patch_hub::lore::patch::Author;
 use ratatui::text::Text;
 use std::{
     collections::{HashMap, HashSet},
@@ -25,6 +26,12 @@ pub struct DetailsActions {
     /// If true, display the preview in full screen
     pub preview_fullscreen: bool,
     pub patchset_actions: HashMap<PatchsetAction, bool>,
+    /// For each patch, a set of `Authors` that appear in `Reviewed-by` trailers
+    pub reviewed_by: Vec<HashSet<Author>>,
+    /// For each patch, a set of `Authors` that appear in `Tested-by` trailers
+    pub tested_by: Vec<HashSet<Author>>,
+    /// For each patch, a set of `Authors` that appear in `Acked-by` trailers
+    pub acked_by: Vec<HashSet<Author>>,
     pub last_screen: CurrentScreen,
     pub lore_api_client: BlockingLoreAPIClient,
 }

--- a/src/handler/details_actions.rs
+++ b/src/handler/details_actions.rs
@@ -21,8 +21,12 @@ pub fn handle_patchset_details<B: Backend>(
     let patchset_details_and_actions = app.details_actions.as_mut().unwrap();
 
     if key.modifiers.contains(KeyModifiers::SHIFT) {
-        if let KeyCode::Char('G') = key.code {
-            patchset_details_and_actions.go_to_last_line()
+        match key.code {
+            KeyCode::Char('G') => patchset_details_and_actions.go_to_last_line(),
+            KeyCode::Char('R') => {
+                patchset_details_and_actions.toggle_reply_with_reviewed_by_action(true);
+            }
+            _ => {}
         }
         return Ok(());
     }
@@ -91,7 +95,7 @@ pub fn handle_patchset_details<B: Backend>(
             patchset_details_and_actions.toggle_bookmark_action();
         }
         KeyCode::Char('r') => {
-            patchset_details_and_actions.toggle_reply_with_reviewed_by_action();
+            patchset_details_and_actions.toggle_reply_with_reviewed_by_action(false);
         }
         KeyCode::Enter => {
             if patchset_details_and_actions.actions_require_user_io() {
@@ -135,6 +139,7 @@ pub fn generate_help_popup() -> Box<dyn PopUp> {
         .keybind("p", "Preview previous patch")
         .keybind("b", "Toggle bookmark action")
         .keybind("r", "Toggle reply with Reviewed-by action")
+        .keybind("Shift+r", "Toggle reply with Reviewed-by action for all patches")
         .build();
 
     Box::new(popup)

--- a/src/handler/details_actions.rs
+++ b/src/handler/details_actions.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::{
     app::{screens::CurrentScreen, App},
-    ui::popup::{help::HelpPopUpBuilder, PopUp},
+    ui::popup::{help::HelpPopUpBuilder, review_trailers::ReviewTrailersPopUp, PopUp},
     utils,
 };
 use ratatui::{
@@ -46,6 +46,11 @@ pub fn handle_patchset_details<B: Backend>(
             }
             KeyCode::Char('d') => {
                 patchset_details_and_actions.preview_scroll_down(terminal_height / 2);
+            }
+            KeyCode::Char('t') => {
+                let popup =
+                    ReviewTrailersPopUp::generate_trailers_popup(patchset_details_and_actions);
+                app.popup = Some(popup);
             }
             _ => {}
         }
@@ -140,6 +145,7 @@ pub fn generate_help_popup() -> Box<dyn PopUp> {
         .keybind("b", "Toggle bookmark action")
         .keybind("r", "Toggle reply with Reviewed-by action")
         .keybind("Shift+r", "Toggle reply with Reviewed-by action for all patches")
+        .keybind("Ctrl+t", "Show code-review trailers details")
         .build();
 
     Box::new(popup)

--- a/src/lore/lore_session/tests.rs
+++ b/src/lore/lore_session/tests.rs
@@ -534,11 +534,14 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
             .unwrap(),
     ];
 
+    let patches_to_reply = vec![true; patches.len()];
+
     let git_reply_commands = prepare_reply_patchset_with_reviewed_by(
         &lore_api_client,
         tmp_dir,
         target_list,
         &patches,
+        &patches_to_reply,
         "Bar Foo <bar@foo.bar.foo>",
         "--dry-run --suppress-cc=all",
     )

--- a/src/lore/patch.rs
+++ b/src/lore/patch.rs
@@ -31,7 +31,7 @@ pub struct Patch {
     updated: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Author {
     pub name: String,
     pub email: String,

--- a/src/lore/patch.rs
+++ b/src/lore/patch.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use derive_getters::Getters;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -35,6 +37,13 @@ pub struct Patch {
 pub struct Author {
     pub name: String,
     pub email: String,
+}
+
+impl Display for Author {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} <{}>", self.name, self.email)?;
+        Ok(())
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/src/ui/details_actions.rs
+++ b/src/ui/details_actions.rs
@@ -6,7 +6,46 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{screens::details_actions::PatchsetAction, App};
+use crate::app::{
+    screens::details_actions::{DetailsActions, PatchsetAction},
+    App,
+};
+
+/// Returns a `Line` type that represents a line containing stats about reply
+/// trailers. It currently considers the _Reviewed-by_, _Tested-by_, and
+/// _Acked-by_ trailers and colors them depending if they are 0 or not.  Example
+/// of line returned:
+///
+/// _**Reviewed-by: 1 | Tested-by: 0 | Acked-by: 2**_
+fn review_trailers_details(details_actions: &DetailsActions) -> Line<'static> {
+    let i = details_actions.preview_index;
+
+    let resolve_color = |n_trailers: usize| -> Style {
+        if n_trailers == 0 {
+            Style::default().fg(Color::White)
+        } else {
+            Style::default().fg(Color::Green)
+        }
+    };
+
+    Line::from(vec![
+        Span::styled("Reviewed-by: ", Style::default().fg(Color::Cyan)),
+        Span::styled(
+            details_actions.reviewed_by[i].len().to_string(),
+            resolve_color(details_actions.reviewed_by[i].len()),
+        ),
+        Span::styled(" | Tested-by: ", Style::default().fg(Color::Cyan)),
+        Span::styled(
+            details_actions.tested_by[i].len().to_string(),
+            resolve_color(details_actions.tested_by[i].len()),
+        ),
+        Span::styled(" | Acked-by: ", Style::default().fg(Color::Cyan)),
+        Span::styled(
+            details_actions.acked_by[i].len().to_string(),
+            resolve_color(details_actions.acked_by[i].len()),
+        ),
+    ])
+}
 
 fn render_details_and_actions(f: &mut Frame, app: &App, details_chunk: Rect, actions_chunk: Rect) {
     let patchset_details_and_actions = app.details_actions.as_ref().unwrap();
@@ -72,6 +111,7 @@ fn render_details_and_actions(f: &mut Frame, app: &App, details_chunk: Rect, act
                 Style::default().fg(Color::White),
             ),
         ]),
+        review_trailers_details(patchset_details_and_actions),
     ];
     if !staged_to_reply.is_empty() {
         patchset_details.push(Line::from(vec![

--- a/src/ui/popup.rs
+++ b/src/ui/popup.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use ratatui::{crossterm::event::KeyEvent, layout::Rect, Frame};
 
 pub mod help;
+pub mod review_trailers;
 
 /// A trait that represents a popup that can be rendered on top of a screen
 pub trait PopUp: Debug {

--- a/src/ui/popup/review_trailers.rs
+++ b/src/ui/popup/review_trailers.rs
@@ -1,0 +1,158 @@
+use std::collections::HashSet;
+
+use patch_hub::lore::patch::Author;
+use ratatui::{
+    crossterm::event::KeyCode,
+    layout::Alignment,
+    style::{Color, Modifier, Style, Stylize},
+    text::Line,
+    widgets::{Clear, Paragraph},
+};
+
+use crate::app::screens::details_actions::DetailsActions;
+
+use super::PopUp;
+
+#[derive(Debug)]
+pub struct ReviewTrailersPopUp {
+    reviewed_by_text: String,
+    tested_by_text: String,
+    acked_by_text: String,
+    offset: (u16, u16),
+    max_offset: (u16, u16),
+    dimensions: (u16, u16),
+}
+
+impl ReviewTrailersPopUp {
+    /// Generate a pop-up that contains details about the code-review trailers
+    /// of a specific patch.
+    ///
+    /// The specific patch is defined by the currently previewing patch of
+    /// `@details_actions` and the information about the trailers is stored in
+    /// the fields `reviewed_by`, `tested_by`, and `acked_by`, which are the
+    /// tags considered for the generated pop-up. This function succeeds regardless if
+    /// there are no code-review trailers for the specific patch.
+    pub fn generate_trailers_popup(details_actions: &DetailsActions) -> Box<dyn PopUp> {
+        let i = details_actions.preview_index;
+        let mut reviewed_by_text = String::new();
+        let mut tested_by_text = String::new();
+        let mut acked_by_text = String::new();
+        let mut columns = 0;
+
+        // Auxiliary routines to avoid code duplications
+        let mut update_columns = |line_len: usize| {
+            if line_len > columns {
+                columns = line_len;
+            }
+        };
+        let mut fill_text = |text: &mut String, authors: &HashSet<Author>| {
+            for author in authors {
+                let author = format!(" - {}\n", author);
+                text.push_str(&author);
+                update_columns(author.len());
+            }
+        };
+
+        fill_text(&mut reviewed_by_text, &details_actions.reviewed_by[i]);
+        fill_text(&mut tested_by_text, &details_actions.tested_by[i]);
+        fill_text(&mut acked_by_text, &details_actions.acked_by[i]);
+
+        let lines = (3
+            + details_actions.reviewed_by[i].len()
+            + details_actions.tested_by[i].len()
+            + details_actions.acked_by[i].len()) as u16;
+
+        // TODO: Calculate percentage based on the lines and screen size
+        let dimensions = (50, 40);
+
+        Box::new(ReviewTrailersPopUp {
+            reviewed_by_text,
+            tested_by_text,
+            acked_by_text,
+            offset: (0, 0),
+            max_offset: (lines, columns as u16),
+            dimensions,
+        })
+    }
+}
+
+impl PopUp for ReviewTrailersPopUp {
+    fn dimensions(&self) -> (u16, u16) {
+        self.dimensions
+    }
+
+    /// Renders a centered overlaying pop-up with entries for code-review
+    /// trailers of "Reviewed-by", "Tested-by", and "Acked-by".
+    fn render(&self, f: &mut ratatui::Frame, chunk: ratatui::prelude::Rect) {
+        let mut contents = vec![];
+
+        // Auxilliary closure to avoid code duplication
+        let mut add_entry_to_contents = |name: &str, text: &str| {
+            contents.push(Line::styled(
+                name.to_string(),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+                    .add_modifier(Modifier::UNDERLINED),
+            ));
+            for line in text.lines() {
+                contents.push(Line::styled(
+                    line.to_string(),
+                    Style::default().fg(Color::White),
+                ));
+            }
+            contents.push(Line::from("")); // equivalent to newline
+        };
+
+        add_entry_to_contents("Reviewed-by", &self.reviewed_by_text);
+        add_entry_to_contents("Tested-by", &self.tested_by_text);
+        add_entry_to_contents("Acked-by", &self.acked_by_text);
+
+        let block = ratatui::widgets::Block::default()
+            .title("Code-Review Trailers")
+            .title_alignment(Alignment::Center)
+            .title_style(ratatui::style::Style::default().bold().blue())
+            .title_bottom(Line::styled("(ESC) Close", Style::default().bold().blue()))
+            .borders(ratatui::widgets::Borders::ALL)
+            .border_type(ratatui::widgets::BorderType::Double)
+            .style(ratatui::style::Style::default());
+
+        let pop_up = Paragraph::new(contents)
+            .style(ratatui::style::Style::default())
+            .block(block)
+            .alignment(ratatui::layout::Alignment::Left)
+            .scroll(self.offset);
+
+        f.render_widget(Clear, chunk);
+        f.render_widget(pop_up, chunk);
+    }
+
+    /// Handles simple one-char width navigation.
+    fn handle(&mut self, key: ratatui::crossterm::event::KeyEvent) -> color_eyre::Result<()> {
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.offset.0 > 0 {
+                    self.offset.0 -= 1;
+                }
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if self.offset.0 < self.max_offset.0 {
+                    self.offset.0 += 1;
+                }
+            }
+            KeyCode::Left | KeyCode::Char('h') => {
+                if self.offset.1 > 0 {
+                    self.offset.1 -= 1;
+                }
+            }
+            KeyCode::Right | KeyCode::Char('l') => {
+                if self.offset.1 < self.max_offset.1 {
+                    self.offset.1 += 1;
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
# PR Commits

- **First**: Implement "raw" functionality to reply to a subset of patches from a series. It is "raw" in the sense that it doesn't implement a way to toggle the reply to all patches (which was the previous behavior) and doesn't update the UI component for this functionality
- **Second**: Implement the key bind uppercase `R` to toggle the reply to all patches
- **Third**: Update the UI to reflect the changes introduced by the third and fourth commits
- **Fourth**: Make UI display the list of patches that were replied with/ the tag as well, giving precedence to those over the staged ones and displaying them in a different color. 

Closes: #78 

---

# Example

Selecting patches 1, 5, and 7 from a series with 29 patches, in which patches 0, 3, 7, and 11 have already been replied with `Reviewed-by`.

![2024-11-11-134637_1894x1027_scrot](https://github.com/user-attachments/assets/3235150f-e61d-4ab2-aa63-1a18b0ed0519)

---

# Steps to test this change

1. Sync your local repo with the latest unstable
2. Checkout to the latest commit of the unstable (commit 0bbf9c6e688a98c7b442b93990b63241c5dcd869)
3. Fetch and switch to this branch
```
git fetch https://github.com/davidbtadokoro/patch-hub.git feat-reviewed-by-subset
git checkout FETCH_HEAD
```
4. Launch `patch-hub` w/ `cargo run --release`
5. **IMPORTANT:** `--dry-run` is enabled by default, but, for sanity, check if it is indeed enabled by going to the configurations screen (`F2`) and checking the config `git send email option`.
6. Consult an arbitrary patchset, preferably a multi-patch series.
7. To stage a patch to reply w/ the tag, hit lowercase `r`. You should see the title `Preview` of the patch preview tab become `Preview [REVIEWED-BY]*`. You should also see the full subset of patches that have been replied w/ the tag and the ones staged in the `Details` tab as the entry `Reviewed-by: (<patch-number-reviewed>,<patch-number-staged>*,...)`.
8. To (un)stage all patches, hit uppercase `R`.
9. To consolidate the reply of the staged patches, hit `ENTER`. This should tear the sleek TUI, and display the raw output of the underlying `git send-email` command.
10. After returning from the last step, there should be no patch staged to be replied to, no buttons `[x] reviewed-by`, and the patches that were replied to should be previewed w/ the title `Preview [REVIEWED-BY]` (without the asterisk) and show in the entry `Reviewed-by:` of the tab `Details`.

**Any** problem report or idea is welcomed, and thank you for testing this feature. 