### PR TITLE
feat: make CI workflows run on the exact PR branch

### DIFF
--- a/.github/workflows/build_and_unit_test.yml
+++ b/.github/workflows/build_and_unit_test.yml
@@ -28,6 +28,8 @@ jobs:
     if: '!github.event.pull_request.draft'
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Update rustup and install rustc and cargo
         shell: bash

--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -24,6 +24,8 @@ jobs:
     if: '!github.event.pull_request.draft'
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Update rustup and install rustfmt
         shell: bash
@@ -43,6 +45,8 @@ jobs:
     if: '!github.event.pull_request.draft'
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Update rustup and install clippy
         shell: bash


### PR DESCRIPTION
The project's CI relies heavily on the `checkout` action from GitHub Actions that, essentially, deals with checking out to the correct commit on which to run the workflow. By default, PRs check out to the temporary merge commit resulting from the PR branch HEAD and the target branch HEAD (`unstable` here in `patch-hub`). This logic is sound to "assure" that the workflows run on a version of the PR that considers the latest state of the branch it intends to merge.

However, it can cause strange side effects, such as when GitHub can successfully merge, but the PR branch conflicts in other ways. In this example [1][2], the PR #100 changed the function `install_hooks()` to expect an argument, but in `unstable`, there was a commit that introduced a test that used `install_hooks()` without arguments. The merge was done seamlessly, but it generated a compilation error.

In this sense, change the workflows to check out to PR branch HEAD commit instead of merge commit [3] to avoid us guessing what happened when debugging failing workflows. This has the upside down of "wasting" CI on "stale" PR branches, but demanding updated branches is a maintainer's job (besides being a good practice from contributors).

[1]: https://github.com/kworkflow/patch-hub/actions/runs/13722146202/job/38391557671
[2]: https://github.com/kworkflow/patch-hub/actions/runs/13722146239/job/38379854217
[3]: https://github.com/actions/checkout/blob/main/README.md#Checkout-pull-request-HEAD-commit-instead-of-merge-commit