### PR TITLE
Move dependecy check out of `run_app`

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -17,13 +17,11 @@ use std::{
 
 use crate::{
     app::{screens::CurrentScreen, App},
-    infrastructure::logging::Logger,
     loading_screen,
     ui::draw_ui,
 };
 
 use bookmarked::handle_bookmarked_patchsets;
-use color_eyre::eyre::bail;
 use details_actions::handle_patchset_details;
 use edit_config::handle_edit_config;
 use latest::handle_latest_patchsets;
@@ -108,11 +106,6 @@ pub fn run_app<B>(mut terminal: Terminal<B>, mut app: App) -> color_eyre::Result
 where
     B: Backend + Send + 'static,
 {
-    if !app.check_external_deps() {
-        Logger::error("patch-hub cannot be executed because some dependencies are missing");
-        bail!("patch-hub cannot be executed because some dependencies are missing, check logs for more information");
-    }
-
     loop {
         terminal = logic_handling(terminal, &mut app)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,16 +6,16 @@ mod lore;
 mod macros;
 mod ui;
 
-use std::ops::ControlFlow;
-
 use app::{config::Config, App};
 use clap::Parser;
 use cli::Cli;
+use color_eyre::eyre::bail;
 use handler::run_app;
 use infrastructure::{
     logging::Logger,
     terminal::{init, restore},
 };
+use std::ops::ControlFlow;
 
 fn main() -> color_eyre::Result<()> {
     let args = Cli::parse();
@@ -32,6 +32,10 @@ fn main() -> color_eyre::Result<()> {
     }
 
     let app = App::new(config)?;
+    if !app.check_external_deps() {
+        Logger::error("patch-hub cannot be executed because some dependencies are missing");
+        bail!("patch-hub cannot be executed because some dependencies are missing, check logs for more information");
+    }
 
     run_app(terminal, app)?;
     restore()?;


### PR DESCRIPTION
I think it is cleaner for `run_app` to be focused on just running the app. Checks for dependencies can be done outside of this step.
