### PR TITLE
fix: remove UI auto-refresh to solve high CPU usage

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -112,17 +112,21 @@ where
 
         terminal = logic_handling(terminal, &mut app)?;
 
-        if event::poll(Duration::from_millis(16))? {
-            if let Event::Key(key) = event::read()? {
-                if key.kind == KeyEventKind::Release {
-                    continue;
-                }
-                match key_handling(terminal, &mut app, key)? {
-                    ControlFlow::Continue(t) => terminal = t,
-                    ControlFlow::Break(_) => return Ok(()),
-                }
+        // *IMPORTANT*: Uncommenting the if below makes `patch-hub` not block
+        // until an event is captured.  We should only do it when (if ever) we
+        // need to refresh the UI independently of any event as doing so gravely
+        // hinders the performance to below acceptable.
+        // if event::poll(Duration::from_millis(16))? {
+        if let Event::Key(key) = event::read()? {
+            if key.kind == KeyEventKind::Release {
+                continue;
+            }
+            match key_handling(terminal, &mut app, key)? {
+                ControlFlow::Continue(t) => terminal = t,
+                ControlFlow::Break(_) => return Ok(()),
             }
         }
+        // }
     }
 }
 


### PR DESCRIPTION
Due to `patch-hub` refreshing the UI 60 times per second [1], some idle screens consume unreasonable CPU (like 10%, 20%, or even, 30%). At the moment, we don't even need to refresh the UI if there are no events to be processed. Currently we only process key events, but any kind of event works. In all trueness, we may never need to periodically refresh the UI, as `patch-hub` is purposed to be a lightweight TUI to streamline the work of Linux kernel maintainers and not a latest-gen game in which frames get stale basically instantaneously.

Given this context, remove any auto-refresh of the UI. The `if` block that effectively toggles the blocking and refreshing nature of the UI wasn't removed, only commented out in case we need to reintroduce this in the future.

[1]: https://github.com/kworkflow/patch-hub/blob/8f7a6dc883d3ebc852c7d94741742115be136f3d/src/handler.rs#L133

Closes: #87