### PR TITLE
Basic `git am` support

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -148,6 +148,7 @@ impl App {
                     ]),
                     last_screen: current_screen,
                     lore_api_client: self.lore_api_client.clone(),
+                    path: patchset_path,
                 });
                 Ok(())
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -244,6 +244,9 @@ impl App {
             if let Ok(git_send_email_option) = edit_config.git_send_email_option() {
                 self.config.set_git_send_email_option(git_send_email_option)
             }
+            if let Ok(git_am_option) = edit_config.git_am_option() {
+                self.config.set_git_am_option(git_am_option)
+            }
             if let Ok(patch_renderer) = edit_config.extract_patch_renderer() {
                 self.config.set_patch_renderer(patch_renderer.into())
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -145,6 +145,7 @@ impl App {
                     patchset_actions: HashMap::from([
                         (PatchsetAction::Bookmark, is_patchset_bookmarked),
                         (PatchsetAction::ReplyWithReviewedBy, false),
+                        (PatchsetAction::Apply, false),
                     ]),
                     last_screen: current_screen,
                     lore_api_client: self.lore_api_client.clone(),
@@ -217,6 +218,18 @@ impl App {
                 .as_mut()
                 .unwrap()
                 .toggle_action(PatchsetAction::ReplyWithReviewedBy);
+        }
+
+        if let Some(true) = self.patchset_details_and_actions_state.as_ref().unwrap().patchset_actions.get(&PatchsetAction::Apply) {
+            self.patchset_details_and_actions_state
+                .as_ref()
+                .unwrap()
+                .apply_patchset(&self.config);
+
+            self.patchset_details_and_actions_state
+                .as_mut()
+                .unwrap()
+                .toggle_apply_action();
         }
 
         Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -220,7 +220,13 @@ impl App {
                 .toggle_action(PatchsetAction::ReplyWithReviewedBy);
         }
 
-        if let Some(true) = self.patchset_details_and_actions_state.as_ref().unwrap().patchset_actions.get(&PatchsetAction::Apply) {
+        if let Some(true) = self
+            .patchset_details_and_actions_state
+            .as_ref()
+            .unwrap()
+            .patchset_actions
+            .get(&PatchsetAction::Apply)
+        {
             self.patchset_details_and_actions_state
                 .as_ref()
                 .unwrap()

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,10 +1,7 @@
 use derive_getters::Getters;
 use serde::{Deserialize, Serialize};
 use std::{
-    env,
-    fs::{self, File},
-    io,
-    path::Path,
+    collections::HashMap, env, fs::{self, File}, io, path::Path
 };
 
 use super::patch_renderer::PatchRenderer;
@@ -31,6 +28,14 @@ pub struct Config {
     patch_renderer: PatchRenderer,
     /// Maximum age of a log file in days
     max_log_age: usize,
+    /// Flags to be use with `git am` command when applying patches
+    git_am_options: String,
+    #[getter(skip)]
+    /// List of kernel trees
+    kernel_trees: HashMap<String, String>,
+    /// The current kernel tree being used
+    current_tree: Option<String>,
+    git_am_branch_prefix: String,
 }
 
 impl Config {
@@ -50,6 +55,10 @@ impl Config {
             cache_dir,
             data_dir,
             max_log_age: 30,
+            git_am_options: "".to_string(),
+            kernel_trees: HashMap::new(),
+            current_tree: None,
+            git_am_branch_prefix: "patchset-".to_string(),
         }
     }
 
@@ -138,6 +147,21 @@ impl Config {
 
     pub fn set_git_send_email_option(&mut self, git_send_email_options: String) {
         self.git_send_email_options = git_send_email_options;
+    }
+
+    pub fn set_git_am_option(&mut self, git_am_options: String) {
+        self.git_am_options = git_am_options;
+    }
+
+    #[allow(dead_code)]
+    /// Returns the list of names of the registered kernel trees
+    pub fn kernel_trees(&self) -> Vec<&String> {
+        self.kernel_trees.keys().collect::<Vec<&String>>()
+    }
+
+    /// Returns the path of the kernel tree with the given name if it exists
+    pub fn kernel_tree_path(&self, kernel_tree: &str) -> Option<&String> {
+        self.kernel_trees.get(kernel_tree)
     }
 
     pub fn set_patch_renderer(&mut self, patch_renderer: PatchRenderer) {

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,7 +1,11 @@
 use derive_getters::Getters;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap, env, fs::{self, File}, io, path::Path
+    collections::HashMap,
+    env,
+    fs::{self, File},
+    io,
+    path::Path,
 };
 
 use super::patch_renderer::PatchRenderer;

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -27,6 +27,7 @@ const LAST_LINE_PADDING: usize = 10;
 pub enum PatchsetAction {
     Bookmark,
     ReplyWithReviewedBy,
+    Apply,
 }
 
 impl PatchsetDetailsAndActionsState {
@@ -100,6 +101,10 @@ impl PatchsetDetailsAndActionsState {
         self.toggle_action(PatchsetAction::Bookmark);
     }
 
+    pub fn toggle_apply_action(&mut self) {
+        self.toggle_action(PatchsetAction::Apply);
+    }
+
     pub fn toggle_reply_with_reviewed_by_action(&mut self) {
         self.toggle_action(PatchsetAction::ReplyWithReviewedBy);
     }
@@ -160,7 +165,7 @@ impl PatchsetDetailsAndActionsState {
 
     /// Apply the patchset to the current selected kernel tree
     pub fn apply_patchset(&self, config: &Config) {
-        let tree = config.current_tree().as_ref().unwrap();
+        let tree: &String = config.current_tree().as_ref().unwrap();
         let tree_path = config.kernel_tree_path(tree).unwrap();
         let am_options = config.git_am_options();
         let branch_prefix = config.git_am_branch_prefix();

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -5,7 +5,6 @@ use ::patch_hub::{lore_api_client::BlockingLoreAPIClient, lore_session, patch::P
 use color_eyre::eyre::bail;
 use std::{collections::HashMap, path::Path, process::Command};
 
-
 pub struct PatchsetDetailsAndActionsState {
     pub representative_patch: Patch,
     pub path: String,
@@ -202,7 +201,10 @@ impl PatchsetDetailsAndActionsState {
         let out = cmd.output().unwrap();
 
         if !out.status.success() {
-            Logger::error(format!("Failed to apply the patchset `{}`", self.representative_patch.title()));
+            Logger::error(format!(
+                "Failed to apply the patchset `{}`",
+                self.representative_patch.title()
+            ));
             Logger::error(String::from_utf8_lossy(&out.stderr));
             let _ = Command::new("git")
                 .arg("am")
@@ -224,7 +226,7 @@ impl PatchsetDetailsAndActionsState {
             .arg("-")
             .output()
             .unwrap();
-        
+
         if !out.status.success() {
             let _ = Command::new("git")
                 .arg("branch")

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -189,7 +189,7 @@ impl PatchsetDetailsAndActionsState {
             .output()
             .unwrap();
 
-        // 3. Apply the patchset
+        // 4. Apply the patchset
         let mut cmd = Command::new("git");
 
         cmd.arg("am").arg(&self.path);
@@ -205,7 +205,12 @@ impl PatchsetDetailsAndActionsState {
                 "Failed to apply the patchset `{}`",
                 self.representative_patch.title()
             ));
-            Logger::error(String::from_utf8_lossy(&out.stderr));
+
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if !stderr.trim().is_empty() {
+                Logger::error(format!("git am output: {}", stderr));
+            }
+
             let _ = Command::new("git")
                 .arg("am")
                 .arg("--abort")
@@ -220,7 +225,7 @@ impl PatchsetDetailsAndActionsState {
             ));
         }
 
-        // 4. git checkout -
+        // 5. git checkout -
         let _ = Command::new("git")
             .arg("checkout")
             .arg("-")
@@ -235,7 +240,7 @@ impl PatchsetDetailsAndActionsState {
                 .output()
                 .unwrap();
         }
-        // 5. CD back
+        // 6. CD back
         std::env::set_current_dir(&oldwd).unwrap();
     }
 }

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -1,7 +1,10 @@
+use crate::app::{config::Config, logging::Logger};
+
 use super::CurrentScreen;
 use ::patch_hub::{lore_api_client::BlockingLoreAPIClient, lore_session, patch::Patch};
 use color_eyre::eyre::bail;
 use std::{collections::HashMap, path::Path, process::Command};
+
 
 pub struct PatchsetDetailsAndActionsState {
     pub representative_patch: Patch,
@@ -153,5 +156,79 @@ impl PatchsetDetailsAndActionsState {
         }
 
         Ok(successful_indexes)
+    }
+
+    /// Apply the patchset to the current selected kernel tree
+    pub fn apply_patchset(&self, config: &Config) {
+        let tree = config.current_tree().as_ref().unwrap();
+        let tree_path = config.kernel_tree_path(tree).unwrap();
+        let am_options = config.git_am_options();
+        let branch_prefix = config.git_am_branch_prefix();
+        // TODO: Select a kernel tree
+
+        // Change the current working directory to the tree_path
+        // Save the old working directory
+        let oldwd = std::env::current_dir().unwrap();
+
+        std::env::set_current_dir(tree_path).unwrap();
+        // TODO: Select a branch
+        // 3. Create a new branch
+        let branch_name = format!(
+            "{}{}",
+            branch_prefix,
+            chrono::Utc::now().format("%Y-%m-%d-%H-%M-%S")
+        );
+        let _ = Command::new("git")
+            .arg("checkout")
+            .arg("-b")
+            .arg(&branch_name)
+            .output()
+            .unwrap();
+
+        // 3. Apply the patchset
+        let mut cmd = Command::new("git");
+
+        cmd.arg("am").arg(&self.path);
+
+        am_options.split_whitespace().for_each(|opt| {
+            cmd.arg(opt);
+        });
+
+        let out = cmd.output().unwrap();
+
+        if !out.status.success() {
+            Logger::error(format!("Failed to apply the patchset `{}`", self.representative_patch.title()));
+            Logger::error(String::from_utf8_lossy(&out.stderr));
+            let _ = Command::new("git")
+                .arg("am")
+                .arg("--abort")
+                .output()
+                .unwrap();
+        } else {
+            Logger::info(format!(
+                "Patchset `{}` applied successfully to `{}` tree at branch `{}`",
+                self.representative_patch.title(),
+                tree,
+                branch_name
+            ));
+        }
+
+        // 4. git checkout -
+        let _ = Command::new("git")
+            .arg("checkout")
+            .arg("-")
+            .output()
+            .unwrap();
+        
+        if !out.status.success() {
+            let _ = Command::new("git")
+                .arg("branch")
+                .arg("-D")
+                .arg(&branch_name)
+                .output()
+                .unwrap();
+        }
+        // 5. CD back
+        std::env::set_current_dir(&oldwd).unwrap();
     }
 }

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, path::Path, process::Command};
 
 pub struct PatchsetDetailsAndActionsState {
     pub representative_patch: Patch,
+    pub path: String,
     pub patches: Vec<String>,
     pub preview_index: usize,
     pub preview_scroll_offset: usize,

--- a/src/app/screens/edit_config.rs
+++ b/src/app/screens/edit_config.rs
@@ -24,6 +24,10 @@ impl EditConfigState {
             config.git_send_email_options().to_string(),
         );
         config_buffer.insert(
+            EditableConfig::GitAmOpt,
+            config.git_am_options().to_string(),
+        );
+        config_buffer.insert(
             EditableConfig::PatchRenderer,
             config.patch_renderer().to_string(),
         );
@@ -166,6 +170,12 @@ impl EditConfigState {
         Ok(git_send_emial_option)
     }
 
+    /// Extracts the `git am` option from the config
+    pub fn git_am_option(&mut self) -> Result<String, ()> {
+        let git_am_option = self.extract_config_buffer_val(&EditableConfig::GitAmOpt);
+        Ok(git_am_option)
+    }
+
     pub fn extract_patch_renderer(&mut self) -> Result<String, ()> {
         let patch_renderer = self.extract_config_buffer_val(&EditableConfig::PatchRenderer);
         Ok(patch_renderer)
@@ -178,6 +188,7 @@ enum EditableConfig {
     CacheDir,
     DataDir,
     GitSendEmailOpt,
+    GitAmOpt,
     PatchRenderer,
 }
 
@@ -190,7 +201,8 @@ impl TryFrom<usize> for EditableConfig {
             1 => Ok(EditableConfig::CacheDir),
             2 => Ok(EditableConfig::DataDir),
             3 => Ok(EditableConfig::GitSendEmailOpt),
-            4 => Ok(EditableConfig::PatchRenderer),
+            4 => Ok(EditableConfig::GitAmOpt),
+            5 => Ok(EditableConfig::PatchRenderer),
             _ => bail!("Invalid index {} for EditableConfig", value), // Handle out of bounds
         }
     }
@@ -206,6 +218,7 @@ impl Display for EditableConfig {
                 write!(f, "Patch Renderer (bat, delta, diff-so-fancy)")
             }
             EditableConfig::GitSendEmailOpt => write!(f, "`git send email` option"),
+            EditableConfig::GitAmOpt => write!(f, "`git am` option"),
         }
     }
 }

--- a/src/handler/details_actions.rs
+++ b/src/handler/details_actions.rs
@@ -54,7 +54,8 @@ pub fn handle_patchset_details<B: Backend>(
             app.reset_patchset_details_and_actions_state();
         }
         KeyCode::Char('a') => {
-            patchset_details_and_actions.apply_patchset(&app.config);
+            patchset_details_and_actions.toggle_apply_action();
+            //TODO: patchset_details_and_actions.apply_patchset(&app.config);
         }
         KeyCode::Char('j') | KeyCode::Down => {
             patchset_details_and_actions.preview_scroll_down(1);

--- a/src/handler/details_actions.rs
+++ b/src/handler/details_actions.rs
@@ -53,6 +53,9 @@ pub fn handle_patchset_details<B: Backend>(
             app.set_current_screen(ps_da_clone);
             app.reset_patchset_details_and_actions_state();
         }
+        KeyCode::Char('a') => {
+            patchset_details_and_actions.apply_patchset(&app.config);
+        }
         KeyCode::Char('j') | KeyCode::Down => {
             patchset_details_and_actions.preview_scroll_down(1);
         }

--- a/src/test_samples/app/config/config.json
+++ b/src/test_samples/app/config/config.json
@@ -9,5 +9,10 @@
   "cache_dir": "/cache_dir",
   "data_dir": "/data_dir",
   "patch_renderer": "default",
-  "max_log_age": 42
+  "max_log_age": 42,
+  "git_am_options": "--long-option value -s -h -o -r -t",
+  "kernel_trees": {
+    "linux": "/home/user/linux"
+  },
+  "git_am_branch_prefix": "patchset-"
 }

--- a/src/ui/details_actions.rs
+++ b/src/ui/details_actions.rs
@@ -66,6 +66,7 @@ fn render_details_and_actions(f: &mut Frame, app: &App, details_chunk: Rect, act
     f.render_widget(patchset_details, details_chunk);
 
     let patchset_actions = &patchset_details_and_actions.patchset_actions;
+    // TODO: Create a function to produce new action lines
     let patchset_actions = vec![
         Line::from(vec![
             if *patchset_actions.get(&PatchsetAction::Bookmark).unwrap() {
@@ -99,6 +100,24 @@ fn render_details_and_actions(f: &mut Frame, app: &App, details_chunk: Rect, act
                     .add_modifier(Modifier::BOLD),
             ),
             Span::styled("eviewed-by", Style::default().fg(Color::Cyan)),
+        ]),
+        Line::from(vec![
+            if *patchset_actions
+                .get(&PatchsetAction::Apply)
+                .unwrap()
+            {
+                Span::styled("[x] ", Style::default().fg(Color::Green))
+            } else {
+                Span::styled("[ ] ", Style::default().fg(Color::Cyan))
+            },
+            Span::styled(
+                "a",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::UNDERLINED)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("pply patchset", Style::default().fg(Color::Cyan)),
         ]),
     ];
     let patchset_actions = Paragraph::new(patchset_actions)

--- a/src/ui/details_actions.rs
+++ b/src/ui/details_actions.rs
@@ -102,10 +102,7 @@ fn render_details_and_actions(f: &mut Frame, app: &App, details_chunk: Rect, act
             Span::styled("eviewed-by", Style::default().fg(Color::Cyan)),
         ]),
         Line::from(vec![
-            if *patchset_actions
-                .get(&PatchsetAction::Apply)
-                .unwrap()
-            {
+            if *patchset_actions.get(&PatchsetAction::Apply).unwrap() {
                 Span::styled("[x] ", Style::default().fg(Color::Green))
             } else {
                 Span::styled("[ ] ", Style::default().fg(Color::Cyan))


### PR DESCRIPTION
This is still a draft for this feature. The purpose of this is to implement just the backbone for the patch apply feature for `patch-hub`

# What Is This?

This PR introduces an apply feature for `patch-hub` that let's kernel developers select a given patchset and apply it on a given kernel tree.

# How it Works?

Currently open the details of a patchset and then press `a`. This will run `git am` in the background and try to apply the selected patchset to the selected kernel tree.

At the moment, you need to manually set some configurations in the `config.json` file in order to use this feature. The configs are:

- `git_am_options`: a string with options to be passed to `git am` command (similar to `git_send_email_options`)
- `kernel_trees`: an object to indicate which kernel trees you're working on. The key specifies the name of the kernel tree (any name you want) the value is the path to the kernel tree 
- `current_tree`: a string that specifies which of the above declared kernel trees are you working on, this is used when applying the patchset so patch-hub automatically `cd`s into the right directory
- `git_am_branch_prefix`: for higienic reasons this feature creates a new branch when applying the patch, this option let's you configure a prefix for this branch's name

Applying a patchset is done in a couple of steps:
- **`cd` into the tree**: use the `current_tree` option and `kernel_trees` to find out where patch-hub is suposed to find the kernel tree where to apply the selected patchset
- **Create a branch**: once in the kernel tree directory, create a new branch use the specified prefix and the current timestamp (YYYY-mm-dd-HH-MM-SS)
- **Apply the patchset**: when opening a patchset to show the details, we store the patch to the `.mbx` file in a field called `path` in the `PatchsetDetailsAndActionsState` struct. When then use `Command` to run `git am` with the given `git_am_options` to try to apply the patchset in the newly created branch 
- **Did it succeed?**: check if the apply worked. If not we call `git am --abort` to clean the state of the tree and log any useful information
- **Clean it up**: once we applied (or not) the patchset we `git checkout -` and `cd` back to the directory we where when we started the apply. Also if `git am` failed we delete the branch

# What's next

- Let the user define kernel trees in-app
- Let the user select a tree
- Let the user checkout a branch before applying
- Let the user decide how to handle errors (abort, manually, automatically(?))
- Provide an app screen with all the above
- Write tests

@davidbtadokoro this PR works but there is no intuitive UI/UX for it so needs more polishing before being merged

@rodrigosiqueira any more hints about what a kernel developer might want when applying a patchset is welcome 