### PR TITLE
Add Dependabot Integration for Cargo packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    target-branch: "unstable"
+    groups:
+      all-dependencies:
+        applies-to: [version-updates, security-updates]
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR introduces Dependabot to automate dependency updates for patch-hub. Dependabot will check for new versions of dependencies every week and if any are found, it will send a PR to `unstable` bumping the versions up.