### PR TITLE
feat(ui): Improve mailing list filtering and display

### DIFF
--- a/src/app/screens/mail_list.rs
+++ b/src/app/screens/mail_list.rs
@@ -55,17 +55,25 @@ impl MailingListSelection {
         }
 
         let query = self.target_list.to_lowercase();
-        let mut possible_mailing_lists: Vec<MailingList> = Vec::new();
+        let mut exact_matches: Vec<MailingList> = Vec::new();
+        let mut partial_matches: Vec<MailingList> = Vec::new();
 
         for mailing_list in &self.mailing_lists {
-            if mailing_list.name().to_lowercase().contains(&query)
-                || mailing_list.description().to_lowercase().contains(&query)
-            {
-                possible_mailing_lists.push(mailing_list.clone());
+            let name_lower = mailing_list.name().to_lowercase();
+            let desc_lower = mailing_list.description().to_lowercase();
+
+            // Check for exact match first (case-insensitive)
+            if name_lower == query {
+                exact_matches.push(mailing_list.clone());
+            } else if name_lower.contains(&query) || desc_lower.contains(&query) {
+                partial_matches.push(mailing_list.clone());
             }
         }
 
-        self.possible_mailing_lists = possible_mailing_lists;
+        // Prioritize exact matches by placing them first
+        let mut all_matches = exact_matches;
+        all_matches.append(&mut partial_matches);
+        self.possible_mailing_lists = all_matches;
         self.highlighted_list_index = 0;
     }
 

--- a/src/app/screens/mail_list.rs
+++ b/src/app/screens/mail_list.rs
@@ -48,10 +48,19 @@ impl MailingListSelection {
     }
 
     fn process_possible_mailing_lists(&mut self) {
+        if self.target_list.is_empty() {
+            self.possible_mailing_lists = self.mailing_lists.clone();
+            self.highlighted_list_index = 0;
+            return;
+        }
+
+        let query = self.target_list.to_lowercase();
         let mut possible_mailing_lists: Vec<MailingList> = Vec::new();
 
         for mailing_list in &self.mailing_lists {
-            if mailing_list.name().starts_with(&self.target_list) {
+            if mailing_list.name().to_lowercase().contains(&query)
+                || mailing_list.description().to_lowercase().contains(&query)
+            {
                 possible_mailing_lists.push(mailing_list.clone());
             }
         }

--- a/src/ui/edit_config.rs
+++ b/src/ui/edit_config.rs
@@ -64,7 +64,7 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
     }
 }
 
-pub fn mode_footer_text(app: &App) -> Vec<Span> {
+pub fn mode_footer_text(app: &App) -> Vec<Span<'_>> {
     let edit_config_state = app.edit_config.as_ref().unwrap();
     vec![if edit_config_state.is_editing() {
         Span::styled("Editing...", Style::default().fg(Color::LightYellow))
@@ -73,7 +73,7 @@ pub fn mode_footer_text(app: &App) -> Vec<Span> {
     }]
 }
 
-pub fn keys_hint(app: &App) -> Span {
+pub fn keys_hint(app: &App) -> Span<'_> {
     let edit_config_state = app.edit_config.as_ref().unwrap();
     match edit_config_state.is_editing() {
         true => Span::styled(

--- a/src/ui/latest.rs
+++ b/src/ui/latest.rs
@@ -67,7 +67,7 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
     f.render_stateful_widget(list, chunk, &mut list_state);
 }
 
-pub fn mode_footer_text(app: &App) -> Vec<Span> {
+pub fn mode_footer_text(app: &App) -> Vec<Span<'_>> {
     vec![Span::styled(
         format!(
             "Latest Patchsets from {} (page {})",

--- a/src/ui/mail_list.rs
+++ b/src/ui/mail_list.rs
@@ -54,11 +54,10 @@ pub fn mode_footer_text(app: &App) -> Vec<Span<'_>> {
     let text_area = if app.mailing_list_selection.target_list.is_empty() {
         Span::styled("type the target list", Style::default().fg(Color::DarkGray))
     } else {
-        let exact_match = app
-            .mailing_list_selection
-            .mailing_lists
-            .iter()
-            .any(|ml| ml.name() == &app.mailing_list_selection.target_list);
+        let exact_match = app.mailing_list_selection.mailing_lists.iter().any(|ml| {
+            ml.name()
+                .eq_ignore_ascii_case(&app.mailing_list_selection.target_list)
+        });
 
         if exact_match {
             Span::styled(

--- a/src/ui/mail_list.rs
+++ b/src/ui/mail_list.rs
@@ -50,39 +50,33 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
     f.render_stateful_widget(list, chunk, &mut list_state);
 }
 
-pub fn mode_footer_text(app: &App) -> Vec<Span> {
-    let mut text_area = Span::default();
-
-    if app.mailing_list_selection.target_list.is_empty() {
-        text_area = Span::styled("type the target list", Style::default().fg(Color::DarkGray))
+pub fn mode_footer_text(app: &App) -> Vec<Span<'_>> {
+    let text_area = if app.mailing_list_selection.target_list.is_empty() {
+        Span::styled("type the target list", Style::default().fg(Color::DarkGray))
     } else {
-        for mailing_list in &app.mailing_list_selection.mailing_lists {
-            if mailing_list
-                .name()
-                .eq(&app.mailing_list_selection.target_list)
-            {
-                text_area = Span::styled(
-                    &app.mailing_list_selection.target_list,
-                    Style::default().fg(Color::Green),
-                );
-                break;
-            } else if mailing_list
-                .name()
-                .starts_with(&app.mailing_list_selection.target_list)
-            {
-                text_area = Span::styled(
-                    &app.mailing_list_selection.target_list,
-                    Style::default().fg(Color::LightCyan),
-                );
-            }
-        }
-        if text_area.content.is_empty() {
-            text_area = Span::styled(
+        let exact_match = app
+            .mailing_list_selection
+            .mailing_lists
+            .iter()
+            .any(|ml| ml.name() == &app.mailing_list_selection.target_list);
+
+        if exact_match {
+            Span::styled(
+                &app.mailing_list_selection.target_list,
+                Style::default().fg(Color::Green),
+            )
+        } else if !app.mailing_list_selection.possible_mailing_lists.is_empty() {
+            Span::styled(
+                &app.mailing_list_selection.target_list,
+                Style::default().fg(Color::LightCyan),
+            )
+        } else {
+            Span::styled(
                 &app.mailing_list_selection.target_list,
                 Style::default().fg(Color::Red),
-            );
+            )
         }
-    }
+    };
 
     vec![
         Span::styled("Target List: ", Style::default().fg(Color::Green)),


### PR DESCRIPTION
## Improved Mailing List Filtering & UI Cleanup


https://github.com/user-attachments/assets/4ff033a0-ea12-44b3-a5c9-8c66279229cf


### Changes
* **Search:** Switched from prefix matching to substring matching. It now searches both **names** and **descriptions** (case-insensitive).
* **UI:** Updated the footer to provide visual feedback. It now differentiates between exact, partial, and zero matches using color-coded status.
* **Refactor:** Fixed `Span<'_>` lifetime annotations in the UI components to resolve compiler warnings and improve type consistency.

### Why?
The previous "starts with" search was too restrictive. I was attempting to find the f2fs mailing list, and my eyes just weren't wanting to find it. The filter didn't help, and I decided to make some changes. This makes finding lists much more intuitive, especially when you only remember a keyword from the description.
