### PR TITLE
Add `q` as alternative to `ESC` and simplify edit config screen keybinds

### DIFF
--- a/src/handler/bookmarked.rs
+++ b/src/handler/bookmarked.rs
@@ -19,7 +19,7 @@ where
     B: Backend + Send + 'static,
 {
     match key.code {
-        KeyCode::Esc => {
+        KeyCode::Esc | KeyCode::Char('q') => {
             app.bookmarked_patchsets.patchset_index = 0;
             app.set_current_screen(CurrentScreen::MailingListSelection);
         }

--- a/src/handler/details_actions.rs
+++ b/src/handler/details_actions.rs
@@ -48,7 +48,7 @@ pub fn handle_patchset_details<B: Backend>(
     }
 
     match key.code {
-        KeyCode::Esc => {
+        KeyCode::Esc | KeyCode::Char('q') => {
             let ps_da_clone = patchset_details_and_actions.last_screen.clone();
             app.set_current_screen(ps_da_clone);
             app.reset_details_actions();

--- a/src/handler/edit_config.rs
+++ b/src/handler/edit_config.rs
@@ -23,7 +23,7 @@ pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()
                 _ => {}
             },
             false => match key.code {
-                KeyCode::Esc => {
+                KeyCode::Esc | KeyCode::Char('q') => {
                     app.reset_edit_config();
                     app.set_current_screen(CurrentScreen::MailingListSelection);
                 }

--- a/src/handler/edit_config.rs
+++ b/src/handler/edit_config.rs
@@ -24,10 +24,12 @@ pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()
             },
             false => match key.code {
                 KeyCode::Esc | KeyCode::Char('q') => {
+                    app.consolidate_edit_config();
+                    app.config.save_patch_hub_config()?;
                     app.reset_edit_config();
                     app.set_current_screen(CurrentScreen::MailingListSelection);
                 }
-                KeyCode::Char('e') => {
+                KeyCode::Enter => {
                     edit_config_state.toggle_editing();
                 }
                 KeyCode::Char('j') | KeyCode::Down => {
@@ -35,12 +37,6 @@ pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()
                 }
                 KeyCode::Char('k') | KeyCode::Up => {
                     edit_config_state.highlight_prev();
-                }
-                KeyCode::Enter => {
-                    app.consolidate_edit_config();
-                    app.config.save_patch_hub_config()?;
-                    app.reset_edit_config();
-                    app.set_current_screen(CurrentScreen::MailingListSelection);
                 }
                 _ => {}
             },

--- a/src/handler/latest.rs
+++ b/src/handler/latest.rs
@@ -21,7 +21,7 @@ where
     let latest_patchsets = app.latest_patchsets.as_mut().unwrap();
 
     match key.code {
-        KeyCode::Esc => {
+        KeyCode::Esc | KeyCode::Char('q') => {
             app.reset_latest_patchsets();
             app.set_current_screen(CurrentScreen::MailingListSelection);
         }

--- a/src/ui/bookmarked.rs
+++ b/src/ui/bookmarked.rs
@@ -64,7 +64,7 @@ pub fn mode_footer_text() -> Vec<Span<'static>> {
 
 pub fn keys_hint() -> Span<'static> {
     Span::styled(
-        "(ESC) to return | (ENTER) to select | ( j / 🡇 ) down | ( k / 🡅 ) up",
+        "(ESC / q) to return | (ENTER) to select | ( j / 🡇 ) down | ( k / 🡅 ) up",
         Style::default().fg(Color::Red),
     )
 }

--- a/src/ui/details_actions.rs
+++ b/src/ui/details_actions.rs
@@ -183,7 +183,7 @@ pub fn mode_footer_text() -> Vec<Span<'static>> {
 
 pub fn keys_hint() -> Span<'static> {
     Span::styled(
-        "(ESC) to return | (ENTER) run actions | (jkhl / 🡇 🡅 🡄 🡆 ) | (n) next patch | (p) previous patch | (f) fullscreen",
+        "(ESC / q) to return | (ENTER) run actions | (jkhl / 🡇 🡅 🡄 🡆 ) | (n) next patch | (p) previous patch | (f) fullscreen",
         Style::default().fg(Color::Red),
     )
 }

--- a/src/ui/edit_config.rs
+++ b/src/ui/edit_config.rs
@@ -73,7 +73,7 @@ pub fn keys_hint(app: &App) -> Span {
             Style::default().fg(Color::Red),
         ),
         false => Span::styled(
-            "(ESC / q) cancel | (ENTER) save | (e) edit | (jk| 🡇 🡅 ) down up",
+            "(ESC / q) exit | (ENTER) edit | (jk| 🡇 🡅 ) down up",
             Style::default().fg(Color::Red),
         ),
     }

--- a/src/ui/edit_config.rs
+++ b/src/ui/edit_config.rs
@@ -73,7 +73,7 @@ pub fn keys_hint(app: &App) -> Span {
             Style::default().fg(Color::Red),
         ),
         false => Span::styled(
-            "(ESC) cancel | (ENTER) save | (e) edit | (jk| 🡇 🡅 ) down up",
+            "(ESC / q) cancel | (ENTER) save | (e) edit | (jk| 🡇 🡅 ) down up",
             Style::default().fg(Color::Red),
         ),
     }

--- a/src/ui/latest.rs
+++ b/src/ui/latest.rs
@@ -80,7 +80,7 @@ pub fn mode_footer_text(app: &App) -> Vec<Span> {
 
 pub fn keys_hint() -> Span<'static> {
     Span::styled(
-        "(ESC) to return | (ENTER) to select | ( j / 🡇 ) down | ( k / 🡅 ) up | ( h / 🡄 ) previous page | ( l / 🡆 ) next page",
+        "(ESC / q) to return | (ENTER) to select | ( j / 🡇 ) down | ( k / 🡅 ) up | ( h / 🡄 ) previous page | ( l / 🡆 ) next page",
         Style::default().fg(Color::Red),
     )
 }


### PR DESCRIPTION
This enables `q` as an alternative to `ESC` in every screen (except those that use typing)

Also simplifies the keybinds for edit config screen. Now `ESC` / 'q` saves and `ENTER` toggles the editing mode