### PR TITLE
doc: fix link to git email, link to contributors guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ updated, and so on) and individual patch contents, as well as apply actions
 based on patchsets, like bookmarking/unbookmarking and replying to the entire
 series with the `Reviewed-by` tag.
 
-4. _Patchset Rendering_: Use external tools like [`bat`](https://github.com/sharkdp/bat), 
-[`delta`](https://github.com/dandavison/delta), [`diff-so-fancy`](https://github.com/so-fancy/diff-so-fancy) 
+4. _Patchset Rendering_: Use external tools like [`bat`](https://github.com/sharkdp/bat),
+[`delta`](https://github.com/dandavison/delta), [`diff-so-fancy`](https://github.com/so-fancy/diff-so-fancy)
 to render the patch details and have a better preview screen with colors,
 layouts and even syntax highlight. If you don't wish to use external
 dependencies, you can opt for the vanilla renderer (denominated `default`).
@@ -56,7 +56,7 @@ for later consult.
 In order to use `patch-hub` you must install:
 
 - [`b4`](https://github.com/mricon/b4)
-- [`git-email`](https://git-scm.com/docs/git-send-email/en) (`git send-email` command)
+- [`git-email`](https://git-scm.com/docs/git-send-email) (`git send-email` command)
 - [`bat`](https://github.com/sharkdp/bat), [`delta`](https://github.com/dandavison/delta) and/or [`diff-so-fancy`](https://github.com/so-fancy/diff-so-fancy) optional but highly recommended patchset renderers to enhance previewing patches
 
 ### pre-compiled binaries
@@ -84,3 +84,5 @@ system.
 We are still structuring an organized contribution process, but we more than
 welcome proposed changes through Pull-Requests. For cataloged issues, you can
 check our [issues page](https://github.com/kworkflow/patch-hub/issues).
+Don't forget to read our
+[Contribuitor's Guide](https://kworkflow.org/content/howtocontribute.html)


### PR DESCRIPTION
- add link to KWs contributors guide
- fix link to git send-email docs
- removes extra spaces