### PR TITLE
docs(contributing)!:  clarify use of scopes and breaking changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,10 @@ Thank you for your interest in contributing to `patch-hub`! This document outlin
 1. [Code of Conduct](#code-of-conduct)
 2. [Getting Started](#getting-started)
 3. [Development Workflow](#development-workflow)
-4. [Coding Style](#coding-style)
-5. [Commit Guidelines](#commit-guidelines)
-6. [Pull Request Guidelines](#pull-request-guidelines)
-7. [Issue Reporting](#issue-reporting)
-8. [Communication](#communication)
+4. [Commit Guidelines](#commit-guidelines)
+5. [Pull Request Guidelines](#pull-request-guidelines)
+6. [Issue Reporting](#issue-reporting)
+7. [License](#license)
 
 ## Code of Conduct
 


### PR DESCRIPTION
This updates the "Use Conventional Commits" section to include the proper syntax for scope and breaking changes.

Changes:
- Introduced the format : `<type>(<scope>)! : <description>`
- Added a clear example: `feat (foo)!: introduce breaking change bar`
- Linked to the Conventional Commits v1.0.0 specification

This provides clearer guidance for contributors writing commit messages.