### PR TITLE
docs: fix: table of contents of contributing md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to `patch-hub`! This document outlin
 
 1. [Code of Conduct](#code-of-conduct)
 2. [Getting Started](#getting-started)
-3. [Development Workflow](#development-workflow)
+3. [Development Cycle and Branches](#development-cycle-and-branches)
 4. [Commit Guidelines](#commit-guidelines)
 5. [Pull Request Guidelines](#pull-request-guidelines)
 6. [Issue Reporting](#issue-reporting)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,9 @@ Thank you for your interest in contributing to `patch-hub`! This document outlin
 1. [Code of Conduct](#code-of-conduct)
 2. [Getting Started](#getting-started)
 3. [Development Workflow](#development-workflow)
-4. [Coding Style](#coding-style)
-5. [Commit Guidelines](#commit-guidelines)
-6. [Pull Request Guidelines](#pull-request-guidelines)
-7. [Issue Reporting](#issue-reporting)
-8. [Communication](#communication)
+4. [Commit Guidelines](#commit-guidelines)
+5. [Pull Request Guidelines](#pull-request-guidelines)
+6. [Issue Reporting](#issue-reporting)
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Thank you for your interest in contributing to `patch-hub`! This document outlin
 4. [Commit Guidelines](#commit-guidelines)
 5. [Pull Request Guidelines](#pull-request-guidelines)
 6. [Issue Reporting](#issue-reporting)
+7. [License](#license)
 
 ## Code of Conduct
 


### PR DESCRIPTION
This PR cleans up the CONTRIBUTING.md file by:

Removing nonexistent sections – the 'Coding Style' and 'Communication' sections have been removed since they are not present in the current document.

Adding the missing License section – a 'License' section has been added to reflect the project’s licensing information.

Updating references – internal links now point to the correct top-level sections instead of the 'Development Workflow' subsection.

These changes improve the accuracy, completeness, and navigability of the CONTRIBUTING.md document.

Closes: #136