### PR TITLE
Add Codecov integration for test coverage tracking

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,0 +1,24 @@
+name: Code Coverage
+
+on:
+  push:
+    branches: [ master, unstable ]
+  pull_request:
+    branches: [ master, unstable ]
+
+jobs:
+  test-coverage-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Generate coverage report
+        run: cargo tarpaulin --verbose --out lcov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5


### PR DESCRIPTION
This PR adds Codecov integration to track code coverage. With this setup, Codecov will automatically analyze test coverage and post comments on PRs, helping us monitor changes in coverage over time. I believe this will be a good incentive to increase our coverage as well.

# Requirements
Codecoverage needs a token from their [their website.](https://about.codecov.io/) This needs to be put in GitHub secrets as it's referenced in the .yml file as `${{ secrets.CODECOV_TOKEN }}`