### PR TITLE
fix: ensure loading_screen! generated thread joins before exiting patch-hub

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -72,7 +72,7 @@ where
             if app.mailing_list_selection.mailing_lists.is_empty() {
                 terminal = loading_screen! {
                     terminal, "Fetching mailing lists" => {
-                        app.mailing_list_selection.refresh_available_mailing_lists()?;
+                        app.mailing_list_selection.refresh_available_mailing_lists()
                     }
                 };
             }
@@ -84,7 +84,7 @@ where
                 terminal = loading_screen! {
                     terminal,
                     format!("Fetching patchsets from {}", target_list) => {
-                        patchsets_state.fetch_current_page()?;
+                        patchsets_state.fetch_current_page()
                     }
                 };
 

--- a/src/handler/bookmarked.rs
+++ b/src/handler/bookmarked.rs
@@ -38,8 +38,11 @@ where
             terminal = loading_screen! {
                 terminal,
                 "Loading patchset" => {
-                    app.init_details_actions()?;
-                    app.set_current_screen(CurrentScreen::PatchsetDetails);
+                    let result = app.init_details_actions();
+                    if result.is_ok() {
+                        app.set_current_screen(CurrentScreen::PatchsetDetails);
+                    }
+                    result
                 }
             };
         }

--- a/src/handler/latest.rs
+++ b/src/handler/latest.rs
@@ -42,7 +42,7 @@ where
                 terminal,
                 format!("Fetching patchsets from {}", list_name) => {
                     latest_patchsets.increment_page();
-                    latest_patchsets.fetch_current_page()?;
+                    latest_patchsets.fetch_current_page()
                 }
             };
         }
@@ -53,8 +53,11 @@ where
             terminal = loading_screen! {
                 terminal,
                 "Loading patchset" => {
-                    app.init_details_actions()?;
-                    app.set_current_screen(CurrentScreen::PatchsetDetails);
+                    let result = app.init_details_actions();
+                    if result.is_ok() {
+                        app.set_current_screen(CurrentScreen::PatchsetDetails);
+                    }
+                    result
                 }
             };
         }

--- a/src/handler/mail_list.rs
+++ b/src/handler/mail_list.rs
@@ -37,9 +37,14 @@ where
                 terminal = loading_screen! {
                     terminal,
                     format!("Fetching patchsets from {}", list_name) => {
-                        app.latest_patchsets.as_mut().unwrap().fetch_current_page()?;
-                        app.mailing_list_selection.clear_target_list();
-                        app.set_current_screen(CurrentScreen::LatestPatchsets);
+                        let result =
+                        app.latest_patchsets.as_mut().unwrap()
+                        .fetch_current_page();
+                        if result.is_ok() {
+                            app.mailing_list_selection.clear_target_list();
+                            app.set_current_screen(CurrentScreen::LatestPatchsets);
+                        }
+                        result
                     }
                 };
             }
@@ -49,7 +54,7 @@ where
                 terminal,
                 "Refreshing lists" => {
                     app.mailing_list_selection
-                        .refresh_available_mailing_lists()?;
+                        .refresh_available_mailing_lists()
                 }
             };
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -85,7 +85,10 @@ pub fn binary_exists(binary: &str) -> bool {
 ///
 /// When the execution finishes, the macro will return the terminal.
 ///
-/// Important to notice that the code block will run in the same scope as the rest of the macro
+/// Important to notice that the code block will run in the same scope as the rest of the macro.
+/// Be aware that in Rust, when using `?` or `return` inside a closure, they apply to the outer function,
+/// not the closure itself. This can lead to unexpected behavior if you expect the closure to handle
+/// errors or return values independently of the enclosing function.
 ///
 /// # Example
 /// ```rust norun
@@ -109,11 +112,17 @@ macro_rules! loading_screen {
                 terminal
             });
 
-            $inst;
+            // we have to sleep so the loading thread completes at least one render
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            let inst_result = $inst;
 
             loading.store(false, std::sync::atomic::Ordering::Relaxed);
 
-            handle.join().unwrap()
+            let terminal = handle.join().unwrap();
+
+            inst_result?;
+
+            terminal
         }
     };
 }


### PR DESCRIPTION
This PR fixes #74.

Besides what I've described in the commit message, I would like to point out that this issue is a great example why we should always avoid unwraps and gracefully handle errors. Even though the problem was not caused by any unwraps, the problematic behavior will continue to happen if the code panics before joining the loading screen thread.

I chose to focus on resolving the bug itself, which is why I didn’t remove any unwrapping from the related logic. Additionally, as I mentioned in the commit message, it’s important for us to pay attention to how Rust handles closures. I’m not sure if what we were doing was intentional, but at least for me, it’s counterintuitive that the `?` and `return` inside a closure don’t apply to the closure itself. @davidbtadokoro , if you can remember any other places where we might have handled this incorrectly, let me know, and I can fix it.