### PR TITLE
feat: increase Delta output width

### DIFF
--- a/src/app/patch_renderer.rs
+++ b/src/app/patch_renderer.rs
@@ -98,6 +98,7 @@ fn delta_patch_renderer(patch: &str) -> color_eyre::Result<String> {
     let mut delta = Command::new("delta")
         .arg("--pager")
         .arg("less")
+        .arg("--no-gitconfig")
         .arg("--paging")
         .arg("never")
         .arg("-w")

--- a/src/app/patch_renderer.rs
+++ b/src/app/patch_renderer.rs
@@ -100,6 +100,8 @@ fn delta_patch_renderer(patch: &str) -> color_eyre::Result<String> {
         .arg("less")
         .arg("--paging")
         .arg("never")
+        .arg("-w")
+        .arg("130")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()


### PR DESCRIPTION
Hi!

This PR increases the `delta` output do 130 columns.

This is just an arbitrary number that worked well for me, but ideally I think this should be about the width of the "preview" widget. I really would do this by myself, but, as I don't know Rust I can't do that by now, sorry (looks like I need to learn Rust urgently...).

