### PR TITLE
refactor: rename state structs and methods for clarity

### DIFF
--- a/src/app/screens/bookmarked.rs
+++ b/src/app/screens/bookmarked.rs
@@ -1,11 +1,11 @@
 use patch_hub::lore::patch::Patch;
 
-pub struct BookmarkedPatchsetsState {
+pub struct BookmarkedPatchsets {
     pub bookmarked_patchsets: Vec<Patch>,
     pub patchset_index: usize,
 }
 
-impl BookmarkedPatchsetsState {
+impl BookmarkedPatchsets {
     pub fn select_below_patchset(&mut self) {
         if self.patchset_index + 1 < self.bookmarked_patchsets.len() {
             self.patchset_index += 1;

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -4,7 +4,7 @@ use color_eyre::eyre::bail;
 use ratatui::text::Text;
 use std::{collections::HashMap, path::Path, process::Command};
 
-pub struct PatchsetDetailsAndActionsState {
+pub struct DetailsActions {
     pub representative_patch: Patch,
     /// Raw patches as plain text files
     pub raw_patches: Vec<String>,
@@ -29,7 +29,7 @@ pub enum PatchsetAction {
     ReplyWithReviewedBy,
 }
 
-impl PatchsetDetailsAndActionsState {
+impl DetailsActions {
     pub fn preview_next_patch(&mut self) {
         if (self.preview_index + 1) < self.patches_preview.len() {
             self.preview_index += 1;

--- a/src/app/screens/edit_config.rs
+++ b/src/app/screens/edit_config.rs
@@ -5,7 +5,7 @@ use color_eyre::eyre::bail;
 use derive_getters::Getters;
 
 #[derive(Debug, Getters)]
-pub struct EditConfigState {
+pub struct EditConfig {
     #[getter(skip)]
     config_buffer: HashMap<EditableConfig, String>,
     highlighted: usize,
@@ -13,7 +13,7 @@ pub struct EditConfigState {
     curr_edit: String,
 }
 
-impl EditConfigState {
+impl EditConfig {
     pub fn new(config: &Config) -> Self {
         let mut config_buffer = HashMap::new();
         config_buffer.insert(EditableConfig::PageSize, config.page_size().to_string());
@@ -29,7 +29,7 @@ impl EditConfigState {
         );
         config_buffer.insert(EditableConfig::MaxLogAge, config.max_log_age().to_string());
 
-        EditConfigState {
+        EditConfig {
             config_buffer,
             highlighted: 0,
             is_editing: false,
@@ -99,7 +99,7 @@ impl EditConfigState {
     }
 }
 
-impl EditConfigState {
+impl EditConfig {
     fn extract_config_buffer_val(&mut self, editable_config: &EditableConfig) -> String {
         let mut ret_value = String::new();
         if let Some(config_value) = self.config_buffer.get_mut(editable_config) {

--- a/src/app/screens/latest.rs
+++ b/src/app/screens/latest.rs
@@ -7,7 +7,7 @@ use patch_hub::lore::{
 };
 
 #[derive(Getters)]
-pub struct LatestPatchsetsState {
+pub struct LatestPatchsets {
     lore_session: LoreSession,
     lore_api_client: BlockingLoreAPIClient,
     target_list: String,
@@ -16,13 +16,13 @@ pub struct LatestPatchsetsState {
     page_size: usize,
 }
 
-impl LatestPatchsetsState {
+impl LatestPatchsets {
     pub fn new(
         target_list: String,
         page_size: usize,
         lore_api_client: BlockingLoreAPIClient,
-    ) -> LatestPatchsetsState {
-        LatestPatchsetsState {
+    ) -> LatestPatchsets {
+        LatestPatchsets {
             lore_session: LoreSession::new(target_list.clone()),
             lore_api_client,
             target_list,

--- a/src/app/screens/mail_list.rs
+++ b/src/app/screens/mail_list.rs
@@ -3,7 +3,7 @@ use patch_hub::lore::{
     lore_api_client::BlockingLoreAPIClient, lore_session, mailing_list::MailingList,
 };
 
-pub struct MailingListSelectionState {
+pub struct MailingListSelection {
     pub mailing_lists: Vec<MailingList>,
     pub target_list: String,
     pub possible_mailing_lists: Vec<MailingList>,
@@ -12,7 +12,7 @@ pub struct MailingListSelectionState {
     pub lore_api_client: BlockingLoreAPIClient,
 }
 
-impl MailingListSelectionState {
+impl MailingListSelection {
     pub fn refresh_available_mailing_lists(&mut self) -> color_eyre::Result<()> {
         match lore_session::fetch_available_lists(&self.lore_api_client) {
             Ok(available_mailing_lists) => {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -61,10 +61,10 @@ where
 {
     match app.current_screen {
         CurrentScreen::MailingListSelection => {
-            if app.mailing_list_selection_state.mailing_lists.is_empty() {
+            if app.mailing_list_selection.mailing_lists.is_empty() {
                 terminal = loading_screen! {
                     terminal, "Fetching mailing lists" => {
-                        app.mailing_list_selection_state.refresh_available_mailing_lists()?;
+                        app.mailing_list_selection.refresh_available_mailing_lists()?;
                     }
                 };
             }
@@ -80,7 +80,7 @@ where
                     }
                 };
 
-                app.mailing_list_selection_state.clear_target_list();
+                app.mailing_list_selection.clear_target_list();
             }
         }
         CurrentScreen::BookmarkedPatchsets => {

--- a/src/handler/bookmarked.rs
+++ b/src/handler/bookmarked.rs
@@ -33,7 +33,7 @@ where
             terminal = loading_screen! {
                 terminal,
                 "Loading patchset" => {
-                    app.init_patchset_details_and_actions_state(CurrentScreen::BookmarkedPatchsets)?;
+                    app.init_details_actions(CurrentScreen::BookmarkedPatchsets)?;
                     app.set_current_screen(CurrentScreen::PatchsetDetails);
                 }
             };

--- a/src/handler/details_actions.rs
+++ b/src/handler/details_actions.rs
@@ -17,7 +17,7 @@ pub fn handle_patchset_details<B: Backend>(
     key: KeyEvent,
     terminal: &mut Terminal<B>,
 ) -> color_eyre::Result<()> {
-    let patchset_details_and_actions = app.patchset_details_and_actions_state.as_mut().unwrap();
+    let patchset_details_and_actions = app.details_actions.as_mut().unwrap();
 
     if key.modifiers.contains(KeyModifiers::SHIFT) {
         if let KeyCode::Char('G') = key.code {
@@ -51,7 +51,7 @@ pub fn handle_patchset_details<B: Backend>(
         KeyCode::Esc => {
             let ps_da_clone = patchset_details_and_actions.last_screen.clone();
             app.set_current_screen(ps_da_clone);
-            app.reset_patchset_details_and_actions_state();
+            app.reset_details_actions();
         }
         KeyCode::Char('j') | KeyCode::Down => {
             patchset_details_and_actions.preview_scroll_down(1);

--- a/src/handler/edit_config.rs
+++ b/src/handler/edit_config.rs
@@ -24,7 +24,7 @@ pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()
             },
             false => match key.code {
                 KeyCode::Esc => {
-                    app.reset_edit_config_state();
+                    app.reset_edit_config();
                     app.set_current_screen(CurrentScreen::MailingListSelection);
                 }
                 KeyCode::Char('e') => {
@@ -39,7 +39,7 @@ pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()
                 KeyCode::Enter => {
                     app.consolidate_edit_config();
                     app.config.save_patch_hub_config()?;
-                    app.reset_edit_config_state();
+                    app.reset_edit_config();
                     app.set_current_screen(CurrentScreen::MailingListSelection);
                 }
                 _ => {}

--- a/src/handler/latest.rs
+++ b/src/handler/latest.rs
@@ -22,7 +22,7 @@ where
 
     match key.code {
         KeyCode::Esc => {
-            app.reset_latest_patchsets_state();
+            app.reset_latest_patchsets();
             app.set_current_screen(CurrentScreen::MailingListSelection);
         }
         KeyCode::Char('j') | KeyCode::Down => {
@@ -48,7 +48,7 @@ where
             terminal = loading_screen! {
                 terminal,
                 "Loading patchset" => {
-                    app.init_patchset_details_and_actions_state(CurrentScreen::LatestPatchsets)?;
+                    app.init_details_actions(CurrentScreen::LatestPatchsets)?;
                     app.set_current_screen(CurrentScreen::PatchsetDetails);
                 }
             };

--- a/src/handler/mail_list.rs
+++ b/src/handler/mail_list.rs
@@ -20,8 +20,8 @@ where
 {
     match key.code {
         KeyCode::Enter => {
-            if app.mailing_list_selection_state.has_valid_target_list() {
-                app.init_latest_patchsets_state();
+            if app.mailing_list_selection.has_valid_target_list() {
+                app.init_latest_patchsets();
                 let list_name = app
                     .latest_patchsets_state
                     .as_ref()
@@ -33,7 +33,7 @@ where
                     terminal,
                     format!("Fetching patchsets from {}", list_name) => {
                         app.latest_patchsets_state.as_mut().unwrap().fetch_current_page()?;
-                        app.mailing_list_selection_state.clear_target_list();
+                        app.mailing_list_selection.clear_target_list();
                         app.set_current_screen(CurrentScreen::LatestPatchsets);
                     }
                 };
@@ -43,13 +43,13 @@ where
             terminal = loading_screen! {
                 terminal,
                 "Refreshing lists" => {
-                    app.mailing_list_selection_state
+                    app.mailing_list_selection
                         .refresh_available_mailing_lists()?;
                 }
             };
         }
         KeyCode::F(2) => {
-            app.init_edit_config_state();
+            app.init_edit_config();
             app.set_current_screen(CurrentScreen::EditConfig);
         }
         KeyCode::F(1) => {
@@ -58,26 +58,24 @@ where
                 .bookmarked_patchsets
                 .is_empty()
             {
-                app.mailing_list_selection_state.clear_target_list();
+                app.mailing_list_selection.clear_target_list();
                 app.set_current_screen(CurrentScreen::BookmarkedPatchsets);
             }
         }
         KeyCode::Backspace => {
-            app.mailing_list_selection_state
-                .remove_last_target_list_char();
+            app.mailing_list_selection.remove_last_target_list_char();
         }
         KeyCode::Esc => {
             return Ok(ControlFlow::Break(()));
         }
         KeyCode::Char(ch) => {
-            app.mailing_list_selection_state
-                .push_char_to_target_list(ch);
+            app.mailing_list_selection.push_char_to_target_list(ch);
         }
         KeyCode::Down => {
-            app.mailing_list_selection_state.highlight_below_list();
+            app.mailing_list_selection.highlight_below_list();
         }
         KeyCode::Up => {
-            app.mailing_list_selection_state.highlight_above_list();
+            app.mailing_list_selection.highlight_above_list();
         }
         _ => {}
     }

--- a/src/ui/bookmarked.rs
+++ b/src/ui/bookmarked.rs
@@ -1,5 +1,5 @@
 use crate::app;
-use app::screens::bookmarked::BookmarkedPatchsetsState;
+use app::screens::bookmarked::BookmarkedPatchsets;
 use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
@@ -8,19 +8,11 @@ use ratatui::{
     Frame,
 };
 
-pub fn render_main(
-    f: &mut Frame,
-    bookmarked_patchsets_state: &BookmarkedPatchsetsState,
-    chunk: Rect,
-) {
-    let patchset_index = bookmarked_patchsets_state.patchset_index;
+pub fn render_main(f: &mut Frame, bookmarked_patchsets: &BookmarkedPatchsets, chunk: Rect) {
+    let patchset_index = bookmarked_patchsets.patchset_index;
     let mut list_items = Vec::<ListItem>::new();
 
-    for (index, patch) in bookmarked_patchsets_state
-        .bookmarked_patchsets
-        .iter()
-        .enumerate()
-    {
+    for (index, patch) in bookmarked_patchsets.bookmarked_patchsets.iter().enumerate() {
         let patch_title = format!("{:width$}", patch.title(), width = 70);
         let patch_title = format!("{:.width$}", patch_title, width = 70);
         let patch_author = format!("{:width$}", patch.author().name, width = 30);

--- a/src/ui/details_actions.rs
+++ b/src/ui/details_actions.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use crate::app::{screens::details_actions::PatchsetAction, App};
 
 fn render_details_and_actions(f: &mut Frame, app: &App, details_chunk: Rect, actions_chunk: Rect) {
-    let patchset_details_and_actions = app.patchset_details_and_actions_state.as_ref().unwrap();
+    let patchset_details_and_actions = app.details_actions.as_ref().unwrap();
 
     let patchset_details = &patchset_details_and_actions.representative_patch;
     let patchset_details = vec![
@@ -113,7 +113,7 @@ fn render_details_and_actions(f: &mut Frame, app: &App, details_chunk: Rect, act
 }
 
 fn render_preview(f: &mut Frame, app: &App, chunk: Rect) {
-    let patchset_details_and_actions = app.patchset_details_and_actions_state.as_ref().unwrap();
+    let patchset_details_and_actions = app.details_actions.as_ref().unwrap();
 
     let preview_index = patchset_details_and_actions.preview_index;
 
@@ -149,7 +149,7 @@ fn render_preview(f: &mut Frame, app: &App, chunk: Rect) {
 }
 
 pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
-    let patchset_details_and_actions = app.patchset_details_and_actions_state.as_ref().unwrap();
+    let patchset_details_and_actions = app.details_actions.as_ref().unwrap();
 
     if patchset_details_and_actions.preview_fullscreen {
         render_preview(f, app, chunk);

--- a/src/ui/edit_config.rs
+++ b/src/ui/edit_config.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use crate::app::App;
 
 pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
-    let edit_config_state = app.edit_config_state.as_ref().unwrap();
+    let edit_config = app.edit_config_state.as_ref().unwrap();
     let mut constraints = Vec::new();
 
     for _ in 0..(chunk.height / 3) {
@@ -21,40 +21,36 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
         .constraints(constraints)
         .split(chunk);
 
-    let highlighted_entry = edit_config_state.highlighted();
-    for i in 0..edit_config_state.config_count() {
+    let highlighted_entry = edit_config.highlighted();
+    for i in 0..edit_config.config_count() {
         if i + 1 > config_chunks.len() {
             break;
         }
 
-        let (config, value) = edit_config_state.config(i);
-        let value = Line::from(
-            if edit_config_state.is_editing() && i == highlighted_entry {
-                vec![
-                    Span::styled(edit_config_state.curr_edit().to_string(), Style::default()),
-                    Span::styled(" ", Style::default().bg(Color::White)),
-                ]
-            } else {
-                vec![Span::from(value)]
-            },
-        );
+        let (config, value) = edit_config.config(i);
+        let value = Line::from(if edit_config.is_editing() && i == highlighted_entry {
+            vec![
+                Span::styled(edit_config.curr_edit().to_string(), Style::default()),
+                Span::styled(" ", Style::default().bg(Color::White)),
+            ]
+        } else {
+            vec![Span::from(value)]
+        });
 
         let config_entry = Paragraph::new(value)
             .centered()
             .block(Block::default().borders(Borders::ALL).title(config))
-            .style(
-                if i == highlighted_entry && edit_config_state.is_editing() {
-                    Style::default()
-                        .fg(Color::LightYellow)
-                        .add_modifier(Modifier::BOLD)
-                } else if i == highlighted_entry {
-                    Style::default()
-                        .fg(Color::DarkGray)
-                        .add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default()
-                },
-            );
+            .style(if i == highlighted_entry && edit_config.is_editing() {
+                Style::default()
+                    .fg(Color::LightYellow)
+                    .add_modifier(Modifier::BOLD)
+            } else if i == highlighted_entry {
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            });
 
         f.render_widget(config_entry, config_chunks[i]);
     }

--- a/src/ui/mail_list.rs
+++ b/src/ui/mail_list.rs
@@ -9,10 +9,10 @@ use ratatui::{
 use crate::app::App;
 
 pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
-    let highlighted_list_index = app.mailing_list_selection_state.highlighted_list_index;
+    let highlighted_list_index = app.mailing_list_selection.highlighted_list_index;
     let mut list_items = Vec::<ListItem>::new();
 
-    for mailing_list in &app.mailing_list_selection_state.possible_mailing_lists {
+    for mailing_list in &app.mailing_list_selection.possible_mailing_lists {
         list_items.push(ListItem::new(
             Line::from(vec![
                 Span::styled(
@@ -53,32 +53,32 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
 pub fn mode_footer_text(app: &App) -> Vec<Span> {
     let mut text_area = Span::default();
 
-    if app.mailing_list_selection_state.target_list.is_empty() {
+    if app.mailing_list_selection.target_list.is_empty() {
         text_area = Span::styled("type the target list", Style::default().fg(Color::DarkGray))
     } else {
-        for mailing_list in &app.mailing_list_selection_state.mailing_lists {
+        for mailing_list in &app.mailing_list_selection.mailing_lists {
             if mailing_list
                 .name()
-                .eq(&app.mailing_list_selection_state.target_list)
+                .eq(&app.mailing_list_selection.target_list)
             {
                 text_area = Span::styled(
-                    &app.mailing_list_selection_state.target_list,
+                    &app.mailing_list_selection.target_list,
                     Style::default().fg(Color::Green),
                 );
                 break;
             } else if mailing_list
                 .name()
-                .starts_with(&app.mailing_list_selection_state.target_list)
+                .starts_with(&app.mailing_list_selection.target_list)
             {
                 text_area = Span::styled(
-                    &app.mailing_list_selection_state.target_list,
+                    &app.mailing_list_selection.target_list,
                     Style::default().fg(Color::LightCyan),
                 );
             }
         }
         if text_area.content.is_empty() {
             text_area = Span::styled(
-                &app.mailing_list_selection_state.target_list,
+                &app.mailing_list_selection.target_list,
                 Style::default().fg(Color::Red),
             );
         }


### PR DESCRIPTION
To streamline code readability, the App struct's fields representing screen states have been renamed, removing the "State" suffix. Each field already represents a distinct screen state, so this suffix was unnecessary and redundant. This refactoring aligns with the intent to keep App minimal and coherent without sacrificing clarity.

Signed-off-by: gabrielsrd <alvesgabriel@usp.br>