### PR TITLE
Fix `cargo install` failing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "4.5.13", features = ["derive"] }
 chrono = "0.4.38"
 ansi-to-tui = "6.0.0"
 which = "6.0.3"
-ureq = { version = "3.0.0-rc2", features = ["rustls"] }
+ureq = { version = "=3.0.0-rc2", features = ["rustls"] }
 
 # The profile that 'cargo dist' will build with
 [profile.dist]


### PR DESCRIPTION
Fixes #119 
As I was working on something else when I encountered the bug, I wasn't going to try to fix it immediately. But I couldn't help but do a little bit of digging and was able to resolve it fairly quickly so...

This commit locks the version of `ureq` to `v3.0.0-rc2`, a tested, working build.

Version strings specified in `Cargo.toml` represent a range from the specified version to the next `minor` upgrade according to `SemVer`. And since `cargo install` does not use `Cargo.lock` to build the project, it will use a patched version of `ureq` which changes the function signature of `ureq::Agent::user-agent`.

Reference: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio