### PR TITLE
Remove redundant test

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -142,11 +142,6 @@ mod tests {
     }
 
     #[test]
-    fn test_install_hooks() {
-        setup();
-    }
-
-    #[test]
     fn test_error_hook_works() {
         setup();
 


### PR DESCRIPTION
`test_install_hooks` was a test that simply ran the `setup()` function, and does not assert or verify anything. `setup()` is also ran by most of the other tests, so we would know if it ever fails.