### PR TITLE
Add setup function and new tests for hooks in `utils.rs`

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -118,12 +118,62 @@ macro_rules! loading_screen {
     };
 }
 
+#[cfg(test)]
 mod tests {
+    use std::sync::Once;
+
+    use super::*;
+
+    static INIT: Once = Once::new();
+
+    // Tests can be run in parallel, we don't want to override previously installed hooks
+    fn setup() {
+        INIT.call_once(|| {
+            install_hooks().expect("Failed to install hooks");
+        })
+    }
+
     #[test]
     fn test_binary_exists() {
         // cargo should always exist since we are running the tests with `cargo test`
         assert!(super::binary_exists("cargo"));
         // there is no way this binary exists
         assert!(!super::binary_exists("there_is_no_way_this_binary_exists"));
+    }
+
+    #[test]
+    fn test_install_hooks() {
+        setup();
+
+        assert!(true);
+    }
+
+    #[test]
+    fn test_error_hook_works() {
+        setup();
+
+        let result: color_eyre::Result<()> = Err(eyre::eyre!("Test error"));
+
+        // We can't directly test the hook's formatting, but we can verify
+        // that handling an error doesn't cause unexpected panics
+        match result {
+            Ok(_) => panic!("Expected an error"),
+            Err(e) => {
+                let _ = format!("{:?}", e);
+                assert!(true, "Error hook worked without panicking");
+            }
+        }
+    }
+
+
+    #[test]
+    fn test_panic_hook() {
+        setup();
+
+        let result = std::panic::catch_unwind(|| {
+            std::panic!("Test panic")
+        });
+
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
This PR improves the test suite in utils.rs by introducing a `setup()` function that ensures hooks are installed only once, preventing conflicts in parallel test execution. Additionally, it includes new test cases to verify hook installation and error handling.

## Changes
- Added a setup() function using std::sync::Once to prevent duplicate hook installation.
- Implemented test_install_hooks to validate hook setup.
- Introduced test_error_hook_works to check error hook behavior.