### PR TITLE
fix: patch-hub crashes when loading patches after b4 fails 

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@ use cover_renderer::render_cover;
 use logging::Logger;
 use patch_hub::lore::{
     lore_api_client::BlockingLoreAPIClient,
-    lore_session,
+    lore_session::{self, B4Result},
     patch::{Author, Patch},
 };
 use patch_renderer::{render_patch_preview, PatchRenderer};
@@ -132,7 +132,7 @@ impl App {
     /// Initializes field [App::details_actions], from currently selected
     /// patchset in [App::bookmarked_patchsets] or [App::latest_patchsets],
     /// depending on the value of [App::current_screen].
-    pub fn init_details_actions(&mut self) -> color_eyre::Result<()> {
+    pub fn init_details_actions(&mut self) -> color_eyre::Result<B4Result> {
         let representative_patch: Patch;
         let mut is_patchset_bookmarked = true;
         let mut reviewed_by = Vec::new();
@@ -160,12 +160,14 @@ impl App {
             screen => bail!(format!("Invalid screen passed as argument {screen:?}")),
         };
 
-        let patchset_path: String = match log_on_error!(lore_session::download_patchset(
+        let patchset_path: String = match lore_session::download_patchset(
             self.config.patchsets_cache_dir(),
             &representative_patch,
-        )) {
-            Ok(result) => result,
-            Err(io_error) => bail!("{io_error}"),
+        ) {
+            lore_session::B4Result::PatchFound(path) => path,
+            lore_session::B4Result::PatchNotFound(error) => {
+                return Ok(lore_session::B4Result::PatchNotFound(error))
+            }
         };
 
         match log_on_error!(lore_session::split_patchset(&patchset_path)) {
@@ -250,7 +252,7 @@ impl App {
                     lore_api_client: self.lore_api_client.clone(),
                     patchset_path,
                 });
-                Ok(())
+                Ok(B4Result::PatchFound("Patch found".to_string()))
             }
             Err(message) => bail!(message),
         }

--- a/src/handler/latest.rs
+++ b/src/handler/latest.rs
@@ -3,13 +3,16 @@ use std::ops::ControlFlow;
 use crate::{
     app::{screens::CurrentScreen, App},
     loading_screen,
-    ui::popup::{help::HelpPopUpBuilder, PopUp},
+    ui::popup::{help::HelpPopUpBuilder, info_popup::InfoPopUp, PopUp},
 };
+use color_eyre::eyre::Ok;
 use ratatui::{
     crossterm::event::{KeyCode, KeyEvent},
     prelude::Backend,
     Terminal,
 };
+
+use patch_hub::lore::lore_session::B4Result;
 
 pub fn handle_latest_patchsets<B>(
     app: &mut App,
@@ -55,9 +58,18 @@ where
                 "Loading patchset" => {
                     let result = app.init_details_actions();
                     if result.is_ok() {
-                        app.set_current_screen(CurrentScreen::PatchsetDetails);
+                        match result.unwrap() {
+                            B4Result::PatchFound(_) => {
+                                app.set_current_screen(CurrentScreen::PatchsetDetails);
+                            }
+
+                            B4Result::PatchNotFound(err_cause) => {
+                                app.popup = Some(InfoPopUp::generate_info_popup("Error",&format!("The selected patchset couldn't be retrieved.\nReason:  {err_cause}\nPlease choose another patchset.")));
+                                app.set_current_screen(CurrentScreen::LatestPatchsets);
+                            }
+                        }
                     }
-                    result
+                    Ok(())
                 }
             };
         }

--- a/src/lore/lore_session.rs
+++ b/src/lore/lore_session.rs
@@ -7,6 +7,7 @@ use derive_getters::Getters;
 use regex::Regex;
 use serde_xml_rs::from_str;
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
 use std::io::{BufRead, BufReader};
 use std::mem::swap;
 use std::path::Path;
@@ -17,6 +18,11 @@ use std::{
     io,
 };
 use thiserror::Error;
+
+pub enum B4Result {
+    PatchFound(String),
+    PatchNotFound(String),
+}
 
 #[cfg(test)]
 mod tests;
@@ -152,17 +158,20 @@ impl LoreSession {
     }
 }
 
-pub fn download_patchset(output_dir: &str, patch: &Patch) -> io::Result<String> {
+pub fn download_patchset(output_dir: &str, patch: &Patch) -> B4Result {
     let message_id: &str = &patch.message_id().href;
     let mbox_name: String = extract_mbox_name_from_message_id(message_id);
 
     if !Path::new(output_dir).exists() {
-        fs::create_dir_all(output_dir)?;
+        match fs::create_dir_all(output_dir) {
+            Ok(_) => {}
+            Err(_) => return B4Result::PatchNotFound("Couldn't create patches dir.".to_string()),
+        };
     }
 
     let filepath: String = format!("{output_dir}/{mbox_name}");
     if !Path::new(&filepath).exists() {
-        Command::new("b4")
+        match Command::new("b4")
             .arg("--quiet")
             .arg("am")
             .arg("--use-version")
@@ -174,10 +183,20 @@ pub fn download_patchset(output_dir: &str, patch: &Patch) -> io::Result<String> 
             .arg(&mbox_name)
             .stdout(Stdio::null())
             .stderr(Stdio::null())
-            .status()?;
+            .status()
+        {
+            Ok(_) => {}
+            Err(_) => return B4Result::PatchNotFound("Couldn't create patch file.".to_string()),
+        };
     }
 
-    Ok(filepath)
+    let path = Path::new(OsStr::new(&filepath));
+
+    if !path.exists() {
+        return B4Result::PatchNotFound("Couldn't create patch file.".to_string());
+    }
+
+    B4Result::PatchFound(filepath)
 }
 
 fn extract_mbox_name_from_message_id(message_id: &str) -> String {


### PR DESCRIPTION
Seeking to fix #69, this first commit introduces a check to the function init_details_actions. We hoped to stop the crash described in #69 by throwing an Err and catching it in the handle_latest_patchsets fucntion before showing a popup to the user. For some still unkown reason, the TUI freezes and 'melts' after the popup is shown.

Co-developed-by: Bruno Stephan <bruno.stephan@usp.br>
Co-developed-by: Andre de Lima <aschwarz@usp.br>