### PR TITLE
chore: remove testing branch from `build_and_unit_test` CI workflow

### DIFF
--- a/.github/workflows/build_and_unit_test.yml
+++ b/.github/workflows/build_and_unit_test.yml
@@ -16,7 +16,6 @@ on:
     branches:
       - master
       - unstable
-      - feat-build-and-unit-test-ci
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
When I was first implementing the CI workflow for project building and unit tests, I've added the branch `feat-build-and-unit-test-ci` as one of the triggers on-push to test the workflow without pushing to `master` or `unstable`. Somehow, I forgot to remove it before merging.

This isn't a real problem, but to not be negligent and keep things clean, remove this branch from the triggers on-push.