### PR TITLE
tests: add test for cover render

### DIFF
--- a/src/app/cover_renderer.rs
+++ b/src/app/cover_renderer.rs
@@ -76,3 +76,53 @@ fn bat_cover_renderer(patch: &str) -> color_eyre::Result<String> {
     let output = bat.wait_with_output()?;
     Ok(String::from_utf8(output.stdout)?)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::app::config::Config;
+
+    use super::*;
+
+    #[test]
+    fn test_cover_renderer_from_string() {
+        assert!(matches!(CoverRenderer::from("bat".to_string()), CoverRenderer::Bat));
+        assert!(matches!(CoverRenderer::from("default".to_string()), CoverRenderer::Default));
+        assert!(matches!(CoverRenderer::from("qualquer".to_string()), CoverRenderer::Default));
+    }
+
+    #[test]
+    fn test_cover_renderer_from_str() {
+        assert!(matches!(CoverRenderer::from("bat"), CoverRenderer::Bat));
+        assert!(matches!(CoverRenderer::from("default"), CoverRenderer::Default));
+        assert!(matches!(CoverRenderer::from("zzz"), CoverRenderer::Default));
+    }
+
+    #[test]
+    fn test_cover_renderer_display() {
+        assert_eq!(CoverRenderer::Default.to_string(), "default");
+        assert_eq!(CoverRenderer::Bat.to_string(), "bat");
+    }
+
+    #[test]
+    fn test_render_cover_default() {
+        let text = "abc";
+        let result = render_cover(text, &CoverRenderer::Default).unwrap();
+        assert_eq!(result, "abc");
+    }
+
+    #[test]
+    fn test_bat_renderer_fails_when_bat_missing() {
+        let cfg = Config::default();
+        Logger::init_log_file(&cfg).ok();
+
+        let backup = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", "");
+
+        let result = bat_cover_renderer("x");
+
+        std::env::set_var("PATH", backup);
+
+        assert!(result.is_err());
+    }
+}
+


### PR DESCRIPTION
This commit add's tests for cover render functions, increasing patch_hub test coverage.