### PR TITLE
refactor: build `Config` outside of `App`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -26,7 +26,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::utils;
 
-mod config;
+pub mod config;
 pub mod cover_renderer;
 pub mod logging;
 pub mod patch_renderer;
@@ -65,10 +65,7 @@ impl App {
     /// # Returns
     ///
     /// `App` instance with loading configurations and app data.
-    pub fn new() -> color_eyre::Result<Self> {
-        let config: Config = Config::build();
-        config.create_dirs();
-
+    pub fn new(config: Config) -> color_eyre::Result<Self> {
         let mailing_lists =
             lore_session::load_available_lists(config.mailing_lists_path()).unwrap_or_default();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::ops::ControlFlow;
 
 use crate::app::App;
-use app::logging::Logger;
+use app::{config::Config, logging::Logger};
 use clap::Parser;
 use cli::Cli;
 use handler::run_app;
@@ -17,7 +17,10 @@ fn main() -> color_eyre::Result<()> {
 
     utils::install_hooks()?;
     let mut terminal = utils::init()?;
-    let mut app = App::new()?;
+
+    let config = Config::build();
+    config.create_dirs();
+    let mut app = App::new(config)?;
 
     match args.resolve(terminal, &mut app) {
         ControlFlow::Break(b) => return b,


### PR DESCRIPTION
`App` previously built `Config` inside `App::new()`, which made it difficult to access `Config` inside main(). It likely did this because `App` itself contained `Config`. However, having `Config` outside lets us perform other actions on it before giving up ownership to `App`. Such as resolving arguments.