### PR TITLE
fix: cleans the mail list to better rendering

### DIFF
--- a/src/ui/mail_list.rs
+++ b/src/ui/mail_list.rs
@@ -2,7 +2,7 @@ use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, HighlightSpacing, List, ListItem, ListState},
+    widgets::{Block, Borders, Clear, HighlightSpacing, List, ListItem, ListState},
     Frame,
 };
 
@@ -47,6 +47,7 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
     let mut list_state = ListState::default();
     list_state.select(Some(highlighted_list_index));
 
+    f.render_widget(Clear, chunk);
     f.render_stateful_widget(list, chunk, &mut list_state);
 }
 


### PR DESCRIPTION
It was reported a bug in some types of consoles that afters firing up patch hub the mail list was buggy, in a way that after passing throught list, the list accessed before stays in a different color.

To fix this, we cleared the content using RATTATUI after every frame to prevent this type of behaviour.