### PR TITLE
feat: add entry in "Edit Config" for max log age

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -247,6 +247,9 @@ impl App {
             if let Ok(patch_renderer) = edit_config.extract_patch_renderer() {
                 self.config.set_patch_renderer(patch_renderer.into())
             }
+            if let Ok(max_log_age) = edit_config.max_log_age() {
+                self.config.set_max_log_age(max_log_age)
+            }
         }
     }
 

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -144,6 +144,10 @@ impl Config {
         self.patch_renderer = patch_renderer;
     }
 
+    pub fn set_max_log_age(&mut self, max_log_age: usize) {
+        self.max_log_age = max_log_age;
+    }
+
     pub fn save_patch_hub_config(&self) -> io::Result<()> {
         let config_path = if let Ok(path) = env::var("PATCH_HUB_CONFIG_PATH") {
             path

--- a/src/app/screens/edit_config.rs
+++ b/src/app/screens/edit_config.rs
@@ -27,6 +27,7 @@ impl EditConfigState {
             EditableConfig::PatchRenderer,
             config.patch_renderer().to_string(),
         );
+        config_buffer.insert(EditableConfig::MaxLogAge, config.max_log_age().to_string());
 
         EditConfigState {
             config_buffer,
@@ -170,6 +171,21 @@ impl EditConfigState {
         let patch_renderer = self.extract_config_buffer_val(&EditableConfig::PatchRenderer);
         Ok(patch_renderer)
     }
+
+    /// Extracts the max log age from the config
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the max log age inserted string is not a valid integer
+    pub fn max_log_age(&mut self) -> Result<usize, ()> {
+        match self
+            .extract_config_buffer_val(&EditableConfig::MaxLogAge)
+            .parse::<usize>()
+        {
+            Ok(value) => Ok(value),
+            Err(_) => Err(()),
+        }
+    }
 }
 
 #[derive(Debug, Hash, Eq, PartialEq)]
@@ -179,6 +195,7 @@ enum EditableConfig {
     DataDir,
     GitSendEmailOpt,
     PatchRenderer,
+    MaxLogAge,
 }
 
 impl TryFrom<usize> for EditableConfig {
@@ -191,6 +208,7 @@ impl TryFrom<usize> for EditableConfig {
             2 => Ok(EditableConfig::DataDir),
             3 => Ok(EditableConfig::GitSendEmailOpt),
             4 => Ok(EditableConfig::PatchRenderer),
+            5 => Ok(EditableConfig::MaxLogAge),
             _ => bail!("Invalid index {} for EditableConfig", value), // Handle out of bounds
         }
     }
@@ -206,6 +224,7 @@ impl Display for EditableConfig {
                 write!(f, "Patch Renderer (bat, delta, diff-so-fancy)")
             }
             EditableConfig::GitSendEmailOpt => write!(f, "`git send email` option"),
+            EditableConfig::MaxLogAge => write!(f, "Max Log Age"),
         }
     }
 }


### PR DESCRIPTION
There is a config called max_log_age for determining how long logs produced by patch-hub will live on the user fs (the app cleans them at start-up using this value). This commit adds an entry in the "Edit Config" screen for it.