### PR TITLE
Replace `unwrap()` with better alternatives

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -65,7 +65,7 @@ impl App {
     /// # Returns
     ///
     /// `App` instance with loading configurations and app data.
-    pub fn new() -> App {
+    pub fn new() -> color_eyre::Result<Self> {
         let config: Config = Config::build();
         config.create_dirs();
 
@@ -83,11 +83,11 @@ impl App {
         let lore_api_client = BlockingLoreAPIClient::default();
 
         // Initialize the logger before the app starts
-        Logger::init_log_file(&config);
+        Logger::init_log_file(&config)?;
         Logger::info("patch-hub started");
         logging::garbage_collector::collect_garbage(&config);
 
-        App {
+        Ok(App {
             current_screen: CurrentScreen::MailingListSelection,
             mailing_list_selection: MailingListSelection {
                 mailing_lists: mailing_lists.clone(),
@@ -108,7 +108,7 @@ impl App {
             config,
             lore_api_client,
             popup: None,
-        }
+        })
     }
 
     /// Initializes field [App::latest_patchsets], from currently selected

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -54,8 +54,12 @@ pub struct KernelTree {
 
 impl Config {
     fn default() -> Self {
-        let cache_dir = format!("{}/.cache/patch_hub", env::var("HOME").unwrap());
-        let data_dir = format!("{}/.local/share/patch_hub", env::var("HOME").unwrap());
+        let home = env::var("HOME").unwrap_or_else(|_| {
+            eprintln!("$HOME environment variable not set, using current directory");
+            ".".to_string()
+        });
+        let cache_dir = format!("{}/.cache/patch_hub", home);
+        let data_dir = format!("{}/.local/share/patch_hub", home);
 
         Config {
             page_size: 30,

--- a/src/app/logging.rs
+++ b/src/app/logging.rs
@@ -244,31 +244,24 @@ impl Logger {
     /// // ... initialize the log file
     /// Logger::init_log_file(&config);
     /// ```
-    pub fn init_log_file(config: &Config) {
+    pub fn init_log_file(config: &Config) -> Result<(), std::io::Error> {
         let logger = Logger::get_logger();
 
-        let logs_path = &config.logs_path();
-        fs::create_dir_all(logs_path)
-            .unwrap_or_else(|_| panic!("Failed to create the logs folder at {}", logs_path));
+        let logs_path = config.logs_path();
+        fs::create_dir_all(logs_path)?;
 
         if logger.latest_log_file.is_none() {
             let latest_log_filename = LATEST_LOG_FILENAME.to_string();
             let latest_log_filepath = format!("{}/{}", logs_path, latest_log_filename);
 
-            File::create(&latest_log_filepath).expect("To clear latest.log file successfully");
+            File::create(&latest_log_filepath)?;
 
-            logger.latest_log_file = Some(
-                OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&latest_log_filepath)
-                    .unwrap_or_else(|_| {
-                        panic!(
-                            "Failed to create the latest.log file at {}",
-                            latest_log_filepath
-                        )
-                    }),
-            );
+            let log_file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&latest_log_filepath)?;
+
+            logger.latest_log_file = Some(log_file);
             logger.latest_log_filepath = Some(latest_log_filepath);
         }
 
@@ -279,17 +272,16 @@ impl Logger {
             );
             let log_filepath = format!("{}/{}", logs_path, log_filename);
 
-            logger.log_file = Some(
-                OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&log_filepath)
-                    .unwrap_or_else(|_| {
-                        panic!("Failed to create the log file at {}", log_filepath)
-                    }),
-            );
+            let log_file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&log_filepath)?;
+
+            logger.log_file = Some(log_file);
             logger.log_filepath = Some(log_filepath);
         }
+
+        Ok(())
     }
 }
 

--- a/src/app/patch_renderer.rs
+++ b/src/app/patch_renderer.rs
@@ -4,6 +4,7 @@ use std::{
     process::{Command, Stdio},
 };
 
+use color_eyre::eyre::eyre;
 use serde::{Deserialize, Serialize};
 
 use super::logging::Logger;
@@ -101,7 +102,7 @@ fn bat_patch_renderer(patch: &str) -> color_eyre::Result<String> {
 
     bat.stdin
         .as_mut()
-        .unwrap()
+        .ok_or_else(|| eyre!("Failed to get stdin handle"))?
         .write_all(cleaned_patch.as_bytes())?;
     let output = bat.wait_with_output()?;
     Ok(String::from_utf8(output.stdout)?)
@@ -134,7 +135,7 @@ fn delta_patch_renderer(patch: &str) -> color_eyre::Result<String> {
     delta
         .stdin
         .as_mut()
-        .unwrap()
+        .ok_or_else(|| eyre!("Failed to get stdin handle"))?
         .write_all(cleaned_patch.as_bytes())?;
     let output = delta.wait_with_output()?;
     Ok(String::from_utf8(output.stdout)?)
@@ -162,7 +163,7 @@ fn diff_so_fancy_renderer(patch: &str) -> color_eyre::Result<String> {
 
     dsf.stdin
         .as_mut()
-        .unwrap()
+        .ok_or_else(|| eyre!("Failed to get stdin handle"))?
         .write_all(cleaned_patch.as_bytes())?;
     let output = dsf.wait_with_output()?;
     Ok(String::from_utf8(output.stdout)?)

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -154,7 +154,10 @@ impl DetailsActions {
     }
 
     pub fn toggle_action(&mut self, patchset_action: PatchsetAction) {
-        let current_value = *self.patchset_actions.get(&patchset_action).unwrap();
+        let current_value = *self
+            .patchset_actions
+            .get(&patchset_action)
+            .expect("DetailsActions::Patchset_actions must be initialized properly");
         self.patchset_actions
             .insert(patchset_action, !current_value);
     }

--- a/src/lore/lore_session.rs
+++ b/src/lore/lore_session.rs
@@ -142,11 +142,10 @@ impl LoreSession {
         }
 
         for i in lower_end..upper_end {
-            patch_feed_page.push(
-                self.processed_patches_map
-                    .get(&self.representative_patches_ids[i])
-                    .unwrap(),
-            )
+            let patch = self
+                .processed_patches_map
+                .get(&self.representative_patches_ids[i])?;
+            patch_feed_page.push(patch);
         }
 
         Some(patch_feed_page)

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> color_eyre::Result<()> {
 
     utils::install_hooks()?;
     let mut terminal = utils::init()?;
-    let mut app = App::new();
+    let mut app = App::new()?;
 
     match args.resolve(terminal, &mut app) {
         ControlFlow::Break(b) => return b,

--- a/src/ui/edit_config.rs
+++ b/src/ui/edit_config.rs
@@ -6,6 +6,7 @@ use ratatui::{
     Frame,
 };
 
+use crate::app::logging::Logger;
 use crate::app::App;
 
 pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
@@ -27,7 +28,14 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
             break;
         }
 
-        let (config, value) = edit_config.config(i);
+        let (config, value) = match edit_config.config(i) {
+            Some((cfg, val)) => (cfg, val),
+            None => {
+                Logger::error(format!("Invalid configuration index: {}", i));
+                return;
+            }
+        };
+
         let value = Line::from(if edit_config.is_editing() && i == highlighted_entry {
             vec![
                 Span::styled(edit_config.curr_edit().to_string(), Style::default()),


### PR DESCRIPTION
Addresses #2. Notably, the following files and unwraps were affected:
- `Config::default` unwrapped `env::var("HOME")`, this was changed to use current directory in the case $HOME is not set.
- I/O errors in `init_log_file` had their errors propagate rather than unwrapped. This meant additional changes all the way to main.
- Patch renderer unwrapped calls to get the stdin handle for each type of supported renderer.
- `get_patch_feed_page` returned the error instead of unwrapping.