### PR TITLE
Feat: PopUps

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -14,7 +14,7 @@ use screens::{
     mail_list::MailingListSelectionState,
     CurrentScreen,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, LinkedList};
 
 use crate::utils;
 
@@ -33,7 +33,7 @@ pub struct App {
     pub reviewed_patchsets: HashMap<String, Vec<usize>>,
     pub config: Config,
     pub lore_api_client: BlockingLoreAPIClient,
-    pub popup: Option<Box<dyn PopUp>>,
+    pub popup: LinkedList<Box<dyn PopUp>>,
 }
 
 impl App {
@@ -79,7 +79,7 @@ impl App {
             reviewed_patchsets,
             config,
             lore_api_client,
-            popup: None,
+            popup: LinkedList::new(),
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::log_on_error;
+use crate::{log_on_error, ui::popup::PopUp};
 use ansi_to_tui::IntoText;
 use color_eyre::eyre::bail;
 use config::Config;
@@ -33,6 +33,7 @@ pub struct App {
     pub reviewed_patchsets: HashMap<String, Vec<usize>>,
     pub config: Config,
     pub lore_api_client: BlockingLoreAPIClient,
+    pub popup: Option<Box<dyn PopUp>>,
 }
 
 impl App {
@@ -78,6 +79,7 @@ impl App {
             reviewed_patchsets,
             config,
             lore_api_client,
+            popup: None,
         }
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -35,9 +35,9 @@ fn key_handling<B>(
 where
     B: Backend + Send + 'static,
 {
-    if let Some(popup) = app.popup.as_mut() {
+    if let Some(popup) = app.popup.back_mut() {
         if key.code == KeyCode::Esc {
-            app.popup = None;
+            app.popup.pop_back();
         } else {
             popup.handle(key)?;
         }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -42,8 +42,6 @@ where
             popup.handle(key)?;
         }
     } else {
-
-        
         match app.current_screen {
             CurrentScreen::MailingListSelection => {
                 return handle_mailing_list_selection(app, key, terminal);

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -35,21 +35,31 @@ fn key_handling<B>(
 where
     B: Backend + Send + 'static,
 {
-    match app.current_screen {
-        CurrentScreen::MailingListSelection => {
-            return handle_mailing_list_selection(app, key, terminal);
+    if let Some(popup) = app.popup.as_mut() {
+        if key.code == KeyCode::Esc {
+            app.popup = None;
+        } else {
+            popup.handle(key)?;
         }
-        CurrentScreen::BookmarkedPatchsets => {
-            return handle_bookmarked_patchsets(app, key, terminal);
-        }
-        CurrentScreen::PatchsetDetails => {
-            handle_patchset_details(app, key, &mut terminal)?;
-        }
-        CurrentScreen::EditConfig => {
-            handle_edit_config(app, key)?;
-        }
-        CurrentScreen::LatestPatchsets => {
-            return handle_latest_patchsets(app, key, terminal);
+    } else {
+
+        
+        match app.current_screen {
+            CurrentScreen::MailingListSelection => {
+                return handle_mailing_list_selection(app, key, terminal);
+            }
+            CurrentScreen::BookmarkedPatchsets => {
+                return handle_bookmarked_patchsets(app, key, terminal);
+            }
+            CurrentScreen::PatchsetDetails => {
+                handle_patchset_details(app, key, &mut terminal)?;
+            }
+            CurrentScreen::EditConfig => {
+                handle_edit_config(app, key)?;
+            }
+            CurrentScreen::LatestPatchsets => {
+                return handle_latest_patchsets(app, key, terminal);
+            }
         }
     }
     Ok(ControlFlow::Continue(terminal))

--- a/src/handler/bookmarked.rs
+++ b/src/handler/bookmarked.rs
@@ -3,6 +3,7 @@ use std::ops::ControlFlow;
 use crate::{
     app::{screens::CurrentScreen, App},
     loading_screen,
+    ui::popup::{help::HelpPopUpBuilder, PopUp},
 };
 use ratatui::{
     crossterm::event::{KeyCode, KeyEvent},
@@ -19,6 +20,10 @@ where
     B: Backend + Send + 'static,
 {
     match key.code {
+        KeyCode::Char('?') => {
+            let popup = generate_help_popup();
+            app.popup = Some(popup);
+        }
         KeyCode::Esc => {
             app.bookmarked_patchsets_state.patchset_index = 0;
             app.set_current_screen(CurrentScreen::MailingListSelection);
@@ -41,4 +46,18 @@ where
         _ => {}
     }
     Ok(ControlFlow::Continue(terminal))
+}
+
+pub fn generate_help_popup() -> Box<dyn PopUp> {
+    let popup = HelpPopUpBuilder::new()
+        .title("Bookmarked Patchsets")
+        .description("This screen shows all the patchsets you have bookmarked.\nThis is quite useful to keep track of patchsets you are interested in take a look later.")
+        .keybind("ESC", "Exit")
+        .keybind("ENTER", "See details of the selected patchset")
+        .keybind("?", "Show this help screen")
+        .keybind("j/🡇", "Down")
+        .keybind("k/🡅", "Up")
+        .build();
+
+    Box::new(popup)
 }

--- a/src/handler/bookmarked.rs
+++ b/src/handler/bookmarked.rs
@@ -22,7 +22,7 @@ where
     match key.code {
         KeyCode::Char('?') => {
             let popup = generate_help_popup();
-            app.popup = Some(popup);
+            app.popup.push_back(popup);
         }
         KeyCode::Esc => {
             app.bookmarked_patchsets_state.patchset_index = 0;

--- a/src/handler/details_actions.rs
+++ b/src/handler/details_actions.rs
@@ -51,7 +51,7 @@ pub fn handle_patchset_details<B: Backend>(
     match key.code {
         KeyCode::Char('?') => {
             let popup = generate_help_popup();
-            app.popup = Some(popup);
+            app.popup.push_back(popup);
         }
         KeyCode::Esc => {
             let ps_da_clone = patchset_details_and_actions.last_screen.clone();

--- a/src/handler/details_actions.rs
+++ b/src/handler/details_actions.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use crate::{
     app::{screens::CurrentScreen, App},
+    ui::popup::{help::HelpPopUpBuilder, PopUp},
     utils,
 };
 use ratatui::{
@@ -48,6 +49,10 @@ pub fn handle_patchset_details<B: Backend>(
     }
 
     match key.code {
+        KeyCode::Char('?') => {
+            let popup = generate_help_popup();
+            app.popup = Some(popup);
+        }
         KeyCode::Esc => {
             let ps_da_clone = patchset_details_and_actions.last_screen.clone();
             app.set_current_screen(ps_da_clone);
@@ -109,4 +114,28 @@ pub fn handle_patchset_details<B: Backend>(
         _ => {}
     }
     Ok(())
+}
+
+pub fn generate_help_popup() -> Box<dyn PopUp> {
+    let popup = HelpPopUpBuilder::new()
+        .title("Patchset Details and Actions")
+        .description("This screen displays the details of a patchset and allows you to perform actions on it.\nA series of actions are available to you, they are:\n - Bookmark: Save the patchset for later\n - Reply with Reviewed-by: Reply to the patchset with a Reviewed-by tag")
+        .keybind("ESC", "Exit")
+        .keybind("ENTER", "Consolidate marked actions")
+        .keybind("?", "Show this help screen")
+        .keybind("j/🡇", "Scroll down")
+        .keybind("k/🡅", "Scroll up")
+        .keybind("h/🡄", "Pan left")
+        .keybind("l/🡆", "Pan right")
+        .keybind("0", "Go to start of line")
+        .keybind("g", "Go to first line")
+        .keybind("G", "Go to last line")
+        .keybind("f", "Toggle fullscreen")
+        .keybind("n", "Preview next patch")
+        .keybind("p", "Preview previous patch")
+        .keybind("b", "Toggle bookmark action")
+        .keybind("r", "Toggle reply with Reviewed-by action")
+        .build();
+
+    Box::new(popup)
 }

--- a/src/handler/edit_config.rs
+++ b/src/handler/edit_config.rs
@@ -1,4 +1,7 @@
-use crate::app::{screens::CurrentScreen, App};
+use crate::{
+    app::{screens::CurrentScreen, App},
+    ui::popup::{help::HelpPopUpBuilder, PopUp},
+};
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 
 pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()> {
@@ -23,6 +26,10 @@ pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()
                 _ => {}
             },
             false => match key.code {
+                KeyCode::Char('?') => {
+                    let popup = generate_help_popup();
+                    app.popup = Some(popup);
+                }
                 KeyCode::Esc => {
                     app.reset_edit_config_state();
                     app.set_current_screen(CurrentScreen::MailingListSelection);
@@ -47,4 +54,20 @@ pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()
         }
     }
     Ok(())
+}
+
+// TODO: Move this to a more appropriate place
+pub fn generate_help_popup() -> Box<dyn PopUp> {
+    let popup = HelpPopUpBuilder::new()
+        .title("Edit Config")
+        .description("This screen allows you to edit the configuration options for Patch Hub.\nMore configurations may be available in the configuration file.")
+        .keybind("ESC", "Exit")
+        .keybind("ENTER", "Save changes")
+        .keybind("?", "Show this help screen")
+        .keybind("j/🡇", "Down")
+        .keybind("k/🡅", "Up")
+        .keybind("e", "Toggle editing for a configuration option")
+        .build();
+
+    Box::new(popup)
 }

--- a/src/handler/edit_config.rs
+++ b/src/handler/edit_config.rs
@@ -28,7 +28,7 @@ pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()
             false => match key.code {
                 KeyCode::Char('?') => {
                     let popup = generate_help_popup();
-                    app.popup = Some(popup);
+                    app.popup.push_back(popup);
                 }
                 KeyCode::Esc => {
                     app.reset_edit_config_state();

--- a/src/handler/latest.rs
+++ b/src/handler/latest.rs
@@ -3,6 +3,7 @@ use std::ops::ControlFlow;
 use crate::{
     app::{screens::CurrentScreen, App},
     loading_screen,
+    ui::popup::{help::HelpPopUpBuilder, PopUp},
 };
 use ratatui::{
     crossterm::event::{KeyCode, KeyEvent},
@@ -21,6 +22,10 @@ where
     let latest_patchsets = app.latest_patchsets_state.as_mut().unwrap();
 
     match key.code {
+        KeyCode::Char('?') => {
+            let popup = generate_help_popup();
+            app.popup = Some(popup);
+        }
         KeyCode::Esc => {
             app.reset_latest_patchsets_state();
             app.set_current_screen(CurrentScreen::MailingListSelection);
@@ -56,4 +61,19 @@ where
         _ => {}
     }
     Ok(ControlFlow::Continue(terminal))
+}
+
+pub fn generate_help_popup() -> Box<dyn PopUp> {
+    let popup = HelpPopUpBuilder::new()
+        .title("Latest Patchsets")
+        .description("This screen allows you to see a list of the latest patchsets from a mailing list.\nYou might also be able to view the details of a patchset.")
+        .keybind("ESC", "Exit")
+        .keybind("ENTER", "See details of the selected patchset")
+        .keybind("?", "Show this help screen")
+        .keybind("j/🡇", "Down")
+        .keybind("k/🡅", "Up")
+        .keybind("l/🡆", "Next page")
+        .keybind("h/🡄", "Previous page")
+        .build();
+    Box::new(popup)
 }

--- a/src/handler/latest.rs
+++ b/src/handler/latest.rs
@@ -24,7 +24,7 @@ where
     match key.code {
         KeyCode::Char('?') => {
             let popup = generate_help_popup();
-            app.popup = Some(popup);
+            app.popup.push_back(popup);
         }
         KeyCode::Esc => {
             app.reset_latest_patchsets_state();

--- a/src/handler/mail_list.rs
+++ b/src/handler/mail_list.rs
@@ -22,7 +22,7 @@ where
     match key.code {
         KeyCode::Char('?') => {
             let popup = generate_help_popup();
-            app.popup = Some(popup);
+            app.popup.push_back(popup);
         }
         KeyCode::Enter => {
             if app.mailing_list_selection_state.has_valid_target_list() {

--- a/src/handler/mail_list.rs
+++ b/src/handler/mail_list.rs
@@ -3,6 +3,7 @@ use std::ops::ControlFlow;
 use crate::{
     app::{screens::CurrentScreen, App},
     loading_screen,
+    ui::popup::{help::HelpPopUpBuilder, PopUp},
 };
 use ratatui::{
     crossterm::event::{KeyCode, KeyEvent},
@@ -19,6 +20,10 @@ where
     B: Backend + Send + 'static,
 {
     match key.code {
+        KeyCode::Char('?') => {
+            let popup = generate_help_popup();
+            app.popup = Some(popup);
+        }
         KeyCode::Enter => {
             if app.mailing_list_selection_state.has_valid_target_list() {
                 app.init_latest_patchsets_state();
@@ -82,4 +87,22 @@ where
         _ => {}
     }
     Ok(ControlFlow::Continue(terminal))
+}
+
+// TODO: Move this to a more appropriate place
+pub fn generate_help_popup() -> Box<dyn PopUp> {
+    let popup = HelpPopUpBuilder::new()
+        .title("Mailing List Selection")
+        .description("This is the mailing list selection screen.\nYou can select a mailing list by typing the name of the list.")
+        .keybind("ESC", "Exit")
+        .keybind("ENTER", "Open the selected mailing list")
+        .keybind("?", "Show this help screen")
+        .keybind("🡇", "Down")
+        .keybind("🡅", "Up")
+        .keybind("F1", "Show bookmarked patchsets")
+        .keybind("F2", "Edit config options")
+        .keybind("F5", "Refresh lists")
+        .build();
+
+    Box::new(popup)
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -40,7 +40,6 @@ pub fn draw_ui(f: &mut Frame, app: &App) {
 
     navigation_bar::render(f, app, chunks[2]);
 
-
     app.popup.back().inspect(|p| {
         let (x, y) = p.dimensions();
         let rect = centered_rect(x, y, f.area());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -41,7 +41,7 @@ pub fn draw_ui(f: &mut Frame, app: &App) {
     navigation_bar::render(f, app, chunks[2]);
 
 
-    app.popup.as_ref().inspect(|p| {
+    app.popup.back().inspect(|p| {
         let (x, y) = p.dimensions();
         let rect = centered_rect(x, y, f.area());
         p.render(f, rect);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -14,6 +14,7 @@ mod latest;
 pub mod loading_screen;
 mod mail_list;
 mod navigation_bar;
+pub mod popup;
 
 pub fn draw_ui(f: &mut Frame, app: &App) {
     let chunks = Layout::default()
@@ -38,6 +39,13 @@ pub fn draw_ui(f: &mut Frame, app: &App) {
     }
 
     navigation_bar::render(f, app, chunks[2]);
+
+
+    app.popup.as_ref().inspect(|p| {
+        let (x, y) = p.dimensions();
+        let rect = centered_rect(x, y, f.area());
+        p.render(f, rect);
+    });
 }
 
 fn render_title(f: &mut Frame, chunk: Rect) {

--- a/src/ui/bookmarked.rs
+++ b/src/ui/bookmarked.rs
@@ -72,7 +72,7 @@ pub fn mode_footer_text() -> Vec<Span<'static>> {
 
 pub fn keys_hint() -> Span<'static> {
     Span::styled(
-        "(ESC) to return | (ENTER) to select | ( j / 🡇 ) down | ( k / 🡅 ) up",
+        "(ESC) to return | (ENTER) to select | (?) help",
         Style::default().fg(Color::Red),
     )
 }

--- a/src/ui/details_actions.rs
+++ b/src/ui/details_actions.rs
@@ -183,7 +183,7 @@ pub fn mode_footer_text() -> Vec<Span<'static>> {
 
 pub fn keys_hint() -> Span<'static> {
     Span::styled(
-        "(ESC) to return | (ENTER) run actions | (jkhl / 🡇 🡅 🡄 🡆 ) | (n) next patch | (p) previous patch | (f) fullscreen",
+        "(ESC) to return | (ENTER) run actions | (?) help",
         Style::default().fg(Color::Red),
     )
 }

--- a/src/ui/edit_config.rs
+++ b/src/ui/edit_config.rs
@@ -77,7 +77,7 @@ pub fn keys_hint(app: &App) -> Span {
             Style::default().fg(Color::Red),
         ),
         false => Span::styled(
-            "(ESC) cancel | (ENTER) save | (e) edit | (jk| 🡇 🡅 ) down up",
+            "(ESC) cancel | (ENTER) save | (e) edit | (?) help",
             Style::default().fg(Color::Red),
         ),
     }

--- a/src/ui/latest.rs
+++ b/src/ui/latest.rs
@@ -84,7 +84,7 @@ pub fn mode_footer_text(app: &App) -> Vec<Span> {
 
 pub fn keys_hint() -> Span<'static> {
     Span::styled(
-        "(ESC) to return | (ENTER) to select | ( j / 🡇 ) down | ( k / 🡅 ) up | ( h / 🡄 ) previous page | ( l / 🡆 ) next page",
+        "(ESC) to return | (ENTER) to select | ( h / 🡄 ) previous page | ( l / 🡆 ) next page | (?) help",
         Style::default().fg(Color::Red),
     )
 }

--- a/src/ui/mail_list.rs
+++ b/src/ui/mail_list.rs
@@ -92,7 +92,7 @@ pub fn mode_footer_text(app: &App) -> Vec<Span> {
 
 pub fn keys_hint() -> Span<'static> {
     Span::styled(
-        "(ESC) to quit | (ENTER) to confirm | (🡇 ) down | (🡅 ) up | (F1) to bookmarked patchsets | (F2) edit config | (F5) refresh lists",
+        "(ESC) to quit | (ENTER) to confirm | (?) help",
         Style::default().fg(Color::Red),
     )
 }

--- a/src/ui/popup.rs
+++ b/src/ui/popup.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use ratatui::{crossterm::event::KeyEvent, layout::Rect, Frame};
 
+pub mod help;
 
 /// A trait that represents a popup that can be rendered on top of a screen
 pub trait PopUp: Debug {

--- a/src/ui/popup.rs
+++ b/src/ui/popup.rs
@@ -1,0 +1,23 @@
+use std::fmt::Debug;
+
+use ratatui::{crossterm::event::KeyEvent, layout::Rect, Frame};
+
+
+/// A trait that represents a popup that can be rendered on top of a screen
+pub trait PopUp: Debug {
+    /// Returns the dimensions of the popup in percentage of the screen
+    /// (width, height)
+    ///
+    /// Those dimensions are used to create the `chunk` used in the render function
+    fn dimensions(&self) -> (u16, u16);
+
+    /// Renders the popup on the given frame using the given chunk
+    /// This chunk is a centered rectangle with the dimensions returned by `dimensions`
+    fn render(&self, f: &mut Frame, chunk: Rect);
+
+    /// Handles the key event for the popup
+    ///
+    /// Is important to notice that except for the 'ESC' key, all other keys are hijacked by the popup
+    /// So the screens handlers won't be called
+    fn handle(&mut self, key: KeyEvent) -> color_eyre::Result<()>;
+}

--- a/src/ui/popup/help.rs
+++ b/src/ui/popup/help.rs
@@ -1,0 +1,193 @@
+use ratatui::{
+    crossterm::event::KeyCode,
+    layout::Alignment,
+    style::Stylize,
+    widgets::{Clear, Paragraph},
+};
+use std::fmt::Display;
+
+use super::PopUp;
+
+/// A popup that displays a help message
+///
+/// This popup is used to display a help message with a title, a description and a list of keybinds.
+/// It's meant to produce a new instance for each screen that needs a help popup and then the handler of this screen
+/// will be responsible for pushing the popup to the app when the user presses the help key (`?` is the suggested default)
+///
+/// The title is displayed at the top center of the popup
+/// The description is displayed below the title and is optional
+/// The keybinds (also optional) are displayed in a table format with the key on the left and the help message on the right
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct HelpPopUp {
+    title: Option<String>,
+    description: Option<String>,
+    keybinds: String,
+    offset: (u16, u16),
+    max_offset: (u16, u16),
+    lines: u16,
+    columns: u16,
+    dimensions: (u16, u16),
+}
+
+/// A helper struct to build a `HelpPopUp`
+#[derive(Debug, Default)]
+pub struct HelpPopUpBuilder {
+    title: Option<String>,
+    description: Option<String>,
+    keybinds: Vec<(String, String)>,
+}
+
+impl HelpPopUpBuilder {
+    /// Creates a new empty `HelpPopUpBuilder`
+    pub fn new() -> Self {
+        Self {
+            title: None,
+            description: None,
+            keybinds: Vec::new(),
+        }
+    }
+
+    /// Defines the title of the popup
+    ///
+    /// The title is displayed at the top center of the popup and
+    /// it's recommended to be short and be the name of the screen
+    pub fn title(mut self, title: &str) -> Self {
+        self.title = Some(title.to_string());
+        self
+    }
+
+    /// Defines the description of the popup
+    ///
+    /// The description is displayed below the title and is optional as its meant
+    /// only to give some extra information about the screen for the user
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
+    }
+
+    /// Adds a new help entry to the popup
+    ///
+    /// A help entry is composed of a key and a help message
+    ///
+    /// The keybinds are listed in order of insertion under a `Keybinds` section in the pop-up body
+    pub fn keybind<K: Display, H: Display>(mut self, key: K, help: H) -> Self {
+        self.keybinds.push((key.to_string(), help.to_string()));
+        self
+    }
+
+    /// Builds the `HelpPopUp` with the given parameters
+    pub fn build(self) -> HelpPopUp {
+        let key_len = self
+            .keybinds
+            .iter()
+            .fold(0, |acc, (k, _)| if k.len() > acc { k.len() } else { acc });
+
+        let help = self.keybinds.iter().fold(String::new(), |acc, (k, v)| {
+            acc + &format!("{:>width$}: {}\n", k, v, width = key_len)
+        });
+
+        let lines = self.keybinds.len() as u16;
+
+        let columns = self.keybinds.iter().fold(0, |acc, (k, v)| {
+            let len = (k.len() + v.len()) as u16;
+            if len > acc {
+                len
+            } else {
+                acc
+            }
+        });
+
+        let dimensions = (50, 50); // TODO: Calculate percentage based on the lines and screen size
+
+        HelpPopUp {
+            title: self.title,
+            description: self.description,
+            keybinds: help,
+            offset: (0, 0),
+            max_offset: (lines, columns),
+            columns: columns + 2,
+            lines,
+            dimensions,
+        }
+    }
+}
+
+impl PopUp for HelpPopUp {
+    fn dimensions(&self) -> (u16, u16) {
+        self.dimensions
+    }
+
+    fn render(&self, f: &mut ratatui::Frame, chunk: ratatui::prelude::Rect) {
+        let block = ratatui::widgets::Block::default()
+            .title(self.to_string())
+            .title_alignment(Alignment::Center)
+            .title_style(ratatui::style::Style::default().bold().blue())
+            .borders(ratatui::widgets::Borders::ALL)
+            .border_type(ratatui::widgets::BorderType::Double)
+            .style(ratatui::style::Style::default());
+
+        // Push the description
+        let text = if let Some(description) = &self.description {
+            format!("{}\n\n", description)
+        } else {
+            String::new()
+        };
+
+        // Push the help entries
+        let text = if self.keybinds.is_empty() {
+            text
+        } else {
+            format!("{}Keybinds:\n{}", text, self.keybinds)
+        };
+
+        let text = Paragraph::new(text)
+            .style(ratatui::style::Style::default())
+            .block(block)
+            .alignment(ratatui::layout::Alignment::Left)
+            .scroll(self.offset);
+
+        f.render_widget(Clear, chunk);
+        f.render_widget(text, chunk);
+    }
+
+    fn handle(&mut self, key: ratatui::crossterm::event::KeyEvent) -> color_eyre::Result<()> {
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.offset.0 > 0 {
+                    self.offset.0 -= 1;
+                }
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if self.offset.0 < self.max_offset.0 {
+                    self.offset.0 += 1;
+                }
+            }
+            KeyCode::Left | KeyCode::Char('h') => {
+                if self.offset.1 > 0 {
+                    self.offset.1 -= 1;
+                }
+            }
+            KeyCode::Right | KeyCode::Char('l') => {
+                if self.offset.1 < self.max_offset.1 {
+                    self.offset.1 += 1;
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+impl Display for HelpPopUp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(title) = &self.title {
+            write!(f, "{}", title)?;
+        } else {
+            write!(f, "Help")?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR is focused on the frontend of patch-hub implementing a PopUp system.

This is still a draft since I'm planning to turn implement a pop-up stack (more explanation below)

# The PopUp

PopUp is defined as a trait (this is something @davidbtadokoro and I discussed offline for the future architecture of patch-hub screens) with 3 basic functions:

 - dimensions: defines the dimensions of the pop-up
 - render: draws the pop-up in a rect produced by the app
 - handle: takes care of key events

Since it's a trait, to each new kind of pop-up one must create a type for it and `impl PopUp for` it

The basic life-cycle of a pop-up is:

1. A new pop-up is instantiated and upcast to a `Box<dyn PopUp>`
2. The pop-up is pushed to the app pop-up stack (at the moment just one pop-up can be display at a time)
3. The app starts a new drawing cicle drawing the new pop-up last
4. The app produces a rect with the dimensions specified by `PopUp::dimensions` (currently the dimensions are a percentage)
5. The app calls `PopUp::render` passing the frame and the created rect so the pop-up has freedom to draw it the way it wants
6. The pop-up being rendered hijacks the key events until it is removed (pressing `ESC` closes the pop-up)

# The Help Pop-Up

This pop-up is both a utility and a blueprint for anyone who needs to create a new pop-up type. It uses a builder to simplify the instantiation. A help pop-up contains:

- title: displayed in the block of the pop-up
- description: an optional help description
- keybinds: a list of pairs of strings representing a key (or a serie of keys) and a short description to what it does

For each screen, I've created a function to simplify the instantiation of a help pop-up to it (in the `src/handler/`) exactly in the same place where the key events for the screen are defined. I then just added a new key event for the key `?` which instantiates a new help pop-up and pushes it to the app "pop-up stack" (it's just an `Option` atm).

The help pop-up draws all the textual content into a `Paragraph` and uses movement keys to pan the text around in case it doesn't fit the screen. Currentl the help pop-up consumes 50% of screen width and height

# What's next

To complete this PR i just plan to implement an actual pop-up stack in the app but some points that can be worked out in the future for help pop-ups are:

- Colorize
- Wrap the lines if they are too long
- Stop scrolling before the text completly vanishes
- Size it acording to its content producing a smaller