### PR TITLE
chore: add rust-toolchain.toml file to pin Rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+# This file forces cargo commands run in the repository to follow the rust version contained here.
+# This is particulary useful to maintain consistency between workflow and local runs
+[toolchain]
+channel = "1.88.0"


### PR DESCRIPTION
This PR aims to add a way to ensure consistency between Rust versions used on workflows and local runs, cargo test, cargo clippy, etc. runs are consistency to workflow runs.
Sometimes during Rust updates, clippy and even formatting rules change. Usually they change for the better, but we should explicitly want to update project Rust version to prevent any unexpected behavior.

The chosen Rust version was 1.88.0 (2025-06-26) because is the last but one stable release.
