### PR TITLE
fix: ui: correct loading screen rectangle dimensions

### DIFF
--- a/src/ui/loading_screen.rs
+++ b/src/ui/loading_screen.rs
@@ -22,6 +22,9 @@ const SPINNER: [char; 8] = [
 ];
 static mut SPINNER_TICK: usize = 1;
 
+const LOADING_AREA_EXTRA_FACTOR_WIDTH: f32 = 1.3;
+const LOADING_AREA_EXTRA_LINES: u16 = 2;
+
 /// This function renders a loading screen taking a `terminal` instance and a
 /// `title`.
 pub fn render<B: Backend>(mut terminal: Terminal<B>, title: impl Display) -> Terminal<B> {
@@ -41,7 +44,13 @@ fn spinner() -> char {
 /// The actual implementation of the loading screen rendering. Currently the
 /// loading notification is static.
 fn draw_loading_screen(f: &mut Frame, title: impl Display) {
+    let frame_area = f.area();
     let loading_text = format!("{} {}", title, spinner());
+
+    let (width_pct, height_pct) =
+        calculate_loading_percentages(loading_text.len(), frame_area.width, frame_area.height);
+
+    let loading_area = centered_rect(width_pct, height_pct, frame_area);
 
     let loading_par = Paragraph::new(Line::from(Span::styled(
         loading_text,
@@ -51,6 +60,55 @@ fn draw_loading_screen(f: &mut Frame, title: impl Display) {
     .centered()
     .wrap(Wrap { trim: true });
 
-    let loading_area = centered_rect(30, 10, f.area());
     f.render_widget(loading_par, loading_area);
+}
+
+fn calculate_loading_percentages(
+    loading_text_len: usize,
+    frame_area_width: u16,
+    frame_area_height: u16,
+) -> (u16, u16) {
+    let min_width = (loading_text_len as f32 * LOADING_AREA_EXTRA_FACTOR_WIDTH).ceil() as u16;
+    let min_height = {
+        let lines = (loading_text_len as u16).div_ceil(frame_area_width).max(1);
+        lines + LOADING_AREA_EXTRA_LINES
+    };
+
+    let width_pct = (100 * min_width).div_ceil(frame_area_width).min(100);
+    let height_pct = (100 * min_height).div_ceil(frame_area_height).min(100);
+
+    (width_pct, height_pct)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_loading_percentages() {
+        // Test case 1: standard case with reasonable frame size
+        let (width_pct, height_pct) = calculate_loading_percentages(10, 40, 20);
+        assert_eq!(width_pct, 33); // (10 * 1.3 = 13 / 40 * 100) = 32.5, rounded up to 33
+        assert_eq!(height_pct, 15); // min_height: 1 line + 2 extra = 3, (3 / 20 * 100) = 15
+
+        // Test case 2: text len exceeds frame width, forcing width_pct to cap at 100%
+        let (width_pct, height_pct) = calculate_loading_percentages(80, 40, 20);
+        assert_eq!(width_pct, 100); // min_width: 104 exceeds frame width, capped at 100%
+        assert_eq!(height_pct, 20); // min_height: 2 lines + 2 extra = 4, (4 / 20 * 100) = 20
+
+        // Test case 3: Very small loading text within large frame area
+        let (width_pct, height_pct) = calculate_loading_percentages(5, 50, 30);
+        assert_eq!(width_pct, 14); // (5 * 1.3 = 7 / 50 * 100) = 14
+        assert_eq!(height_pct, 10); // min_height: 1 line + 2 extra = 3, (3 / 30 * 100) = 10
+
+        // Test case 4: small frame height, causing height_pct to cap at 100%
+        let (width_pct, height_pct) = calculate_loading_percentages(100, 40, 4);
+        assert_eq!(width_pct, 100); // min_width: 130 exceeds frame width, capped at 100%
+        assert_eq!(height_pct, 100); // min_height: 3 lines + 2 extra = 5, capped at 100%
+
+        // Test case 5: small frame width, but big height
+        let (width_pct, height_pct) = calculate_loading_percentages(100, 10, 100);
+        assert_eq!(width_pct, 100); // min_width: 130 exceeds frame width, capped at 100%
+        assert_eq!(height_pct, 12); // min_height: 10 lines + 2 extra = 12
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where the loading screen message doesn't appear in smaller terminal sizes. The idea behind the solution is to consider both the text size and frame dimensions to calculate the desired rectangle percentage. I've also added an automated test for this calculation.

Closes #75

Screenshots after the solution:
Really small length, really small width:
![Captura de tela de 2024-11-02 12-05-04](https://github.com/user-attachments/assets/eb4830f1-0f25-4f85-9102-aeaa9a9640b0)
Small length, small width:
![Captura de tela de 2024-11-02 12-04-56](https://github.com/user-attachments/assets/a5ae4c75-b3ce-443e-acf0-bd09d467e3fd)
Small length, big width:
![Captura de tela de 2024-11-02 12-04-45](https://github.com/user-attachments/assets/b9d506e3-f43e-4914-98da-f365c9e793f6)
Small width, big length:
![Captura de tela de 2024-11-02 12-04-26](https://github.com/user-attachments/assets/71f638ba-d9db-4d90-840b-d7e2d5b1d802)
Big sized terminal:
![Captura de tela de 2024-11-02 12-04-09](https://github.com/user-attachments/assets/28a72210-9be9-4ead-b780-8413e0d9159a)
Full screen terminal:
![Captura de tela de 2024-11-02 12-03-49](https://github.com/user-attachments/assets/ca00d56f-e8b9-43f7-92e7-d4cf09aaec58)

If there is no length and width to show the message there is nothing we can do:
![Captura de tela de 2024-11-02 12-05-23](https://github.com/user-attachments/assets/a9a49e76-182b-4675-8ea0-9bcfddb54e85)