### PR TITLE
Phase 1 - Refactoring: Traits extraction

### DIFF
--- a/src/app/config/mod.rs
+++ b/src/app/config/mod.rs
@@ -4,11 +4,11 @@ use serde::{Deserialize, Serialize};
 
 use std::{
     collections::{HashMap, HashSet},
-    env,
-    fs::{self, File},
-    io,
+    env, io,
     path::Path,
 };
+
+use crate::infrastructure::file_system::{FileSystemError, FileSystemTrait};
 
 pub const DEFAULT_CONFIG_PATH_SUFFIX: &str = ".config/patch-hub/config.json";
 
@@ -91,11 +91,11 @@ impl Config {
     /// Loads the configuration for patch-hub from the config file.
     ///
     /// Returns the default config if the config file is not found or if it's not a valid JSON.
-    fn load_file() -> Config {
+    fn load_file(fs: &dyn FileSystemTrait) -> Config {
         let config_path = Config::get_config_path();
 
-        if Path::new(&config_path).is_file() {
-            match fs::read_to_string(&config_path) {
+        if fs.is_file(Path::new(&config_path)) {
+            match fs.read_to_string(Path::new(&config_path)) {
                 Ok(file_contents) => match serde_json::from_str(&file_contents) {
                     Ok(config) => return config,
                     Err(e) => eprintln!("Failed to parse config file {config_path}: {e}"),
@@ -137,9 +137,9 @@ impl Config {
     /// [tests::can_build_with_config_file]
     /// [tests::can_build_with_env_vars]
     /// [tests::test_config_precedence]
-    pub fn build() -> Self {
-        let mut config = Self::load_file();
-        config.save_patch_hub_config().unwrap_or_else(|e| {
+    pub fn build(fs: &dyn FileSystemTrait) -> Self {
+        let mut config = Self::load_file(fs);
+        config.save_patch_hub_config(fs).unwrap_or_else(|e| {
             eprintln!("Failed to save default config: {e}");
         });
         config.override_with_env_vars();
@@ -205,21 +205,20 @@ impl Config {
         self.max_log_age = max_log_age;
     }
 
-    pub fn save_patch_hub_config(&self) -> io::Result<()> {
+    pub fn save_patch_hub_config(&self, fs: &dyn FileSystemTrait) -> Result<(), FileSystemError> {
         let config_path = Config::get_config_path();
 
         let config_path = Path::new(&config_path);
-        // We need to assure that the parent dir of `config_path` exists
         if let Some(parent_dir) = Path::parent(config_path) {
-            fs::create_dir_all(parent_dir)?;
+            fs.create_dir_all(parent_dir)?;
         }
 
         let tmp_filename = format!("{}.tmp", config_path.display());
         {
-            let tmp_file = File::create(&tmp_filename)?;
-            serde_json::to_writer_pretty(tmp_file, self)?;
+            let tmp_file = fs.create_writer(Path::new(&tmp_filename))?;
+            serde_json::to_writer_pretty(tmp_file, self).map_err(io::Error::from)?;
         }
-        fs::rename(tmp_filename, config_path)?;
+        fs.rename(Path::new(&tmp_filename), config_path)?;
         Ok(())
     }
 
@@ -239,7 +238,7 @@ impl Config {
     /// The directories are defined during the Config build.
     ///
     /// This function must be called as soon as the Config is built so no other function attempt to use an inexistent folder.
-    pub fn create_dirs(&self) {
+    pub fn create_dirs(&self, fs: &dyn FileSystemTrait) {
         let paths = vec![
             &self.cache_dir,
             &self.data_dir,
@@ -248,8 +247,8 @@ impl Config {
         ];
 
         for path in paths {
-            if fs::metadata(path).is_err() {
-                fs::create_dir_all(path).unwrap();
+            if fs.metadata(Path::new(path)).is_err() {
+                fs.create_dir_all(Path::new(path)).unwrap();
             }
         }
     }

--- a/src/app/config/mod.rs
+++ b/src/app/config/mod.rs
@@ -4,11 +4,14 @@ use serde::{Deserialize, Serialize};
 
 use std::{
     collections::{HashMap, HashSet},
-    env, io,
+    io,
     path::Path,
 };
 
-use crate::infrastructure::file_system::{FileSystemError, FileSystemTrait};
+use crate::infrastructure::{
+    env::EnvTrait,
+    file_system::{FileSystemError, FileSystemTrait},
+};
 
 pub const DEFAULT_CONFIG_PATH_SUFFIX: &str = ".config/patch-hub/config.json";
 
@@ -58,14 +61,35 @@ pub struct KernelTree {
 }
 
 impl Default for Config {
+    /// Produces a config whose path fields are derived from the real `HOME`
+    /// environment variable. This impl exists primarily to satisfy
+    /// `#[serde_individual_default]` for per-field serde defaults during
+    /// deserialization. For application startup, prefer
+    /// [`Config::new_with_defaults`] which accepts an [`EnvTrait`].
     fn default() -> Self {
-        let home = env::var("HOME").unwrap_or_else(|_| {
+        let home = std::env::var("HOME").unwrap_or_else(|_| {
             eprintln!("$HOME environment variable not set, using current directory");
             ".".to_string()
         });
+        Config::defaults_from_home(&home)
+    }
+}
+
+impl Config {
+    /// Builds a default `Config` whose path fields are derived from `HOME`
+    /// as returned by `env`. Use this instead of `Default::default()` in all
+    /// production paths.
+    fn new_with_defaults(env: &dyn EnvTrait) -> Self {
+        let home = env.var("HOME").unwrap_or_else(|_| {
+            eprintln!("$HOME environment variable not set, using current directory");
+            ".".to_string()
+        });
+        Config::defaults_from_home(&home)
+    }
+
+    fn defaults_from_home(home: &str) -> Self {
         let cache_dir = format!("{home}/.cache/patch_hub");
         let data_dir = format!("{home}/.local/share/patch_hub");
-
         Config {
             page_size: 30,
             patchsets_cache_dir: format!("{cache_dir}/patchsets"),
@@ -85,14 +109,12 @@ impl Default for Config {
             git_am_branch_prefix: String::from("patchset-"),
         }
     }
-}
 
-impl Config {
     /// Loads the configuration for patch-hub from the config file.
     ///
     /// Returns the default config if the config file is not found or if it's not a valid JSON.
-    fn load_file(fs: &dyn FileSystemTrait) -> Config {
-        let config_path = Config::get_config_path();
+    fn load_file(env: &dyn EnvTrait, fs: &dyn FileSystemTrait) -> Config {
+        let config_path = Config::get_config_path(env);
 
         if fs.is_file(Path::new(&config_path)) {
             match fs.read_to_string(Path::new(&config_path)) {
@@ -106,27 +128,27 @@ impl Config {
             }
         }
 
-        Config::default()
+        Config::new_with_defaults(env)
     }
 
-    fn override_with_env_vars(&mut self) {
-        if let Ok(page_size) = env::var("PATCH_HUB_PAGE_SIZE") {
+    fn override_with_env_vars(&mut self, env: &dyn EnvTrait) {
+        if let Ok(page_size) = env.var("PATCH_HUB_PAGE_SIZE") {
             self.page_size = page_size.parse().unwrap();
         };
 
-        if let Ok(cache_dir) = env::var("PATCH_HUB_CACHE_DIR") {
+        if let Ok(cache_dir) = env.var("PATCH_HUB_CACHE_DIR") {
             self.set_cache_dir(cache_dir);
         };
 
-        if let Ok(data_dir) = env::var("PATCH_HUB_DATA_DIR") {
+        if let Ok(data_dir) = env.var("PATCH_HUB_DATA_DIR") {
             self.set_data_dir(data_dir);
         };
 
-        if let Ok(git_send_email_options) = env::var("PATCH_HUB_GIT_SEND_EMAIL_OPTIONS") {
+        if let Ok(git_send_email_options) = env.var("PATCH_HUB_GIT_SEND_EMAIL_OPTIONS") {
             self.git_send_email_options = git_send_email_options;
         };
 
-        if let Ok(patch_renderer) = env::var("PATCH_HUB_PATCH_RENDERER") {
+        if let Ok(patch_renderer) = env.var("PATCH_HUB_PATCH_RENDERER") {
             self.patch_renderer = patch_renderer.into();
         };
     }
@@ -137,12 +159,12 @@ impl Config {
     /// [tests::can_build_with_config_file]
     /// [tests::can_build_with_env_vars]
     /// [tests::test_config_precedence]
-    pub fn build(fs: &dyn FileSystemTrait) -> Self {
-        let mut config = Self::load_file(fs);
-        config.save_patch_hub_config(fs).unwrap_or_else(|e| {
+    pub fn build(env: &dyn EnvTrait, fs: &dyn FileSystemTrait) -> Self {
+        let mut config = Self::load_file(env, fs);
+        config.save_patch_hub_config(env, fs).unwrap_or_else(|e| {
             eprintln!("Failed to save default config: {e}");
         });
-        config.override_with_env_vars();
+        config.override_with_env_vars(env);
 
         config
     }
@@ -205,8 +227,12 @@ impl Config {
         self.max_log_age = max_log_age;
     }
 
-    pub fn save_patch_hub_config(&self, fs: &dyn FileSystemTrait) -> Result<(), FileSystemError> {
-        let config_path = Config::get_config_path();
+    pub fn save_patch_hub_config(
+        &self,
+        env: &dyn EnvTrait,
+        fs: &dyn FileSystemTrait,
+    ) -> Result<(), FileSystemError> {
+        let config_path = Config::get_config_path(env);
 
         let config_path = Path::new(&config_path);
         if let Some(parent_dir) = Path::parent(config_path) {
@@ -226,12 +252,14 @@ impl Config {
     ///
     /// Resolves to env var PATCH_HUB_CONFIG_PATH, if set, and to env var HOME
     /// plus constant DEFAULT_CONFIG_PATH_SUFFIX, otherwise.
-    fn get_config_path() -> String {
-        env::var("PATCH_HUB_CONFIG_PATH").unwrap_or(format!(
-            "{}/{}",
-            env::var("HOME").unwrap(),
-            DEFAULT_CONFIG_PATH_SUFFIX
-        ))
+    fn get_config_path(env: &dyn EnvTrait) -> String {
+        env.var("PATCH_HUB_CONFIG_PATH").unwrap_or_else(|_| {
+            format!(
+                "{}/{}",
+                env.var("HOME").unwrap(),
+                DEFAULT_CONFIG_PATH_SUFFIX
+            )
+        })
     }
 
     /// Creates the needed directories if they don't exist.

--- a/src/app/config/tests.rs
+++ b/src/app/config/tests.rs
@@ -2,7 +2,13 @@ use serde_json::json;
 
 use super::*;
 
-use std::{process::Command, sync::Mutex};
+use std::{fs, process::Command, sync::Mutex};
+
+use crate::infrastructure::file_system::OsFileSystem;
+
+fn os_fs() -> OsFileSystem {
+    OsFileSystem
+}
 
 static TEST_LOCK: Mutex<()> = Mutex::new(());
 static mut TMP_CONFIG_SAMPLE_FILE_PATH: String = String::new();
@@ -51,7 +57,7 @@ fn can_build_with_default_values() {
     let _lock = TEST_LOCK.lock().unwrap();
 
     env::set_var("HOME", "/fake/home/path");
-    let config = Config::build();
+    let config = Config::build(&os_fs());
 
     assert_eq!(30, config.page_size());
     assert_eq!(
@@ -91,7 +97,7 @@ fn can_build_with_config_file() {
     let _lock = TEST_LOCK.lock().unwrap();
 
     setup_tmp_config_sample_file();
-    let config = Config::build();
+    let config = Config::build(&os_fs());
     teardown_tmp_config_sample_file();
 
     assert_eq!(1234, config.page_size());
@@ -137,7 +143,7 @@ fn can_build_with_env_vars() {
     env::set_var("PATCH_HUB_CACHE_DIR", "/fake/cache/path");
     env::set_var("PATCH_HUB_DATA_DIR", "/fake/data/path");
     env::set_var("PATCH_HUB_GIT_SEND_EMAIL_OPTIONS", "--option1 --option2");
-    let config = Config::build();
+    let config = Config::build(&os_fs());
     env::remove_var("PATCH_HUB_PAGE_SIZE");
     env::remove_var("PATCH_HUB_CACHE_DIR");
     env::remove_var("PATCH_HUB_DATA_DIR");
@@ -171,17 +177,17 @@ fn test_config_precedence() {
 
     // Default values
     env::set_var("HOME", "/fake/home/path");
-    let config = Config::build();
+    let config = Config::build(&os_fs());
     assert_eq!(30, config.page_size());
 
     // Config file should have precedence over default values
     setup_tmp_config_sample_file();
-    let config = Config::build();
+    let config = Config::build(&os_fs());
     assert_eq!(1234, config.page_size());
 
     // Env vars should have precedence over default values
     env::set_var("PATCH_HUB_PAGE_SIZE", "42");
-    let config = Config::build();
+    let config = Config::build(&os_fs());
     assert_eq!(42, config.page_size());
 
     teardown_tmp_config_sample_file();

--- a/src/app/config/tests.rs
+++ b/src/app/config/tests.rs
@@ -1,63 +1,45 @@
 use serde_json::json;
+use std::{env::VarError, fs, process::Command};
 
 use super::*;
 
-use std::{fs, process::Command, sync::Mutex};
-
-use crate::infrastructure::file_system::OsFileSystem;
+use crate::infrastructure::{env::MockEnvTrait, file_system::OsFileSystem};
 
 fn os_fs() -> OsFileSystem {
     OsFileSystem
 }
 
-static TEST_LOCK: Mutex<()> = Mutex::new(());
-static mut TMP_CONFIG_SAMPLE_FILE_PATH: String = String::new();
-
-fn setup_tmp_config_sample_file() {
-    #[allow(static_mut_refs)]
-    unsafe {
-        // Create temporary file
-        TMP_CONFIG_SAMPLE_FILE_PATH = String::from_utf8(
-            Command::new("mktemp")
-                .output()
-                .expect("Failed to create temporary file!")
-                .stdout,
-        )
-        .expect("Couldn't convert `mktemp` output to String!");
-
-        // Copy contents from sample config file to temporary file
-        fs::copy(
-            "test_samples/app/config/config.json",
-            &TMP_CONFIG_SAMPLE_FILE_PATH,
-        )
-        .expect("Couldn't copy config sample file contents to temporary file!");
-
-        // Set temporary config file to be used instead of the git tracked sample file
-        env::set_var("PATCH_HUB_CONFIG_PATH", &TMP_CONFIG_SAMPLE_FILE_PATH);
-    };
-}
-
-fn teardown_tmp_config_sample_file() {
-    #[allow(static_mut_refs)]
-    unsafe {
-        // Sanitizing temporary file
-        let _ = Command::new("rm")
-            .arg(&TMP_CONFIG_SAMPLE_FILE_PATH)
-            .output()
-            .expect("Couldn't remove temporary config sample file!");
-
-        // Unset config file to used
-        env::remove_var("PATCH_HUB_CONFIG_PATH");
-    }
+/// Returns a `MockEnvTrait` that responds to all PATCH_HUB_* and HOME/config
+/// path vars with `NotPresent`, and returns `home` for `HOME`.
+fn default_env(home: &str) -> MockEnvTrait {
+    let home = home.to_string();
+    let mut mock = MockEnvTrait::new();
+    mock.expect_var()
+        .withf(|key| key == "PATCH_HUB_CONFIG_PATH")
+        .returning(|_| Err(VarError::NotPresent.into()));
+    mock.expect_var()
+        .withf(move |key| key == "HOME")
+        .returning(move |_| Ok(home.clone()));
+    mock.expect_var()
+        .withf(|key| {
+            matches!(
+                key,
+                "PATCH_HUB_PAGE_SIZE"
+                    | "PATCH_HUB_CACHE_DIR"
+                    | "PATCH_HUB_DATA_DIR"
+                    | "PATCH_HUB_GIT_SEND_EMAIL_OPTIONS"
+                    | "PATCH_HUB_PATCH_RENDERER"
+            )
+        })
+        .returning(|_| Err(VarError::NotPresent.into()));
+    mock
 }
 
 #[test]
 /// Tests [`Config::build`]
 fn can_build_with_default_values() {
-    let _lock = TEST_LOCK.lock().unwrap();
-
-    env::set_var("HOME", "/fake/home/path");
-    let config = Config::build(&os_fs());
+    let env = default_env("/fake/home/path");
+    let config = Config::build(&env, &os_fs());
 
     assert_eq!(30, config.page_size());
     assert_eq!(
@@ -94,11 +76,41 @@ fn can_build_with_default_values() {
 #[test]
 /// Tests [`Config::build`]
 fn can_build_with_config_file() {
-    let _lock = TEST_LOCK.lock().unwrap();
+    let tmp_path = String::from_utf8(
+        Command::new("mktemp")
+            .output()
+            .expect("Failed to create temporary file!")
+            .stdout,
+    )
+    .expect("Couldn't convert `mktemp` output to String!")
+    .trim()
+    .to_string();
 
-    setup_tmp_config_sample_file();
-    let config = Config::build(&os_fs());
-    teardown_tmp_config_sample_file();
+    fs::copy("test_samples/app/config/config.json", &tmp_path)
+        .expect("Couldn't copy config sample file!");
+
+    let tmp_path_clone = tmp_path.clone();
+    let mut mock = MockEnvTrait::new();
+    mock.expect_var()
+        .withf(|key| key == "PATCH_HUB_CONFIG_PATH")
+        .returning(move |_| Ok(tmp_path_clone.clone()));
+    mock.expect_var()
+        .withf(|key| {
+            matches!(
+                key,
+                "HOME"
+                    | "PATCH_HUB_PAGE_SIZE"
+                    | "PATCH_HUB_CACHE_DIR"
+                    | "PATCH_HUB_DATA_DIR"
+                    | "PATCH_HUB_GIT_SEND_EMAIL_OPTIONS"
+                    | "PATCH_HUB_PATCH_RENDERER"
+            )
+        })
+        .returning(|_| Err(VarError::NotPresent.into()));
+
+    let config = Config::build(&mock, &os_fs());
+
+    let _ = fs::remove_file(&tmp_path);
 
     assert_eq!(1234, config.page_size());
     assert_eq!("/cachedir/path", config.patchsets_cache_dir());
@@ -137,17 +149,30 @@ fn can_build_with_config_file() {
 #[test]
 /// Tests [`Config::build`]
 fn can_build_with_env_vars() {
-    let _lock = TEST_LOCK.lock().unwrap();
+    let mut mock = MockEnvTrait::new();
+    mock.expect_var()
+        .withf(|key| key == "PATCH_HUB_CONFIG_PATH")
+        .returning(|_| Err(VarError::NotPresent.into()));
+    mock.expect_var()
+        .withf(|key| key == "HOME")
+        .returning(|_| Ok("/fake/home/path".to_string()));
+    mock.expect_var()
+        .withf(|key| key == "PATCH_HUB_PAGE_SIZE")
+        .returning(|_| Ok("42".to_string()));
+    mock.expect_var()
+        .withf(|key| key == "PATCH_HUB_CACHE_DIR")
+        .returning(|_| Ok("/fake/cache/path".to_string()));
+    mock.expect_var()
+        .withf(|key| key == "PATCH_HUB_DATA_DIR")
+        .returning(|_| Ok("/fake/data/path".to_string()));
+    mock.expect_var()
+        .withf(|key| key == "PATCH_HUB_GIT_SEND_EMAIL_OPTIONS")
+        .returning(|_| Ok("--option1 --option2".to_string()));
+    mock.expect_var()
+        .withf(|key| key == "PATCH_HUB_PATCH_RENDERER")
+        .returning(|_| Err(VarError::NotPresent.into()));
 
-    env::set_var("PATCH_HUB_PAGE_SIZE", "42");
-    env::set_var("PATCH_HUB_CACHE_DIR", "/fake/cache/path");
-    env::set_var("PATCH_HUB_DATA_DIR", "/fake/data/path");
-    env::set_var("PATCH_HUB_GIT_SEND_EMAIL_OPTIONS", "--option1 --option2");
-    let config = Config::build(&os_fs());
-    env::remove_var("PATCH_HUB_PAGE_SIZE");
-    env::remove_var("PATCH_HUB_CACHE_DIR");
-    env::remove_var("PATCH_HUB_DATA_DIR");
-    env::remove_var("PATCH_HUB_GIT_SEND_EMAIL_OPTIONS");
+    let config = Config::build(&mock, &os_fs());
 
     assert_eq!(42, config.page_size());
     assert_eq!("/fake/cache/path/patchsets", config.patchsets_cache_dir());
@@ -165,33 +190,83 @@ fn can_build_with_env_vars() {
     );
     assert_eq!("/fake/data/path/logs", config.logs_path());
     assert_eq!("--option1 --option2", config.git_send_email_options());
-
-    env::remove_var("PATCH_HUB_CACHE_DIR");
-    env::remove_var("PATCH_HUB_DATA_DIR");
 }
 
 #[test]
 /// Tests [`Config::build`]
 fn test_config_precedence() {
-    let _lock = TEST_LOCK.lock().unwrap();
-
     // Default values
-    env::set_var("HOME", "/fake/home/path");
-    let config = Config::build(&os_fs());
+    let env = default_env("/fake/home/path");
+    let config = Config::build(&env, &os_fs());
     assert_eq!(30, config.page_size());
 
     // Config file should have precedence over default values
-    setup_tmp_config_sample_file();
-    let config = Config::build(&os_fs());
+    let tmp_path = String::from_utf8(
+        Command::new("mktemp")
+            .output()
+            .expect("Failed to create temporary file!")
+            .stdout,
+    )
+    .expect("Couldn't convert `mktemp` output to String!")
+    .trim()
+    .to_string();
+
+    fs::copy("test_samples/app/config/config.json", &tmp_path)
+        .expect("Couldn't copy config sample file!");
+
+    let tmp_path_clone = tmp_path.clone();
+    let mut env_with_file = MockEnvTrait::new();
+    env_with_file
+        .expect_var()
+        .withf(|key| key == "PATCH_HUB_CONFIG_PATH")
+        .returning(move |_| Ok(tmp_path_clone.clone()));
+    env_with_file
+        .expect_var()
+        .withf(|key| {
+            matches!(
+                key,
+                "HOME"
+                    | "PATCH_HUB_PAGE_SIZE"
+                    | "PATCH_HUB_CACHE_DIR"
+                    | "PATCH_HUB_DATA_DIR"
+                    | "PATCH_HUB_GIT_SEND_EMAIL_OPTIONS"
+                    | "PATCH_HUB_PATCH_RENDERER"
+            )
+        })
+        .returning(|_| Err(VarError::NotPresent.into()));
+
+    let config = Config::build(&env_with_file, &os_fs());
     assert_eq!(1234, config.page_size());
 
-    // Env vars should have precedence over default values
-    env::set_var("PATCH_HUB_PAGE_SIZE", "42");
-    let config = Config::build(&os_fs());
+    // Env vars should have precedence over config file values
+    let tmp_path_clone2 = tmp_path.clone();
+    let mut env_with_file_and_var = MockEnvTrait::new();
+    env_with_file_and_var
+        .expect_var()
+        .withf(|key| key == "PATCH_HUB_CONFIG_PATH")
+        .returning(move |_| Ok(tmp_path_clone2.clone()));
+    env_with_file_and_var
+        .expect_var()
+        .withf(|key| key == "PATCH_HUB_PAGE_SIZE")
+        .returning(|_| Ok("42".to_string()));
+    env_with_file_and_var
+        .expect_var()
+        .withf(|key| {
+            matches!(
+                key,
+                "HOME"
+                    | "PATCH_HUB_CACHE_DIR"
+                    | "PATCH_HUB_DATA_DIR"
+                    | "PATCH_HUB_GIT_SEND_EMAIL_OPTIONS"
+                    | "PATCH_HUB_PATCH_RENDERER"
+            )
+        })
+        .returning(|_| Err(VarError::NotPresent.into()));
+
+    let config = Config::build(&env_with_file_and_var, &os_fs());
     assert_eq!(42, config.page_size());
 
-    teardown_tmp_config_sample_file();
-    env::remove_var("PATCH_HUB_PAGE_SIZE");
+    let _ = fs::remove_file(&tmp_path);
 }
 
 #[test]

--- a/src/app/cover_renderer.rs
+++ b/src/app/cover_renderer.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
-
-use std::{
-    fmt::Display,
-    io::Write,
-    process::{Command, Stdio},
-};
 use tracing::{event, Level};
+
+use std::fmt::Display;
+
+use color_eyre::eyre::eyre;
+
+use crate::infrastructure::shell::{ShellCommand, ShellTrait};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Default)]
 pub enum CoverRenderer {
@@ -43,10 +43,14 @@ impl Display for CoverRenderer {
     }
 }
 
-pub fn render_cover(raw: &str, renderer: &CoverRenderer) -> color_eyre::Result<String> {
+pub fn render_cover(
+    shell: &dyn ShellTrait,
+    raw: &str,
+    renderer: &CoverRenderer,
+) -> color_eyre::Result<String> {
     let text = match renderer {
         CoverRenderer::Default => Ok(raw.to_string()),
-        CoverRenderer::Bat => bat_cover_renderer(raw),
+        CoverRenderer::Bat => bat_cover_renderer(shell, raw),
     }?;
 
     Ok(text)
@@ -57,21 +61,15 @@ pub fn render_cover(raw: &str, renderer: &CoverRenderer) -> color_eyre::Result<S
 /// # Errors
 ///
 /// If bat isn't installed or if the command fails, an error will be returned.
-fn bat_cover_renderer(patch: &str) -> color_eyre::Result<String> {
-    let mut bat = Command::new("bat")
-        .arg("-pp")
-        .arg("-f")
-        .arg("-l")
-        .arg("mbx")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
+fn bat_cover_renderer(shell: &dyn ShellTrait, patch: &str) -> color_eyre::Result<String> {
+    let cmd = ShellCommand::new("bat").args(["-pp", "-f", "-l", "mbx"]);
+
+    let out = shell
+        .execute_with_stdin(&cmd, patch.as_bytes())
         .map_err(|e| {
             event!(Level::ERROR, "Failed to spawn bat for cover preview: {}", e);
-            e
+            eyre!(e)
         })?;
 
-    bat.stdin.as_mut().unwrap().write_all(patch.as_bytes())?;
-    let output = bat.wait_with_output()?;
-    Ok(String::from_utf8(output.stdout)?)
+    Ok(String::from_utf8(out.stdout)?)
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11,7 +11,9 @@ use tracing::{event, Level};
 use std::collections::{HashMap, HashSet};
 
 use crate::{
-    infrastructure::monitoring::logging::garbage_collector::collect_garbage,
+    infrastructure::{
+        file_system::FileSystemTrait, monitoring::logging::garbage_collector::collect_garbage,
+    },
     log_on_error,
     lore::{
         lore_api_client::BlockingLoreAPIClient,
@@ -55,6 +57,8 @@ pub struct App {
     /// Client to handle Lore API requests and responses
     pub lore_api_client: BlockingLoreAPIClient,
     pub popup: Option<Box<dyn PopUp>>,
+    /// Filesystem abstraction
+    pub fs: Box<dyn FileSystemTrait>,
 }
 
 impl App {
@@ -65,16 +69,16 @@ impl App {
     /// # Returns
     ///
     /// `App` instance with loading configurations and app data.
-    pub fn new(config: Config) -> color_eyre::Result<Self> {
-        let mailing_lists =
-            lore_session::load_available_lists(config.mailing_lists_path()).unwrap_or_default();
+    pub fn new(config: Config, fs: Box<dyn FileSystemTrait>) -> color_eyre::Result<Self> {
+        let mailing_lists = lore_session::load_available_lists(&*fs, config.mailing_lists_path())
+            .unwrap_or_default();
 
         let bookmarked_patchsets =
-            lore_session::load_bookmarked_patchsets(config.bookmarked_patchsets_path())
+            lore_session::load_bookmarked_patchsets(&*fs, config.bookmarked_patchsets_path())
                 .unwrap_or_default();
 
         let reviewed_patchsets =
-            lore_session::load_reviewed_patchsets(config.reviewed_patchsets_path())
+            lore_session::load_reviewed_patchsets(&*fs, config.reviewed_patchsets_path())
                 .unwrap_or_default();
 
         let lore_api_client = BlockingLoreAPIClient::default();
@@ -103,6 +107,7 @@ impl App {
             config,
             lore_api_client,
             popup: None,
+            fs,
         })
     }
 
@@ -166,6 +171,7 @@ impl App {
         };
 
         let patchset_path: String = match lore_session::download_patchset(
+            &*self.fs,
             self.config.patchsets_cache_dir(),
             &representative_patch,
         ) {
@@ -175,7 +181,7 @@ impl App {
             }
         };
 
-        match log_on_error!(lore_session::split_patchset(&patchset_path)) {
+        match log_on_error!(lore_session::split_patchset(&*self.fs, &patchset_path)) {
             Ok(raw_patches) => {
                 let mut patches_preview: Vec<Text> = Vec::new();
                 for raw_patch in &raw_patches {
@@ -296,6 +302,7 @@ impl App {
         }
 
         lore_session::save_bookmarked_patchsets(
+            &*self.fs,
             &self.bookmarked_patchsets.bookmarked_patchsets,
             self.config.bookmarked_patchsets_path(),
         )?;
@@ -306,6 +313,7 @@ impl App {
                 .remove(&representative_patch.message_id().href)
                 .unwrap_or_default();
             details_actions.reply_patchset_with_reviewed_by(
+                &*self.fs,
                 "all",
                 self.config.git_send_email_options(),
                 &mut successful_indexes,
@@ -316,6 +324,7 @@ impl App {
             );
 
             lore_session::save_reviewed_patchsets(
+                &*self.fs,
                 &self.reviewed_patchsets,
                 self.config.reviewed_patchsets_path(),
             )?;
@@ -337,7 +346,7 @@ impl App {
                 .details_actions
                 .as_ref()
                 .unwrap()
-                .apply_patchset(&self.config)
+                .apply_patchset(&*self.fs, &self.config)
             {
                 Ok(msg) => InfoPopUp::generate_info_popup("Patchset Apply Success", &msg),
                 Err(msg) => InfoPopUp::generate_info_popup("Patchset Apply Fail", &msg),
@@ -369,10 +378,10 @@ impl App {
             if let Ok(page_size) = edit_config.page_size() {
                 self.config.set_page_size(page_size)
             }
-            if let Ok(cache_dir) = edit_config.cache_dir() {
+            if let Ok(cache_dir) = edit_config.cache_dir(&*self.fs) {
                 self.config.set_cache_dir(cache_dir)
             }
-            if let Ok(data_dir) = edit_config.data_dir() {
+            if let Ok(data_dir) = edit_config.data_dir(&*self.fs) {
                 self.config.set_data_dir(data_dir)
             }
             if let Ok(git_send_email_option) = edit_config.git_send_email_option() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -13,6 +13,7 @@ use std::collections::{HashMap, HashSet};
 use crate::{
     infrastructure::{
         file_system::FileSystemTrait, monitoring::logging::garbage_collector::collect_garbage,
+        shell::ShellTrait,
     },
     log_on_error,
     lore::{
@@ -59,6 +60,8 @@ pub struct App {
     pub popup: Option<Box<dyn PopUp>>,
     /// Filesystem abstraction
     pub fs: Box<dyn FileSystemTrait>,
+    /// Shell abstraction
+    pub shell: Box<dyn ShellTrait>,
 }
 
 impl App {
@@ -69,7 +72,11 @@ impl App {
     /// # Returns
     ///
     /// `App` instance with loading configurations and app data.
-    pub fn new(config: Config, fs: Box<dyn FileSystemTrait>) -> color_eyre::Result<Self> {
+    pub fn new(
+        config: Config,
+        fs: Box<dyn FileSystemTrait>,
+        shell: Box<dyn ShellTrait>,
+    ) -> color_eyre::Result<Self> {
         let mailing_lists = lore_session::load_available_lists(&*fs, config.mailing_lists_path())
             .unwrap_or_default();
 
@@ -108,6 +115,7 @@ impl App {
             lore_api_client,
             popup: None,
             fs,
+            shell,
         })
     }
 
@@ -172,6 +180,7 @@ impl App {
 
         let patchset_path: String = match lore_session::download_patchset(
             &*self.fs,
+            &*self.shell,
             self.config.patchsets_cache_dir(),
             &representative_patch,
         ) {
@@ -216,29 +225,32 @@ impl App {
                     tested_by.push(authors_tested_by);
                     acked_by.push(authors_acked_by);
 
-                    let rendered_cover = match render_cover(raw_cover, self.config.cover_renderer())
-                    {
-                        Ok(render) => render,
-                        Err(_) => {
-                            event!(
-                                Level::ERROR,
-                                "Failed to render cover preview with external program"
-                            );
-                            raw_cover.to_string()
-                        }
-                    };
-
-                    let rendered_patch =
-                        match render_patch_preview(raw_patch, self.config.patch_renderer()) {
+                    let rendered_cover =
+                        match render_cover(&*self.shell, raw_cover, self.config.cover_renderer()) {
                             Ok(render) => render,
                             Err(_) => {
                                 event!(
                                     Level::ERROR,
-                                    "Failed to render patch preview with external program",
+                                    "Failed to render cover preview with external program"
                                 );
-                                raw_patch.to_string()
+                                raw_cover.to_string()
                             }
                         };
+
+                    let rendered_patch = match render_patch_preview(
+                        &*self.shell,
+                        raw_patch,
+                        self.config.patch_renderer(),
+                    ) {
+                        Ok(render) => render,
+                        Err(_) => {
+                            event!(
+                                Level::ERROR,
+                                "Failed to render patch preview with external program",
+                            );
+                            raw_patch.to_string()
+                        }
+                    };
 
                     patches_preview
                         .push(format!("{rendered_cover}---\n{rendered_patch}").into_text()?);
@@ -314,6 +326,7 @@ impl App {
                 .unwrap_or_default();
             details_actions.reply_patchset_with_reviewed_by(
                 &*self.fs,
+                &*self.shell,
                 "all",
                 self.config.git_send_email_options(),
                 &mut successful_indexes,
@@ -342,12 +355,11 @@ impl App {
             .patchset_actions
             .get(&PatchsetAction::Apply)
         {
-            let popup = match self
-                .details_actions
-                .as_ref()
-                .unwrap()
-                .apply_patchset(&*self.fs, &self.config)
-            {
+            let popup = match self.details_actions.as_ref().unwrap().apply_patchset(
+                &*self.fs,
+                &*self.shell,
+                &self.config,
+            ) {
                 Ok(msg) => InfoPopUp::generate_info_popup("Patchset Apply Success", &msg),
                 Err(msg) => InfoPopUp::generate_info_popup("Patchset Apply Fail", &msg),
             };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -79,6 +79,7 @@ impl App {
         fs: Box<dyn FileSystemTrait>,
         shell: Box<dyn ShellTrait>,
         env: Box<dyn EnvTrait>,
+        lore_client: BlockingLoreAPIClient,
     ) -> color_eyre::Result<Self> {
         let mailing_lists = lore_session::load_available_lists(&*fs, config.mailing_lists_path())
             .unwrap_or_default();
@@ -91,8 +92,6 @@ impl App {
             lore_session::load_reviewed_patchsets(&*fs, config.reviewed_patchsets_path())
                 .unwrap_or_default();
 
-        let lore_api_client = BlockingLoreAPIClient::default();
-
         event!(Level::INFO, "patch-hub started");
         collect_garbage(&config);
 
@@ -104,7 +103,7 @@ impl App {
                 possible_mailing_lists: mailing_lists,
                 highlighted_list_index: 0,
                 mailing_lists_path: config.mailing_lists_path().to_string(),
-                lore_api_client: Box::new(lore_api_client.clone()),
+                lore_api_client: Box::new(lore_client.clone()),
             },
             latest_patchsets: None,
             details_actions: None,
@@ -115,7 +114,7 @@ impl App {
             },
             reviewed_patchsets,
             config,
-            lore_api_client,
+            lore_api_client: lore_client,
             popup: None,
             fs,
             shell,
@@ -280,7 +279,7 @@ impl App {
                     tested_by,
                     acked_by,
                     last_screen: self.current_screen.clone(),
-                    lore_api_client: self.lore_api_client.clone(),
+                    lore_api_client: Box::new(self.lore_api_client.clone()),
                     patchset_path,
                 });
                 // At this point, if the initialization is successful, we just

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,8 +12,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::{
     infrastructure::{
-        file_system::FileSystemTrait, monitoring::logging::garbage_collector::collect_garbage,
-        shell::ShellTrait,
+        env::EnvTrait, file_system::FileSystemTrait,
+        monitoring::logging::garbage_collector::collect_garbage, shell::ShellTrait,
     },
     log_on_error,
     lore::{
@@ -62,6 +62,8 @@ pub struct App {
     pub fs: Box<dyn FileSystemTrait>,
     /// Shell abstraction
     pub shell: Box<dyn ShellTrait>,
+    /// Environment abstraction
+    pub env: Box<dyn EnvTrait>,
 }
 
 impl App {
@@ -76,6 +78,7 @@ impl App {
         config: Config,
         fs: Box<dyn FileSystemTrait>,
         shell: Box<dyn ShellTrait>,
+        env: Box<dyn EnvTrait>,
     ) -> color_eyre::Result<Self> {
         let mailing_lists = lore_session::load_available_lists(&*fs, config.mailing_lists_path())
             .unwrap_or_default();
@@ -116,6 +119,7 @@ impl App {
             popup: None,
             fs,
             shell,
+            env,
         })
     }
 
@@ -426,7 +430,7 @@ impl App {
     pub fn check_external_deps(&self) -> bool {
         let mut app_can_run = true;
 
-        if which::which("b4").is_err() {
+        if !self.env.which("b4") {
             event!(
                 Level::ERROR,
                 "b4 is not installed, patchsets cannot be downloaded"
@@ -434,13 +438,13 @@ impl App {
             app_can_run = false;
         }
 
-        if which::which("git").is_err() {
+        if !self.env.which("git") {
             event!(Level::WARN, "git is not installed, send-email won't work");
         }
 
         match self.config.patch_renderer() {
             PatchRenderer::Bat => {
-                if which::which("bat").is_err() {
+                if !self.env.which("bat") {
                     event!(
                         Level::WARN,
                         "bat is not installed, patch rendering will fallback to default"
@@ -448,7 +452,7 @@ impl App {
                 }
             }
             PatchRenderer::Delta => {
-                if which::which("delta").is_err() {
+                if !self.env.which("delta") {
                     event!(
                         Level::WARN,
                         "delta is not installed, patch rendering will fallback to default",
@@ -456,7 +460,7 @@ impl App {
                 }
             }
             PatchRenderer::DiffSoFancy => {
-                if which::which("diff-so-fancy").is_err() {
+                if !self.env.which("diff-so-fancy") {
                     event!(
                         Level::WARN,
                         "diff-so-fancy is not installed, patch rendering will fallback to default",

--- a/src/app/patch_renderer.rs
+++ b/src/app/patch_renderer.rs
@@ -2,11 +2,9 @@ use color_eyre::eyre::eyre;
 use serde::{Deserialize, Serialize};
 use tracing::{event, Level};
 
-use std::{
-    fmt::Display,
-    io::Write,
-    process::{Command, Stdio},
-};
+use std::fmt::Display;
+
+use crate::infrastructure::shell::{ShellCommand, ShellTrait};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Default)]
 pub enum PatchRenderer {
@@ -54,12 +52,16 @@ impl Display for PatchRenderer {
     }
 }
 
-pub fn render_patch_preview(raw: &str, renderer: &PatchRenderer) -> color_eyre::Result<String> {
+pub fn render_patch_preview(
+    shell: &dyn ShellTrait,
+    raw: &str,
+    renderer: &PatchRenderer,
+) -> color_eyre::Result<String> {
     let text = match renderer {
         PatchRenderer::Default => Ok(raw.to_string()),
-        PatchRenderer::Bat => bat_patch_renderer(raw),
-        PatchRenderer::Delta => delta_patch_renderer(raw),
-        PatchRenderer::DiffSoFancy => diff_so_fancy_renderer(raw),
+        PatchRenderer::Bat => bat_patch_renderer(shell, raw),
+        PatchRenderer::Delta => delta_patch_renderer(shell, raw),
+        PatchRenderer::DiffSoFancy => diff_so_fancy_renderer(shell, raw),
     }?;
 
     Ok(text)
@@ -87,28 +89,19 @@ fn clean_patch_for_preview(patch: &str) -> String {
 /// # Tests
 ///
 /// [tests::test_bat_patch_renderer]
-fn bat_patch_renderer(patch: &str) -> color_eyre::Result<String> {
+fn bat_patch_renderer(shell: &dyn ShellTrait, patch: &str) -> color_eyre::Result<String> {
     let cleaned_patch = clean_patch_for_preview(patch);
 
-    let mut bat = Command::new("bat")
-        .arg("-pp")
-        .arg("-f")
-        .arg("-l")
-        .arg("patch")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
+    let cmd = ShellCommand::new("bat").args(["-pp", "-f", "-l", "patch"]);
+
+    let out = shell
+        .execute_with_stdin(&cmd, cleaned_patch.as_bytes())
         .map_err(|e| {
             event!(Level::ERROR, "Failed to spawn bat for patch preview: {}", e);
-            e
+            eyre!(e)
         })?;
 
-    bat.stdin
-        .as_mut()
-        .ok_or_else(|| eyre!("Failed to get stdin handle"))?
-        .write_all(cleaned_patch.as_bytes())?;
-    let output = bat.wait_with_output()?;
-    Ok(String::from_utf8(output.stdout)?)
+    Ok(String::from_utf8(out.stdout)?)
 }
 
 /// Renders a patch using the `delta` command line tool.
@@ -120,36 +113,31 @@ fn bat_patch_renderer(patch: &str) -> color_eyre::Result<String> {
 /// # Tests
 ///
 /// [tests::test_delta_patch_renderer]
-fn delta_patch_renderer(patch: &str) -> color_eyre::Result<String> {
+fn delta_patch_renderer(shell: &dyn ShellTrait, patch: &str) -> color_eyre::Result<String> {
     let cleaned_patch = clean_patch_for_preview(patch);
 
-    let mut delta = Command::new("delta")
-        .arg("--pager")
-        .arg("less")
-        .arg("--no-gitconfig")
-        .arg("--paging")
-        .arg("never")
-        .arg("-w")
-        .arg("130")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
+    let cmd = ShellCommand::new("delta").args([
+        "--pager",
+        "less",
+        "--no-gitconfig",
+        "--paging",
+        "never",
+        "-w",
+        "130",
+    ]);
+
+    let out = shell
+        .execute_with_stdin(&cmd, cleaned_patch.as_bytes())
         .map_err(|e| {
             event!(
                 Level::ERROR,
                 "Failed to spawn delta for patch preview: {}",
                 e
             );
-            e
+            eyre!(e)
         })?;
 
-    delta
-        .stdin
-        .as_mut()
-        .ok_or_else(|| eyre!("Failed to get stdin handle"))?
-        .write_all(cleaned_patch.as_bytes())?;
-    let output = delta.wait_with_output()?;
-    Ok(String::from_utf8(output.stdout)?)
+    Ok(String::from_utf8(out.stdout)?)
 }
 
 /// Renders a patch using the `diff-so-fancy` command line tool.
@@ -161,26 +149,21 @@ fn delta_patch_renderer(patch: &str) -> color_eyre::Result<String> {
 /// # Tests
 ///
 /// [tests::test_diff_so_fancy_renderer]
-fn diff_so_fancy_renderer(patch: &str) -> color_eyre::Result<String> {
+fn diff_so_fancy_renderer(shell: &dyn ShellTrait, patch: &str) -> color_eyre::Result<String> {
     let cleaned_patch = clean_patch_for_preview(patch);
 
-    let mut dsf = Command::new("diff-so-fancy")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
+    let cmd = ShellCommand::new("diff-so-fancy");
+
+    let out = shell
+        .execute_with_stdin(&cmd, cleaned_patch.as_bytes())
         .map_err(|e| {
             event!(
                 Level::ERROR,
                 "Failed to spawn diff-so-fancy for patch preview: {}",
                 e
             );
-            e
+            eyre!(e)
         })?;
 
-    dsf.stdin
-        .as_mut()
-        .ok_or_else(|| eyre!("Failed to get stdin handle"))?
-        .write_all(cleaned_patch.as_bytes())?;
-    let output = dsf.wait_with_output()?;
-    Ok(String::from_utf8(output.stdout)?)
+    Ok(String::from_utf8(out.stdout)?)
 }

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -9,6 +9,7 @@ use std::{
 
 use crate::{
     app::config::{Config, KernelTree},
+    infrastructure::file_system::FileSystemTrait,
     lore::{
         lore_api_client::BlockingLoreAPIClient,
         lore_session,
@@ -175,6 +176,7 @@ impl DetailsActions {
 
     pub fn reply_patchset_with_reviewed_by(
         &self,
+        fs: &dyn FileSystemTrait,
         target_list: &str,
         git_send_email_options: &str,
         successful_indexes: &mut HashSet<usize>,
@@ -197,6 +199,7 @@ impl DetailsActions {
         );
 
         let git_reply_commands = match lore_session::prepare_reply_patchset_with_reviewed_by(
+            fs,
             &self.lore_api_client,
             tmp_dir,
             target_list,
@@ -232,7 +235,11 @@ impl DetailsActions {
     /// that kernel tree is a valid git directory.
     ///
     /// Returns the a valid `KernelTree` or a `String` with the error message on failure.
-    fn validate_kernel_tree<'a>(&self, config: &'a Config) -> Result<&'a KernelTree, String> {
+    fn validate_kernel_tree<'a>(
+        &self,
+        fs: &dyn FileSystemTrait,
+        config: &'a Config,
+    ) -> Result<&'a KernelTree, String> {
         let kernel_tree_id = if let Some(target) = config.target_kernel_tree() {
             target
         } else {
@@ -246,9 +253,9 @@ impl DetailsActions {
         };
 
         let kernel_tree_path = Path::new(kernel_tree.path());
-        if !kernel_tree_path.is_dir() {
+        if !fs.is_dir(kernel_tree_path) {
             return Err(format!("{} isn't a directory", kernel_tree.path()));
-        } else if !kernel_tree_path.join(".git").is_dir() {
+        } else if !fs.is_dir(&kernel_tree_path.join(".git")) {
             return Err(format!("{} isn't a git repository", kernel_tree.path()));
         }
 
@@ -260,22 +267,26 @@ impl DetailsActions {
     // is valid.
     //
     // Returns `()` on success and a `String` with an error message on failure.
-    fn check_git_state(&self, kernel_tree: &KernelTree) -> Result<(), String> {
+    fn check_git_state(
+        &self,
+        fs: &dyn FileSystemTrait,
+        kernel_tree: &KernelTree,
+    ) -> Result<(), String> {
         let kernel_tree_path = Path::new(kernel_tree.path());
 
-        if kernel_tree_path.join(".git/rebase-merge").is_dir() {
+        if fs.is_dir(&kernel_tree_path.join(".git/rebase-merge")) {
             return Err(
                 "rebase in progress. \nrun `git rebase --abort` before continuing".to_string(),
             );
-        } else if kernel_tree_path.join(".git/MERGE_HEAD").is_file() {
+        } else if fs.is_file(&kernel_tree_path.join(".git/MERGE_HEAD")) {
             return Err(
                 "merge in progress. \nrun `git merge --abort` before continuing".to_string(),
             );
-        } else if kernel_tree_path.join(".git/BISECT_LOG").is_file() {
+        } else if fs.is_file(&kernel_tree_path.join(".git/BISECT_LOG")) {
             return Err(
                 "bisect in progress. \nrun `git bisect reset` before continuing".to_string(),
             );
-        } else if kernel_tree_path.join(".git/rebase-apply").is_dir() {
+        } else if fs.is_dir(&kernel_tree_path.join(".git/rebase-apply")) {
             return Err(
                 "`git am` already in progress. \nrun `git am --abort` before continuing"
                     .to_string(),
@@ -435,9 +446,13 @@ impl DetailsActions {
     /// Returns a `Result<String, String>` containing either the success or the error message.
     /// # TODO:
     /// - Add unit tests
-    pub fn apply_patchset(&self, config: &Config) -> Result<String, String> {
-        let kernel_tree = self.validate_kernel_tree(config)?;
-        self.check_git_state(kernel_tree)?;
+    pub fn apply_patchset(
+        &self,
+        fs: &dyn FileSystemTrait,
+        config: &Config,
+    ) -> Result<String, String> {
+        let kernel_tree = self.validate_kernel_tree(fs, config)?;
+        self.check_git_state(fs, kernel_tree)?;
 
         let original_branch = self.get_current_branch(kernel_tree)?;
         let target_branch = self.create_target_branch(kernel_tree, config)?;

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -1,15 +1,15 @@
 use color_eyre::eyre::{bail, eyre};
 use ratatui::text::Text;
 
-use std::{
-    collections::{HashMap, HashSet},
-    path::Path,
-    process::Command,
-};
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 use crate::{
     app::config::{Config, KernelTree},
-    infrastructure::file_system::FileSystemTrait,
+    infrastructure::{
+        file_system::FileSystemTrait,
+        shell::{ShellCommand, ShellTrait},
+    },
     lore::{
         lore_api_client::BlockingLoreAPIClient,
         lore_session,
@@ -177,23 +177,24 @@ impl DetailsActions {
     pub fn reply_patchset_with_reviewed_by(
         &self,
         fs: &dyn FileSystemTrait,
+        shell: &dyn ShellTrait,
         target_list: &str,
         git_send_email_options: &str,
         successful_indexes: &mut HashSet<usize>,
     ) -> color_eyre::Result<()> {
-        let (git_user_name, git_user_email) = lore_session::get_git_signature("");
+        let (git_user_name, git_user_email) = lore_session::get_git_signature(shell, "");
 
         if git_user_name.is_empty() || git_user_email.is_empty() {
             println!("`git config user.name` or `git config user.email` not set\nAborting...");
             return Ok(());
         }
 
-        let tmp_dir = Command::new("mktemp")
-            .arg("--directory")
-            .output()
+        let mktemp_cmd = ShellCommand::new("mktemp").arg("--directory");
+        let tmp_out = shell
+            .execute(&mktemp_cmd)
             .map_err(|e| eyre!("failed to create temp directory: {}", e))?;
         let tmp_dir = Path::new(
-            std::str::from_utf8(&tmp_dir.stdout)
+            std::str::from_utf8(&tmp_out.stdout)
                 .map_err(|e| eyre!("invalid utf-8 in temp dir path: {}", e))?
                 .trim(),
         );
@@ -220,10 +221,9 @@ impl DetailsActions {
             .enumerate()
             .filter_map(|(i, &val)| if val { Some(i) } else { None })
             .collect();
-        for (i, mut command) in git_reply_commands.into_iter().enumerate() {
-            let mut child = command.spawn().unwrap();
-            let exit_status = child.wait().unwrap();
-            if exit_status.success() {
+        for (i, command) in git_reply_commands.into_iter().enumerate() {
+            let success = shell.spawn_interactive(&command).unwrap_or(false);
+            if success {
                 successful_indexes.insert(reply_indexes[i]);
             }
         }
@@ -270,6 +270,7 @@ impl DetailsActions {
     fn check_git_state(
         &self,
         fs: &dyn FileSystemTrait,
+        shell: &dyn ShellTrait,
         kernel_tree: &KernelTree,
     ) -> Result<(), String> {
         let kernel_tree_path = Path::new(kernel_tree.path());
@@ -293,32 +294,33 @@ impl DetailsActions {
             );
         }
 
-        let git_status_out = Command::new("git")
-            .arg("-C")
-            .arg(kernel_tree.path())
-            .arg("status")
-            .arg("--porcelain")
-            .output()
+        let status_out = shell
+            .execute(
+                &ShellCommand::new("git")
+                    .arg("-C")
+                    .arg(kernel_tree.path())
+                    .args(["status", "--porcelain"]),
+            )
             .map_err(|e| format!("failed to check git status {e}"))?;
 
-        let status_output = String::from_utf8_lossy(&git_status_out.stdout);
+        let status_output = String::from_utf8_lossy(&status_out.stdout);
         if !status_output.is_empty() {
             return Err(format!(
                 "there are staged and/or unstaged changes\n{status_output}"
             ));
         }
 
-        let git_show_ref_out = Command::new("git")
-            .arg("-C")
-            .arg(kernel_tree.path())
-            .arg("show-ref")
-            .arg("--verify")
-            .arg("--quiet")
-            .arg(format!("refs/heads/{}", kernel_tree.branch()))
-            .output()
+        let show_ref_out = shell
+            .execute(
+                &ShellCommand::new("git")
+                    .arg("-C")
+                    .arg(kernel_tree.path())
+                    .args(["show-ref", "--verify", "--quiet"])
+                    .arg(format!("refs/heads/{}", kernel_tree.branch())),
+            )
             .map_err(|e| format!("failed to verify branch: {e}"))?;
 
-        if !git_show_ref_out.status.success() {
+        if !show_ref_out.success {
             return Err(format!(
                 "invalid branch '{}' for '{}'",
                 kernel_tree.branch(),
@@ -332,17 +334,21 @@ impl DetailsActions {
     /// Get the current branch of the supplied kernel tree
     ///
     /// Returns the branch name as a `String` or a `String` with the error message on failure
-    fn get_current_branch(&self, kernel_tree: &KernelTree) -> Result<String, String> {
-        let original_branch = Command::new("git")
-            .arg("-C")
-            .arg(kernel_tree.path())
-            .arg("rev-parse")
-            .arg("--abbrev-ref")
-            .arg("HEAD")
-            .output()
+    fn get_current_branch(
+        &self,
+        shell: &dyn ShellTrait,
+        kernel_tree: &KernelTree,
+    ) -> Result<String, String> {
+        let out = shell
+            .execute(
+                &ShellCommand::new("git")
+                    .arg("-C")
+                    .arg(kernel_tree.path())
+                    .args(["rev-parse", "--abbrev-ref", "HEAD"]),
+            )
             .map_err(|e| format!("failed to get current branch: {e}"))?;
 
-        let mut branch = String::from_utf8_lossy(&original_branch.stdout).to_string();
+        let mut branch = String::from_utf8_lossy(&out.stdout).to_string();
         branch.pop();
         Ok(branch)
     }
@@ -350,20 +356,26 @@ impl DetailsActions {
     /// Switch the supplied kernel tree to the supplied branch, if it exists.
     ///
     /// Returns `()` on sucess and a `String` with the error message on failure.
-    fn switch_to_branch(&self, kernel_tree: &KernelTree, branch: &str) -> Result<(), String> {
-        let output = Command::new("git")
-            .arg("-C")
-            .arg(kernel_tree.path())
-            .arg("switch")
-            .arg(branch)
-            .output()
+    fn switch_to_branch(
+        &self,
+        shell: &dyn ShellTrait,
+        kernel_tree: &KernelTree,
+        branch: &str,
+    ) -> Result<(), String> {
+        let out = shell
+            .execute(
+                &ShellCommand::new("git")
+                    .arg("-C")
+                    .arg(kernel_tree.path())
+                    .args(["switch", branch]),
+            )
             .map_err(|e| format!("failed to switch branch: {e}"))?;
 
-        if !output.status.success() {
+        if !out.success {
             return Err(format!(
                 "failed to switch to branch '{}': {}",
                 branch,
-                String::from_utf8_lossy(&output.stderr)
+                String::from_utf8_lossy(&out.stderr)
             ));
         }
 
@@ -376,10 +388,11 @@ impl DetailsActions {
     /// error message on failure.
     fn create_target_branch(
         &self,
+        shell: &dyn ShellTrait,
         kernel_tree: &KernelTree,
         config: &Config,
     ) -> Result<String, String> {
-        self.switch_to_branch(kernel_tree, kernel_tree.branch())?;
+        self.switch_to_branch(shell, kernel_tree, kernel_tree.branch())?;
 
         let target_branch_name = format!(
             "{}{}",
@@ -387,20 +400,20 @@ impl DetailsActions {
             chrono::Utc::now().format("%Y-%m-%d-%H-%M-%S")
         );
 
-        let output = Command::new("git")
-            .arg("-C")
-            .arg(kernel_tree.path())
-            .arg("checkout")
-            .arg("-b")
-            .arg(&target_branch_name)
-            .output()
+        let out = shell
+            .execute(
+                &ShellCommand::new("git")
+                    .arg("-C")
+                    .arg(kernel_tree.path())
+                    .args(["checkout", "-b", &target_branch_name]),
+            )
             .map_err(|e| format!("failed to create target branch: {e}"))?;
 
-        if !output.status.success() {
+        if !out.success {
             return Err(format!(
                 "failed to create branch '{}': {}",
                 target_branch_name,
-                String::from_utf8_lossy(&output.stderr)
+                String::from_utf8_lossy(&out.stderr)
             ));
         }
 
@@ -410,31 +423,33 @@ impl DetailsActions {
     /// Apply the selected patchset on the given `kernel_tree` with arguments from `Config`
     ///
     /// Returns `()` on sucess and a `String` containing the error message on failure.
-    fn run_git_am(&self, kernel_tree: &KernelTree, config: &Config) -> Result<(), String> {
-        let mut git_am_out = Command::new("git");
-        git_am_out
+    fn run_git_am(
+        &self,
+        shell: &dyn ShellTrait,
+        kernel_tree: &KernelTree,
+        config: &Config,
+    ) -> Result<(), String> {
+        let mut git_am_cmd = ShellCommand::new("git")
             .arg("-C")
             .arg(kernel_tree.path())
-            .arg("am")
-            .arg(&self.patchset_path);
-        config.git_am_options().split_whitespace().for_each(|opt| {
-            git_am_out.arg(opt);
-        });
+            .args(["am", &self.patchset_path]);
+        for opt in config.git_am_options().split_whitespace() {
+            git_am_cmd = git_am_cmd.arg(opt);
+        }
 
-        let git_am_out = git_am_out
-            .output()
+        let out = shell
+            .execute(&git_am_cmd)
             .map_err(|e| format!("failed to execute git-am: {e}"))?;
 
-        if !git_am_out.status.success() {
-            let _ = Command::new("git")
-                .arg("-C")
-                .arg(kernel_tree.path())
-                .arg("am")
-                .arg("--abort")
-                .output()
-                .map_err(|e| format!("failed to abort git-am: {e}"));
+        if !out.success {
+            let _ = shell.execute(
+                &ShellCommand::new("git")
+                    .arg("-C")
+                    .arg(kernel_tree.path())
+                    .args(["am", "--abort"]),
+            );
 
-            return Err(String::from_utf8_lossy(&git_am_out.stderr).to_string());
+            return Err(String::from_utf8_lossy(&out.stderr).to_string());
         }
 
         Ok(())
@@ -449,16 +464,17 @@ impl DetailsActions {
     pub fn apply_patchset(
         &self,
         fs: &dyn FileSystemTrait,
+        shell: &dyn ShellTrait,
         config: &Config,
     ) -> Result<String, String> {
         let kernel_tree = self.validate_kernel_tree(fs, config)?;
-        self.check_git_state(fs, kernel_tree)?;
+        self.check_git_state(fs, shell, kernel_tree)?;
 
-        let original_branch = self.get_current_branch(kernel_tree)?;
-        let target_branch = self.create_target_branch(kernel_tree, config)?;
+        let original_branch = self.get_current_branch(shell, kernel_tree)?;
+        let target_branch = self.create_target_branch(shell, kernel_tree, config)?;
 
-        let git_am_result = self.run_git_am(kernel_tree, config);
-        self.switch_to_branch(kernel_tree, &original_branch)?;
+        let git_am_result = self.run_git_am(shell, kernel_tree, config);
+        self.switch_to_branch(shell, kernel_tree, &original_branch)?;
 
         match git_am_result {
             Ok(_) => {

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -11,7 +11,7 @@ use crate::{
         shell::{ShellCommand, ShellTrait},
     },
     lore::{
-        lore_api_client::BlockingLoreAPIClient,
+        lore_api_client::PatchHTMLRequest,
         lore_session,
         patch::{Author, Patch},
     },
@@ -46,7 +46,7 @@ pub struct DetailsActions {
     /// For each patch, a set of `Authors` that appear in `Acked-by` trailers
     pub acked_by: Vec<HashSet<Author>>,
     pub last_screen: CurrentScreen,
-    pub lore_api_client: BlockingLoreAPIClient,
+    pub lore_api_client: Box<dyn PatchHTMLRequest>,
 }
 
 const LAST_LINE_PADDING: usize = 10;
@@ -201,7 +201,7 @@ impl DetailsActions {
 
         let git_reply_commands = match lore_session::prepare_reply_patchset_with_reviewed_by(
             fs,
-            &self.lore_api_client,
+            &*self.lore_api_client,
             tmp_dir,
             target_list,
             &self.raw_patches,

--- a/src/app/screens/edit_config.rs
+++ b/src/app/screens/edit_config.rs
@@ -3,7 +3,7 @@ use derive_getters::Getters;
 
 use std::{collections::HashMap, fmt::Display, path::Path};
 
-use crate::app::config::Config;
+use crate::{app::config::Config, infrastructure::file_system::FileSystemTrait};
 
 #[derive(Debug, Getters)]
 pub struct EditConfig {
@@ -138,13 +138,13 @@ impl EditConfig {
         }
     }
 
-    fn is_valid_dir(dir_path: &str) -> bool {
+    fn is_valid_dir(fs: &dyn FileSystemTrait, dir_path: &str) -> bool {
         let path_to_check = Path::new(dir_path);
 
-        if path_to_check.exists() && path_to_check.is_dir() {
+        if fs.exists(path_to_check) && fs.is_dir(path_to_check) {
             true
         } else {
-            std::fs::create_dir_all(path_to_check).is_ok()
+            fs.create_dir_all(path_to_check).is_ok()
         }
     }
 
@@ -153,9 +153,9 @@ impl EditConfig {
     /// # Errors
     ///
     /// Returns an error if the cache directory is not a valid directory
-    pub fn cache_dir(&mut self) -> Result<String, ()> {
+    pub fn cache_dir(&mut self, fs: &dyn FileSystemTrait) -> Result<String, ()> {
         let cache_dir = self.extract_config_buffer_val(&EditableConfig::CacheDir);
-        match Self::is_valid_dir(&cache_dir) {
+        match Self::is_valid_dir(fs, &cache_dir) {
             true => Ok(cache_dir),
             false => Err(()),
         }
@@ -166,9 +166,9 @@ impl EditConfig {
     /// # Errors
     ///
     /// Returns an error if the data directory is not a valid directory
-    pub fn data_dir(&mut self) -> Result<String, ()> {
+    pub fn data_dir(&mut self, fs: &dyn FileSystemTrait) -> Result<String, ()> {
         let data_dir = self.extract_config_buffer_val(&EditableConfig::DataDir);
-        match Self::is_valid_dir(&data_dir) {
+        match Self::is_valid_dir(fs, &data_dir) {
             true => Ok(data_dir),
             false => Err(()),
         }

--- a/src/app/screens/latest.rs
+++ b/src/app/screens/latest.rs
@@ -40,7 +40,7 @@ impl LatestPatchsets {
         ) {
             match lore_session_error {
                 LoreSessionError::FromLoreAPIClient(client_error) => match client_error {
-                    ClientError::FromUreq(_) => {
+                    ClientError::Net(_) => {
                         bail!("Failed to request feed\n{client_error:#?}")
                     }
                     ClientError::EndOfFeed => (),
@@ -185,7 +185,14 @@ mod tests {
                 target_list_arg == target_list && *min_index_arg == 0
             })
             .times(1)
-            .returning(move |_, _| Err(ClientError::FromUreq(ureq::Error::StatusCode(401))));
+            .returning(move |_, _| {
+                Err(ClientError::Net(
+                    crate::infrastructure::net::NetError::HttpStatus {
+                        code: 401,
+                        message: "HTTP 401".to_string(),
+                    },
+                ))
+            });
 
         let mut latest_patchsets =
             LatestPatchsets::new(target_list.to_string(), 0, Box::new(lore_api_client));

--- a/src/app/screens/mail_list.rs
+++ b/src/app/screens/mail_list.rs
@@ -1,7 +1,8 @@
 use color_eyre::eyre::bail;
 
-use crate::lore::{
-    lore_api_client::AvailableListsRequest, lore_session, mailing_list::MailingList,
+use crate::{
+    infrastructure::file_system::FileSystemTrait,
+    lore::{lore_api_client::AvailableListsRequest, lore_session, mailing_list::MailingList},
 };
 
 pub struct MailingListSelection {
@@ -14,7 +15,10 @@ pub struct MailingListSelection {
 }
 
 impl MailingListSelection {
-    pub fn refresh_available_mailing_lists(&mut self) -> color_eyre::Result<()> {
+    pub fn refresh_available_mailing_lists(
+        &mut self,
+        fs: &dyn FileSystemTrait,
+    ) -> color_eyre::Result<()> {
         match lore_session::fetch_available_lists(&*self.lore_api_client) {
             Ok(available_mailing_lists) => {
                 self.mailing_lists = available_mailing_lists;
@@ -26,7 +30,7 @@ impl MailingListSelection {
 
         self.clear_target_list();
 
-        lore_session::save_available_lists(&self.mailing_lists, &self.mailing_lists_path)?;
+        lore_session::save_available_lists(fs, &self.mailing_lists, &self.mailing_lists_path)?;
 
         Ok(())
     }

--- a/src/handler/edit_config.rs
+++ b/src/handler/edit_config.rs
@@ -33,7 +33,7 @@ pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()
                 }
                 KeyCode::Esc | KeyCode::Char('q') => {
                     app.consolidate_edit_config();
-                    app.config.save_patch_hub_config()?;
+                    app.config.save_patch_hub_config(&*app.fs)?;
                     app.reset_edit_config();
                     app.set_current_screen(CurrentScreen::MailingListSelection);
                 }

--- a/src/handler/edit_config.rs
+++ b/src/handler/edit_config.rs
@@ -33,7 +33,7 @@ pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()
                 }
                 KeyCode::Esc | KeyCode::Char('q') => {
                     app.consolidate_edit_config();
-                    app.config.save_patch_hub_config(&*app.fs)?;
+                    app.config.save_patch_hub_config(&*app.env, &*app.fs)?;
                     app.reset_edit_config();
                     app.set_current_screen(CurrentScreen::MailingListSelection);
                 }

--- a/src/handler/mail_list.rs
+++ b/src/handler/mail_list.rs
@@ -55,7 +55,7 @@ where
                 terminal,
                 "Refreshing lists" => {
                     app.mailing_list_selection
-                        .refresh_available_mailing_lists()
+                        .refresh_available_mailing_lists(&*app.fs)
                 }
             };
         }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -72,7 +72,7 @@ where
             if app.mailing_list_selection.mailing_lists.is_empty() {
                 terminal = loading_screen! {
                     terminal, "Fetching mailing lists" => {
-                        app.mailing_list_selection.refresh_available_mailing_lists()
+                        app.mailing_list_selection.refresh_available_mailing_lists(&*app.fs)
                     }
                 };
             }

--- a/src/infrastructure/env/mod.rs
+++ b/src/infrastructure/env/mod.rs
@@ -1,0 +1,23 @@
+mod r#trait;
+
+pub use r#trait::{EnvError, EnvTrait};
+
+#[cfg(test)]
+pub use r#trait::MockEnvTrait;
+
+use std::env;
+
+#[cfg(test)]
+mod tests;
+
+pub struct OsEnv;
+
+impl EnvTrait for OsEnv {
+    fn var(&self, key: &str) -> Result<String, EnvError> {
+        Ok(env::var(key)?)
+    }
+
+    fn which(&self, name: &str) -> bool {
+        which::which(name).is_ok()
+    }
+}

--- a/src/infrastructure/env/tests.rs
+++ b/src/infrastructure/env/tests.rs
@@ -1,0 +1,30 @@
+use super::{EnvTrait, OsEnv};
+
+#[test]
+fn var_returns_existing_variable() {
+    let env = OsEnv;
+    // PATH is universally set
+    let result = env.var("PATH");
+    assert!(result.is_ok(), "PATH should be set");
+    assert!(!result.unwrap().is_empty());
+}
+
+#[test]
+fn var_returns_error_for_missing_variable() {
+    let env = OsEnv;
+    let result = env.var("__PATCH_HUB_NONEXISTENT_VAR__");
+    assert!(result.is_err());
+}
+
+#[test]
+fn which_returns_true_for_installed_binary() {
+    let env = OsEnv;
+    // sh is present on every POSIX system
+    assert!(env.which("sh"));
+}
+
+#[test]
+fn which_returns_false_for_missing_binary() {
+    let env = OsEnv;
+    assert!(!env.which("__nonexistent_binary_patch_hub__"));
+}

--- a/src/infrastructure/env/trait.rs
+++ b/src/infrastructure/env/trait.rs
@@ -1,0 +1,19 @@
+use mockall::automock;
+use thiserror::Error;
+
+use std::env::VarError;
+
+#[derive(Debug, Error)]
+pub enum EnvError {
+    #[error("{0}")]
+    VarError(#[from] VarError),
+}
+
+#[automock]
+pub trait EnvTrait: Send + Sync {
+    /// Returns the value of the environment variable `key`.
+    fn var(&self, key: &str) -> Result<String, EnvError>;
+
+    /// Returns `true` if the binary `name` is found somewhere on `PATH`.
+    fn which(&self, name: &str) -> bool;
+}

--- a/src/infrastructure/file_system/mod.rs
+++ b/src/infrastructure/file_system/mod.rs
@@ -3,49 +3,58 @@ mod r#trait;
 #[allow(unused_imports)]
 pub use r#trait::{FileSystemError, FileSystemTrait};
 
-use std::{io, path::Path};
+use std::{
+    fs::{self, File},
+    io::{self, BufReader},
+    path::Path,
+};
+
+#[cfg(test)]
+mod tests;
 
 #[allow(dead_code)]
 pub struct OsFileSystem;
 
 impl FileSystemTrait for OsFileSystem {
-    fn read_to_string(&self, _path: &Path) -> Result<String, FileSystemError> {
-        todo!()
+    fn read_to_string(&self, path: &Path) -> Result<String, FileSystemError> {
+        Ok(fs::read_to_string(path)?)
     }
 
-    fn write(&self, _path: &Path, _contents: &[u8]) -> Result<(), FileSystemError> {
-        todo!()
+    fn write(&self, path: &Path, contents: &[u8]) -> Result<(), FileSystemError> {
+        Ok(fs::write(path, contents)?)
     }
 
-    fn create_dir_all(&self, _path: &Path) -> Result<(), FileSystemError> {
-        todo!()
+    fn create_dir_all(&self, path: &Path) -> Result<(), FileSystemError> {
+        Ok(fs::create_dir_all(path)?)
     }
 
-    fn exists(&self, _path: &Path) -> bool {
-        todo!()
+    fn exists(&self, path: &Path) -> bool {
+        path.exists()
     }
 
-    fn is_file(&self, _path: &Path) -> bool {
-        todo!()
+    fn is_file(&self, path: &Path) -> bool {
+        path.is_file()
     }
 
-    fn is_dir(&self, _path: &Path) -> bool {
-        todo!()
+    fn is_dir(&self, path: &Path) -> bool {
+        path.is_dir()
     }
 
-    fn rename(&self, _from: &Path, _to: &Path) -> Result<(), FileSystemError> {
-        todo!()
+    fn rename(&self, from: &Path, to: &Path) -> Result<(), FileSystemError> {
+        Ok(fs::rename(from, to)?)
     }
 
-    fn create_writer(&self, _path: &Path) -> Result<Box<dyn io::Write + Send>, FileSystemError> {
-        todo!()
+    fn create_writer(&self, path: &Path) -> Result<Box<dyn io::Write + Send>, FileSystemError> {
+        let file = File::create(path)?;
+        Ok(Box::new(file))
     }
 
-    fn open_bufreader(&self, _path: &Path) -> Result<Box<dyn io::BufRead + Send>, FileSystemError> {
-        todo!()
+    fn open_bufreader(&self, path: &Path) -> Result<Box<dyn io::BufRead + Send>, FileSystemError> {
+        let file = File::open(path)?;
+        Ok(Box::new(BufReader::new(file)))
     }
 
-    fn metadata(&self, _path: &Path) -> Result<std::fs::Metadata, FileSystemError> {
-        todo!()
+    fn metadata(&self, path: &Path) -> Result<fs::Metadata, FileSystemError> {
+        Ok(fs::metadata(path)?)
     }
 }

--- a/src/infrastructure/file_system/mod.rs
+++ b/src/infrastructure/file_system/mod.rs
@@ -1,0 +1,51 @@
+mod r#trait;
+
+#[allow(unused_imports)]
+pub use r#trait::{FileSystemError, FileSystemTrait};
+
+use std::{io, path::Path};
+
+#[allow(dead_code)]
+pub struct OsFileSystem;
+
+impl FileSystemTrait for OsFileSystem {
+    fn read_to_string(&self, _path: &Path) -> Result<String, FileSystemError> {
+        todo!()
+    }
+
+    fn write(&self, _path: &Path, _contents: &[u8]) -> Result<(), FileSystemError> {
+        todo!()
+    }
+
+    fn create_dir_all(&self, _path: &Path) -> Result<(), FileSystemError> {
+        todo!()
+    }
+
+    fn exists(&self, _path: &Path) -> bool {
+        todo!()
+    }
+
+    fn is_file(&self, _path: &Path) -> bool {
+        todo!()
+    }
+
+    fn is_dir(&self, _path: &Path) -> bool {
+        todo!()
+    }
+
+    fn rename(&self, _from: &Path, _to: &Path) -> Result<(), FileSystemError> {
+        todo!()
+    }
+
+    fn create_writer(&self, _path: &Path) -> Result<Box<dyn io::Write + Send>, FileSystemError> {
+        todo!()
+    }
+
+    fn open_bufreader(&self, _path: &Path) -> Result<Box<dyn io::BufRead + Send>, FileSystemError> {
+        todo!()
+    }
+
+    fn metadata(&self, _path: &Path) -> Result<std::fs::Metadata, FileSystemError> {
+        todo!()
+    }
+}

--- a/src/infrastructure/file_system/mod.rs
+++ b/src/infrastructure/file_system/mod.rs
@@ -1,6 +1,5 @@
 mod r#trait;
 
-#[allow(unused_imports)]
 pub use r#trait::{FileSystemError, FileSystemTrait};
 
 use std::{
@@ -12,7 +11,6 @@ use std::{
 #[cfg(test)]
 mod tests;
 
-#[allow(dead_code)]
 pub struct OsFileSystem;
 
 impl FileSystemTrait for OsFileSystem {

--- a/src/infrastructure/file_system/tests.rs
+++ b/src/infrastructure/file_system/tests.rs
@@ -1,0 +1,166 @@
+use std::path::{Path, PathBuf};
+
+use super::{FileSystemTrait, OsFileSystem};
+
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new(test_name: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!(
+            "patch_hub_fs_test_{}_{test_name}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        Self(dir)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn read_to_string_returns_file_contents() {
+    let dir = TempDir::new("read_to_string");
+    let file_path = dir.path().join("test.txt");
+    std::fs::write(&file_path, "hello world").unwrap();
+
+    let fs = OsFileSystem;
+    let contents = fs.read_to_string(&file_path).unwrap();
+    assert_eq!(contents, "hello world");
+}
+
+#[test]
+fn read_to_string_returns_error_for_missing_file() {
+    let fs = OsFileSystem;
+    let result = fs.read_to_string(Path::new("/nonexistent/path/file.txt"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn write_creates_file_with_contents() {
+    let dir = TempDir::new("write");
+    let file_path = dir.path().join("write_test.txt");
+
+    let fs = OsFileSystem;
+    fs.write(&file_path, b"test data").unwrap();
+
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    assert_eq!(contents, "test data");
+}
+
+#[test]
+fn create_dir_all_creates_nested_directories() {
+    let dir = TempDir::new("create_dir_all");
+    let nested = dir.path().join("a/b/c");
+
+    let fs = OsFileSystem;
+    fs.create_dir_all(&nested).unwrap();
+
+    assert!(nested.is_dir());
+}
+
+#[test]
+fn exists_returns_true_for_existing_path() {
+    let dir = TempDir::new("exists");
+    let file_path = dir.path().join("exists_test.txt");
+    std::fs::write(&file_path, "").unwrap();
+
+    let fs = OsFileSystem;
+    assert!(fs.exists(&file_path));
+    assert!(fs.exists(dir.path()));
+    assert!(!fs.exists(&dir.path().join("nope")));
+}
+
+#[test]
+fn is_file_distinguishes_files_from_dirs() {
+    let dir = TempDir::new("is_file");
+    let file_path = dir.path().join("a_file.txt");
+    std::fs::write(&file_path, "").unwrap();
+
+    let fs = OsFileSystem;
+    assert!(fs.is_file(&file_path));
+    assert!(!fs.is_file(dir.path()));
+}
+
+#[test]
+fn is_dir_distinguishes_dirs_from_files() {
+    let dir = TempDir::new("is_dir");
+    let file_path = dir.path().join("a_file.txt");
+    std::fs::write(&file_path, "").unwrap();
+
+    let fs = OsFileSystem;
+    assert!(fs.is_dir(dir.path()));
+    assert!(!fs.is_dir(&file_path));
+}
+
+#[test]
+fn rename_moves_file() {
+    let dir = TempDir::new("rename");
+    let src = dir.path().join("src.txt");
+    let dst = dir.path().join("dst.txt");
+    std::fs::write(&src, "rename me").unwrap();
+
+    let fs = OsFileSystem;
+    fs.rename(&src, &dst).unwrap();
+
+    assert!(!src.exists());
+    assert_eq!(std::fs::read_to_string(&dst).unwrap(), "rename me");
+}
+
+#[test]
+fn create_writer_writes_to_file() {
+    use std::io::Write;
+
+    let dir = TempDir::new("create_writer");
+    let file_path = dir.path().join("writer_test.txt");
+
+    let fs = OsFileSystem;
+    let mut writer = fs.create_writer(&file_path).unwrap();
+    writer.write_all(b"via writer").unwrap();
+    drop(writer);
+
+    let contents = std::fs::read_to_string(&file_path).unwrap();
+    assert_eq!(contents, "via writer");
+}
+
+#[test]
+fn open_bufreader_reads_file() {
+    use std::io::BufRead;
+
+    let dir = TempDir::new("open_bufreader");
+    let file_path = dir.path().join("bufreader_test.txt");
+    std::fs::write(&file_path, "line1\nline2\n").unwrap();
+
+    let fs = OsFileSystem;
+    let reader = fs.open_bufreader(&file_path).unwrap();
+
+    let lines: Vec<String> = reader.lines().map(|l| l.unwrap()).collect();
+    assert_eq!(lines, vec!["line1", "line2"]);
+}
+
+#[test]
+fn metadata_returns_file_metadata() {
+    let dir = TempDir::new("metadata");
+    let file_path = dir.path().join("meta_test.txt");
+    std::fs::write(&file_path, "some content").unwrap();
+
+    let fs = OsFileSystem;
+    let meta = fs.metadata(&file_path).unwrap();
+    assert!(meta.is_file());
+    assert_eq!(meta.len(), 12);
+}
+
+#[test]
+fn metadata_returns_error_for_missing_path() {
+    let fs = OsFileSystem;
+    let result = fs.metadata(Path::new("/nonexistent/path"));
+    assert!(result.is_err());
+}

--- a/src/infrastructure/file_system/trait.rs
+++ b/src/infrastructure/file_system/trait.rs
@@ -1,0 +1,25 @@
+use mockall::automock;
+use thiserror::Error;
+
+use std::{io, path::Path};
+
+#[derive(Debug, Error)]
+pub enum FileSystemError {
+    #[error("{0}")]
+    IoError(#[from] io::Error),
+}
+
+#[allow(dead_code)]
+#[automock]
+pub trait FileSystemTrait: Send + Sync {
+    fn read_to_string(&self, path: &Path) -> Result<String, FileSystemError>;
+    fn write(&self, path: &Path, contents: &[u8]) -> Result<(), FileSystemError>;
+    fn create_dir_all(&self, path: &Path) -> Result<(), FileSystemError>;
+    fn exists(&self, path: &Path) -> bool;
+    fn is_file(&self, path: &Path) -> bool;
+    fn is_dir(&self, path: &Path) -> bool;
+    fn rename(&self, from: &Path, to: &Path) -> Result<(), FileSystemError>;
+    fn create_writer(&self, path: &Path) -> Result<Box<dyn io::Write + Send>, FileSystemError>;
+    fn open_bufreader(&self, path: &Path) -> Result<Box<dyn io::BufRead + Send>, FileSystemError>;
+    fn metadata(&self, path: &Path) -> Result<std::fs::Metadata, FileSystemError>;
+}

--- a/src/infrastructure/file_system/trait.rs
+++ b/src/infrastructure/file_system/trait.rs
@@ -9,7 +9,6 @@ pub enum FileSystemError {
     IoError(#[from] io::Error),
 }
 
-#[allow(dead_code)]
 #[automock]
 pub trait FileSystemTrait: Send + Sync {
     fn read_to_string(&self, path: &Path) -> Result<String, FileSystemError>;

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -2,5 +2,6 @@ pub mod env;
 pub mod errors;
 pub mod file_system;
 pub mod monitoring;
+pub mod net;
 pub mod shell;
 pub mod terminal;

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,3 +1,4 @@
 pub mod errors;
+pub mod file_system;
 pub mod monitoring;
 pub mod terminal;

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,4 +1,5 @@
 pub mod errors;
 pub mod file_system;
 pub mod monitoring;
+pub mod shell;
 pub mod terminal;

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,3 +1,4 @@
+pub mod env;
 pub mod errors;
 pub mod file_system;
 pub mod monitoring;

--- a/src/infrastructure/net/mod.rs
+++ b/src/infrastructure/net/mod.rs
@@ -1,0 +1,47 @@
+mod r#trait;
+
+pub use r#trait::{HttpMethod, NetClientTrait, NetError};
+
+#[cfg(test)]
+pub use r#trait::MockNetClientTrait;
+
+#[cfg(test)]
+mod tests;
+
+use std::time::Duration;
+
+use ureq::tls::TlsConfig;
+use ureq::Agent;
+
+pub struct UreqNetClient {
+    agent: Agent,
+}
+
+impl UreqNetClient {
+    pub fn new() -> Self {
+        let kw_agent = format!("kworkflow/patch-hub/{}", env!("CARGO_PKG_VERSION"));
+        let agent: Agent = Agent::config_builder()
+            .user_agent(ureq::config::AutoHeaderValue::from(kw_agent))
+            .timeout_per_call(Some(Duration::from_secs(120)))
+            .tls_config(TlsConfig::builder().build())
+            .build()
+            .into();
+        Self { agent }
+    }
+}
+
+impl NetClientTrait for UreqNetClient {
+    fn request(&self, method: HttpMethod, url: &str) -> Result<String, NetError> {
+        let mut response = match method {
+            HttpMethod::Get => self
+                .agent
+                .get(url)
+                .header("Accept", "text/html,application/xhtml+xml,application/xml")
+                .call()?,
+        };
+        response
+            .body_mut()
+            .read_to_string()
+            .map_err(|e| NetError::Other(e.to_string()))
+    }
+}

--- a/src/infrastructure/net/tests.rs
+++ b/src/infrastructure/net/tests.rs
@@ -1,0 +1,37 @@
+use super::{HttpMethod, MockNetClientTrait, NetClientTrait, NetError};
+
+#[test]
+fn mock_net_client_returns_configured_response() {
+    let mut mock = MockNetClientTrait::new();
+    mock.expect_request()
+        .returning(|_, _| Ok("<html>response</html>".to_string()));
+
+    let result = mock.request(HttpMethod::Get, "https://example.com");
+    assert!(result.is_ok());
+    assert_eq!("<html>response</html>", result.unwrap());
+}
+
+#[test]
+fn mock_net_client_can_return_http_status_error() {
+    let mut mock = MockNetClientTrait::new();
+    mock.expect_request().returning(|_, _| {
+        Err(NetError::HttpStatus {
+            code: 404,
+            message: "HTTP 404".to_string(),
+        })
+    });
+
+    let result = mock.request(HttpMethod::Get, "https://example.com/missing");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("404"));
+}
+
+#[test]
+#[ignore = "network-io"]
+fn ureq_net_client_can_reach_lore_kernel_org() {
+    use super::UreqNetClient;
+    let client = UreqNetClient::new();
+    let result = client.request(HttpMethod::Get, "https://lore.kernel.org/?&o=0");
+    assert!(result.is_ok(), "Expected successful response: {result:?}");
+}

--- a/src/infrastructure/net/trait.rs
+++ b/src/infrastructure/net/trait.rs
@@ -1,0 +1,36 @@
+use mockall::automock;
+use thiserror::Error;
+
+pub enum HttpMethod {
+    Get,
+}
+
+#[derive(Debug, Error)]
+pub enum NetError {
+    #[error("Connection error: {0}")]
+    ConnectionError(String),
+    #[error("Timeout: {0}")]
+    Timeout(String),
+    #[error("HTTP {code}: {message}")]
+    HttpStatus { code: u16, message: String },
+    #[error("{0}")]
+    Other(String),
+}
+
+impl From<ureq::Error> for NetError {
+    fn from(e: ureq::Error) -> Self {
+        match e {
+            ureq::Error::StatusCode(code) => NetError::HttpStatus {
+                code,
+                message: format!("HTTP {code}"),
+            },
+            ureq::Error::Timeout(_) => NetError::Timeout(e.to_string()),
+            _ => NetError::ConnectionError(e.to_string()),
+        }
+    }
+}
+
+#[automock]
+pub trait NetClientTrait: Send + Sync {
+    fn request(&self, method: HttpMethod, url: &str) -> Result<String, NetError>;
+}

--- a/src/infrastructure/shell/mod.rs
+++ b/src/infrastructure/shell/mod.rs
@@ -1,0 +1,60 @@
+mod r#trait;
+
+pub use r#trait::{ShellCommand, ShellError, ShellOutput, ShellTrait};
+
+use std::{
+    io::Write,
+    process::{Command, Stdio},
+};
+
+#[cfg(test)]
+mod tests;
+
+pub struct OsShell;
+
+impl ShellTrait for OsShell {
+    fn execute(&self, cmd: &ShellCommand) -> Result<ShellOutput, ShellError> {
+        let output = Command::new(&cmd.program)
+            .args(&cmd.args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()?;
+
+        Ok(ShellOutput {
+            stdout: output.stdout,
+            stderr: output.stderr,
+            success: output.status.success(),
+        })
+    }
+
+    fn execute_with_stdin(
+        &self,
+        cmd: &ShellCommand,
+        stdin: &[u8],
+    ) -> Result<ShellOutput, ShellError> {
+        let mut child = Command::new(&cmd.program)
+            .args(&cmd.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        if let Some(mut handle) = child.stdin.take() {
+            handle.write_all(stdin)?;
+        }
+
+        let output = child.wait_with_output()?;
+
+        Ok(ShellOutput {
+            stdout: output.stdout,
+            stderr: output.stderr,
+            success: output.status.success(),
+        })
+    }
+
+    fn spawn_interactive(&self, cmd: &ShellCommand) -> Result<bool, ShellError> {
+        let status = Command::new(&cmd.program).args(&cmd.args).status()?;
+
+        Ok(status.success())
+    }
+}

--- a/src/infrastructure/shell/tests.rs
+++ b/src/infrastructure/shell/tests.rs
@@ -1,0 +1,55 @@
+use super::{OsShell, ShellCommand, ShellTrait};
+
+#[test]
+fn execute_captures_stdout() {
+    let shell = OsShell;
+    let cmd = ShellCommand::new("echo").arg("hello shell");
+    let out = shell.execute(&cmd).unwrap();
+    assert!(out.success);
+    assert_eq!(String::from_utf8(out.stdout).unwrap().trim(), "hello shell");
+}
+
+#[test]
+fn execute_captures_stderr() {
+    let shell = OsShell;
+    // `ls` on a nonexistent path writes to stderr and exits nonzero
+    let cmd = ShellCommand::new("ls").arg("/nonexistent_path_patch_hub_test");
+    let out = shell.execute(&cmd).unwrap();
+    assert!(!out.success);
+    assert!(!out.stderr.is_empty());
+}
+
+#[test]
+fn execute_with_stdin_pipes_input() {
+    let shell = OsShell;
+    let cmd = ShellCommand::new("cat");
+    let out = shell.execute_with_stdin(&cmd, b"piped input").unwrap();
+    assert!(out.success);
+    assert_eq!(out.stdout, b"piped input");
+}
+
+#[test]
+fn execute_with_stdin_on_failing_command_returns_error() {
+    let shell = OsShell;
+    let cmd = ShellCommand::new("false");
+    let out = shell.execute_with_stdin(&cmd, b"").unwrap();
+    assert!(!out.success);
+}
+
+#[test]
+fn execute_returns_error_for_missing_binary() {
+    let shell = OsShell;
+    let cmd = ShellCommand::new("__nonexistent_binary_patch_hub__");
+    let result = shell.execute(&cmd);
+    assert!(result.is_err());
+}
+
+#[test]
+fn shell_command_builder_chains_args() {
+    let cmd = ShellCommand::new("git")
+        .arg("-C")
+        .arg("/tmp")
+        .args(["status", "--porcelain"]);
+    assert_eq!(cmd.program, "git");
+    assert_eq!(cmd.args, vec!["-C", "/tmp", "status", "--porcelain"]);
+}

--- a/src/infrastructure/shell/trait.rs
+++ b/src/infrastructure/shell/trait.rs
@@ -1,0 +1,64 @@
+use mockall::automock;
+use thiserror::Error;
+
+use std::io;
+
+#[derive(Debug, Error)]
+pub enum ShellError {
+    #[error("{0}")]
+    IoError(#[from] io::Error),
+}
+
+#[derive(Debug)]
+pub struct ShellCommand {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+impl ShellCommand {
+    pub fn new(program: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+        }
+    }
+
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+}
+
+pub struct ShellOutput {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub success: bool,
+}
+
+#[automock]
+pub trait ShellTrait: Send + Sync {
+    /// Execute a command, capturing stdout and stderr.
+    fn execute(&self, cmd: &ShellCommand) -> Result<ShellOutput, ShellError>;
+
+    /// Execute a command, writing `stdin` to the process's standard input and
+    /// capturing stdout and stderr.
+    fn execute_with_stdin(
+        &self,
+        cmd: &ShellCommand,
+        stdin: &[u8],
+    ) -> Result<ShellOutput, ShellError>;
+
+    /// Spawn an interactive subprocess that inherits the current process's
+    /// stdio (terminal passthrough). Returns `true` if the child exited
+    /// successfully.
+    fn spawn_interactive(&self, cmd: &ShellCommand) -> Result<bool, ShellError>;
+}

--- a/src/lore/lore_api_client/mod.rs
+++ b/src/lore/lore_api_client/mod.rs
@@ -1,9 +1,9 @@
 use mockall::automock;
 use thiserror::Error;
-use ureq::tls::TlsConfig;
-use ureq::Agent;
 
-use std::time::Duration;
+use std::sync::Arc;
+
+use crate::infrastructure::net::{HttpMethod, NetClientTrait, NetError};
 
 #[cfg(test)]
 mod tests;
@@ -14,7 +14,7 @@ const BASE_QUERY_FOR_FEED_REQUEST: &str = r"?x=A&q=((s:patch+OR+s:rfc)+AND+NOT+s
 #[derive(Error, Debug)]
 pub enum ClientError {
     #[error(transparent)]
-    FromUreq(#[from] ureq::Error),
+    Net(#[from] NetError),
 
     #[error("Feed ended")]
     EndOfFeed,
@@ -23,27 +23,14 @@ pub enum ClientError {
 #[derive(Clone)]
 pub struct BlockingLoreAPIClient {
     pub lore_domain: String,
-    client: ureq::Agent,
-}
-impl Default for BlockingLoreAPIClient {
-    fn default() -> Self {
-        let kw_agent: String = format!("kworkflow/patch-hub/{}", env!("CARGO_PKG_VERSION"));
-
-        let agent: Agent = Agent::config_builder()
-            .user_agent(ureq::config::AutoHeaderValue::from(kw_agent))
-            .timeout_per_call(Some(Duration::from_secs(120)))
-            .tls_config(TlsConfig::builder().build())
-            .build()
-            .into();
-        Self::new(agent)
-    }
+    net_client: Arc<dyn NetClientTrait>,
 }
 
 impl BlockingLoreAPIClient {
-    pub fn new(client: ureq::Agent) -> BlockingLoreAPIClient {
+    pub fn new(net_client: Box<dyn NetClientTrait>) -> BlockingLoreAPIClient {
         BlockingLoreAPIClient {
             lore_domain: LORE_DOMAIN.to_string(),
-            client,
+            net_client: Arc::from(net_client),
         }
     }
 }
@@ -63,23 +50,18 @@ impl PatchFeedRequest for BlockingLoreAPIClient {
         target_list: &str,
         min_index: usize,
     ) -> Result<String, ClientError> {
-        let feed_url: String = format!(
+        let url = format!(
             "{}/{target_list}/{BASE_QUERY_FOR_FEED_REQUEST}&o={min_index}",
             self.lore_domain
         );
 
-        let request_builder = self
-            .client
-            .get(feed_url)
-            .header("Accept", "text/html,application/xhtml+xml,application/xml");
+        let body = self.net_client.request(HttpMethod::Get, &url)?;
 
-        let feed_response_body = request_builder.call()?.body_mut().read_to_string()?;
-
-        if feed_response_body.eq(r"</feed>") {
+        if body.eq(r"</feed>") {
             return Err(ClientError::EndOfFeed);
-        };
+        }
 
-        Ok(feed_response_body)
+        Ok(body)
     }
 }
 
@@ -90,14 +72,8 @@ pub trait AvailableListsRequest {
 
 impl AvailableListsRequest for BlockingLoreAPIClient {
     fn request_available_lists(&self, min_index: usize) -> Result<String, ClientError> {
-        let available_lists_url = format!("{}/?&o={min_index}", self.lore_domain);
-
-        let body: String = ureq::get(&available_lists_url)
-            .header("Accept", "text/html,application/xhtml+xml,application/xml")
-            .call()?
-            .body_mut()
-            .read_to_string()?;
-        Ok(body)
+        let url = format!("{}/?&o={min_index}", self.lore_domain);
+        Ok(self.net_client.request(HttpMethod::Get, &url)?)
     }
 }
 
@@ -116,15 +92,8 @@ impl PatchHTMLRequest for BlockingLoreAPIClient {
         target_list: &str,
         message_id: &str,
     ) -> Result<String, ClientError> {
-        let patch_html_url = format!("{}/{target_list}/{message_id}/", self.lore_domain);
-
-        let body: String = ureq::get(&patch_html_url)
-            .header("Accept", "text/html,application/xhtml+xml,application/xml")
-            .call()?
-            .body_mut()
-            .read_to_string()?;
-
-        Ok(body)
+        let url = format!("{}/{target_list}/{message_id}/", self.lore_domain);
+        Ok(self.net_client.request(HttpMethod::Get, &url)?)
     }
 }
 

--- a/src/lore/lore_api_client/tests.rs
+++ b/src/lore/lore_api_client/tests.rs
@@ -1,10 +1,14 @@
 use super::*;
-use crate::lore::patch::PatchFeed;
+use crate::{infrastructure::net::UreqNetClient, lore::patch::PatchFeed};
+
+fn default_client() -> BlockingLoreAPIClient {
+    BlockingLoreAPIClient::new(Box::new(UreqNetClient::new()))
+}
 
 #[test]
 #[ignore = "network-io"]
 fn blocking_client_can_request_valid_patch_feed() {
-    let lore_api_client = BlockingLoreAPIClient::default();
+    let lore_api_client = default_client();
 
     let patch_feed = lore_api_client.request_patch_feed("amd-gfx", 0).unwrap();
     let patch_feed: PatchFeed = serde_xml_rs::from_str(&patch_feed).unwrap();
@@ -20,11 +24,11 @@ fn blocking_client_can_request_valid_patch_feed() {
 #[test]
 #[ignore = "network-io"]
 fn blocking_client_should_detect_failed_patch_feed_request() {
-    let lore_api_client = BlockingLoreAPIClient::default();
+    let lore_api_client = default_client();
 
     if let Err(client_error) = lore_api_client.request_patch_feed("invalid-list", 0) {
         match client_error {
-            ClientError::FromUreq(_) => (),
+            ClientError::Net(_) => (),
             _ => {
                 panic!("Invalid request should return non 200 OK status.\n{client_error:#?}")
             }
@@ -48,7 +52,7 @@ fn blocking_client_should_detect_failed_patch_feed_request() {
 #[test]
 #[ignore = "network-io"]
 fn blocking_client_can_request_valid_available_lists() {
-    let lore_api_client = BlockingLoreAPIClient::default();
+    let lore_api_client = default_client();
 
     if lore_api_client.request_available_lists(0).is_err() {
         panic!("Valid request should be successful");
@@ -58,7 +62,7 @@ fn blocking_client_can_request_valid_available_lists() {
 #[test]
 #[ignore = "network-io"]
 fn blocking_client_can_request_valid_patch_html() {
-    let lore_api_client = BlockingLoreAPIClient::default();
+    let lore_api_client = default_client();
 
     if lore_api_client
         .request_patch_html("all", "Pine.LNX.4.58.0507282031180.3307@g5.osdl.org")

--- a/src/lore/lore_session/mod.rs
+++ b/src/lore/lore_session/mod.rs
@@ -5,16 +5,17 @@ use thiserror::Error;
 
 use std::{
     collections::{HashMap, HashSet},
-    ffi::OsStr,
     io::{self, BufRead},
     mem::swap,
     path::Path,
-    process::{Command, Stdio},
     sync::LazyLock,
 };
 
 use crate::{
-    infrastructure::file_system::{FileSystemError, FileSystemTrait},
+    infrastructure::{
+        file_system::{FileSystemError, FileSystemTrait},
+        shell::{ShellCommand, ShellTrait},
+    },
     lore::{
         lore_api_client::{AvailableListsRequest, ClientError, PatchFeedRequest, PatchHTMLRequest},
         mailing_list::MailingList,
@@ -163,7 +164,12 @@ impl LoreSession {
     }
 }
 
-pub fn download_patchset(fs: &dyn FileSystemTrait, output_dir: &str, patch: &Patch) -> B4Result {
+pub fn download_patchset(
+    fs: &dyn FileSystemTrait,
+    shell: &dyn ShellTrait,
+    output_dir: &str,
+    patch: &Patch,
+) -> B4Result {
     let message_id: &str = &patch.message_id().href;
     let mbox_name: String = extract_mbox_name_from_message_id(message_id);
 
@@ -173,20 +179,19 @@ pub fn download_patchset(fs: &dyn FileSystemTrait, output_dir: &str, patch: &Pat
 
     let filepath: String = format!("{output_dir}/{mbox_name}");
     if !fs.exists(Path::new(&filepath)) {
-        match Command::new("b4")
-            .arg("--quiet")
-            .arg("am")
-            .arg("--use-version")
-            .arg(format!("{}", patch.version()))
-            .arg(message_id)
-            .arg("--outdir")
-            .arg(output_dir)
-            .arg("--mbox-name")
-            .arg(&mbox_name)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-        {
+        let cmd = ShellCommand::new("b4").args([
+            "--quiet",
+            "am",
+            "--use-version",
+            &format!("{}", patch.version()),
+            message_id,
+            "--outdir",
+            output_dir,
+            "--mbox-name",
+            &mbox_name,
+        ]);
+
+        match shell.execute(&cmd) {
             Ok(_) => {}
             Err(_) => {
                 return B4Result::PatchNotFound("b4 couldn't fetch patchset file.".to_string())
@@ -194,9 +199,7 @@ pub fn download_patchset(fs: &dyn FileSystemTrait, output_dir: &str, patch: &Pat
         };
     }
 
-    let path = Path::new(OsStr::new(&filepath));
-
-    if fs.exists(path) {
+    if fs.exists(Path::new(&filepath)) {
         B4Result::PatchFound(filepath)
     } else {
         B4Result::PatchNotFound("b4 couldn't fetch patchset file.".to_string())
@@ -426,11 +429,11 @@ pub fn prepare_reply_patchset_with_reviewed_by<T>(
     patches_to_reply: &[bool],
     git_signature: &str,
     git_send_email_options: &str,
-) -> Result<Vec<Command>, LoreSessionError>
+) -> Result<Vec<ShellCommand>, LoreSessionError>
 where
     T: PatchHTMLRequest,
 {
-    let mut git_reply_commands: Vec<Command> = Vec::new();
+    let mut git_reply_commands: Vec<ShellCommand> = Vec::new();
 
     static RE_MESSAGE_ID: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r#"(?m)^Message-Id: <(.*?)>"#).unwrap());
@@ -454,8 +457,11 @@ where
 
         let patch_body = lore_api_client.request_patch_html(target_list, message_id)?;
 
-        let mut git_reply_command = extract_git_reply_command(&patch_body, git_send_email_options);
-        git_reply_command.arg(format!("{}", reply_path.display()));
+        let git_reply_command = extract_git_reply_command(
+            &patch_body,
+            git_send_email_options,
+            &format!("{}", reply_path.display()),
+        );
 
         git_reply_commands.push(git_reply_command);
     }
@@ -496,12 +502,15 @@ fn generate_patch_reply_template(patch_contents: &str) -> String {
     reply_template
 }
 
-fn extract_git_reply_command(patch_html: &str, git_send_email_options: &str) -> Command {
-    let mut git_reply_command = Command::new("git");
-    git_reply_command.arg("send-email");
+fn extract_git_reply_command(
+    patch_html: &str,
+    git_send_email_options: &str,
+    reply_path: &str,
+) -> ShellCommand {
+    let mut args: Vec<String> = vec!["send-email".to_string()];
 
     for option in git_send_email_options.split_whitespace() {
-        git_reply_command.arg(option);
+        args.push(option.to_string());
     }
 
     static RE_FULL_GIT_COMMAND: LazyLock<Regex> = LazyLock::new(|| {
@@ -516,42 +525,50 @@ fn extract_git_reply_command(patch_html: &str, git_send_email_options: &str) -> 
             let full_git_command = full_git_command_match.as_str();
 
             for long_option_match in RE_LONG_OPTIONS.find_iter(full_git_command) {
-                git_reply_command.arg(long_option_match.as_str());
+                args.push(long_option_match.as_str().to_string());
             }
         }
     }
 
-    git_reply_command
+    args.push(reply_path.to_string());
+
+    ShellCommand {
+        program: "git".to_string(),
+        args,
+    }
 }
 
-pub fn get_git_signature(git_repo_path: &str) -> (String, String) {
-    let mut git_user_name_command = Command::new("git");
-    if !git_repo_path.is_empty() {
-        git_user_name_command.arg("-C").arg(git_repo_path);
-    }
-    let git_user_name_output = git_user_name_command
-        .arg("config")
-        .arg("user.name")
-        .output()
-        .unwrap();
-    let git_user_name = std::str::from_utf8(&git_user_name_output.stdout)
-        .unwrap()
-        .trim();
+pub fn get_git_signature(shell: &dyn ShellTrait, git_repo_path: &str) -> (String, String) {
+    let mut name_args = vec!["config".to_string(), "user.name".to_string()];
+    let mut email_args = vec!["config".to_string(), "user.email".to_string()];
 
-    let mut git_user_email_command = Command::new("git");
     if !git_repo_path.is_empty() {
-        git_user_email_command.arg("-C").arg(git_repo_path);
+        name_args.insert(0, git_repo_path.to_string());
+        name_args.insert(0, "-C".to_string());
+        email_args.insert(0, git_repo_path.to_string());
+        email_args.insert(0, "-C".to_string());
     }
-    let git_user_email_output = git_user_email_command
-        .arg("config")
-        .arg("user.email")
-        .output()
-        .unwrap();
-    let git_user_email = std::str::from_utf8(&git_user_email_output.stdout)
-        .unwrap()
-        .trim();
 
-    (git_user_name.to_owned(), git_user_email.to_owned())
+    let name_cmd = ShellCommand {
+        program: "git".to_string(),
+        args: name_args,
+    };
+    let email_cmd = ShellCommand {
+        program: "git".to_string(),
+        args: email_args,
+    };
+
+    let git_user_name = shell
+        .execute(&name_cmd)
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
+        .unwrap_or_default();
+
+    let git_user_email = shell
+        .execute(&email_cmd)
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
+        .unwrap_or_default();
+
+    (git_user_name, git_user_email)
 }
 
 pub fn save_reviewed_patchsets(

--- a/src/lore/lore_session/mod.rs
+++ b/src/lore/lore_session/mod.rs
@@ -431,7 +431,7 @@ pub fn prepare_reply_patchset_with_reviewed_by<T>(
     git_send_email_options: &str,
 ) -> Result<Vec<ShellCommand>, LoreSessionError>
 where
-    T: PatchHTMLRequest,
+    T: PatchHTMLRequest + ?Sized,
 {
     let mut git_reply_commands: Vec<ShellCommand> = Vec::new();
 

--- a/src/lore/lore_session/mod.rs
+++ b/src/lore/lore_session/mod.rs
@@ -6,18 +6,20 @@ use thiserror::Error;
 use std::{
     collections::{HashMap, HashSet},
     ffi::OsStr,
-    fs::{self, File},
-    io::{self, BufRead, BufReader},
+    io::{self, BufRead},
     mem::swap,
     path::Path,
     process::{Command, Stdio},
     sync::LazyLock,
 };
 
-use crate::lore::{
-    lore_api_client::{AvailableListsRequest, ClientError, PatchFeedRequest, PatchHTMLRequest},
-    mailing_list::MailingList,
-    patch::{Patch, PatchFeed, PatchRegex},
+use crate::{
+    infrastructure::file_system::{FileSystemError, FileSystemTrait},
+    lore::{
+        lore_api_client::{AvailableListsRequest, ClientError, PatchFeedRequest, PatchHTMLRequest},
+        mailing_list::MailingList,
+        patch::{Patch, PatchFeed, PatchRegex},
+    },
 };
 
 #[cfg(test)]
@@ -161,19 +163,16 @@ impl LoreSession {
     }
 }
 
-pub fn download_patchset(output_dir: &str, patch: &Patch) -> B4Result {
+pub fn download_patchset(fs: &dyn FileSystemTrait, output_dir: &str, patch: &Patch) -> B4Result {
     let message_id: &str = &patch.message_id().href;
     let mbox_name: String = extract_mbox_name_from_message_id(message_id);
 
-    if !Path::new(output_dir).exists() {
-        match fs::create_dir_all(output_dir) {
-            Ok(_) => {}
-            Err(_) => return B4Result::PatchNotFound("Couldn't create patches dir.".to_string()),
-        };
+    if !fs.exists(Path::new(output_dir)) && fs.create_dir_all(Path::new(output_dir)).is_err() {
+        return B4Result::PatchNotFound("Couldn't create patches dir.".to_string());
     }
 
     let filepath: String = format!("{output_dir}/{mbox_name}");
-    if !Path::new(&filepath).exists() {
+    if !fs.exists(Path::new(&filepath)) {
         match Command::new("b4")
             .arg("--quiet")
             .arg("am")
@@ -197,7 +196,7 @@ pub fn download_patchset(output_dir: &str, patch: &Patch) -> B4Result {
 
     let path = Path::new(OsStr::new(&filepath));
 
-    if path.exists() {
+    if fs.exists(path) {
         B4Result::PatchFound(filepath)
     } else {
         B4Result::PatchNotFound("b4 couldn't fetch patchset file.".to_string())
@@ -218,23 +217,26 @@ fn extract_mbox_name_from_message_id(message_id: &str) -> String {
     mbox_name
 }
 
-pub fn split_patchset(patchset_path_str: &str) -> Result<Vec<String>, String> {
+pub fn split_patchset(
+    fs: &dyn FileSystemTrait,
+    patchset_path_str: &str,
+) -> Result<Vec<String>, String> {
     let mut patches: Vec<String> = Vec::new();
     let patchset_path: &Path = Path::new(patchset_path_str);
     let cover_letter_path_str: String = patchset_path_str.replace(".mbx", ".cover");
     let cover_letter_path: &Path = Path::new(&cover_letter_path_str);
 
-    if !patchset_path.exists() {
+    if !fs.exists(patchset_path) {
         return Err(format!("{}: Path doesn't exist", patchset_path.display()));
-    } else if !patchset_path.is_file() {
+    } else if !fs.is_file(patchset_path) {
         return Err(format!("{}: Not a file", patchset_path.display()));
     }
 
-    if cover_letter_path.exists() && cover_letter_path.is_file() {
-        extract_patches(cover_letter_path, &mut patches);
+    if fs.exists(cover_letter_path) && fs.is_file(cover_letter_path) {
+        extract_patches(fs, cover_letter_path, &mut patches);
     }
 
-    extract_patches(patchset_path, &mut patches);
+    extract_patches(fs, patchset_path, &mut patches);
 
     Ok(patches)
 }
@@ -254,12 +256,12 @@ pub fn split_cover(patch: &str) -> (&str, &str) {
     (cover, diff)
 }
 
-fn extract_patches(mbox_path: &Path, patches: &mut Vec<String>) {
+fn extract_patches(fs: &dyn FileSystemTrait, mbox_path: &Path, patches: &mut Vec<String>) {
     let mut current_patch: String = String::new();
     let mut is_reading_patch: bool = false;
     let mut is_last_line: bool = false;
 
-    let mbox_reader: BufReader<fs::File> = io::BufReader::new(fs::File::open(mbox_path).unwrap());
+    let mbox_reader = fs.open_bufreader(mbox_path).unwrap();
 
     for line in mbox_reader.lines() {
         let line = line.unwrap();
@@ -298,25 +300,29 @@ fn extract_patches(mbox_path: &Path, patches: &mut Vec<String>) {
 }
 
 pub fn save_bookmarked_patchsets(
+    fs: &dyn FileSystemTrait,
     bookmarked_patchsets: &Vec<Patch>,
     filepath: &str,
-) -> io::Result<()> {
+) -> Result<(), FileSystemError> {
     if let Some(parent) = Path::new(filepath).parent() {
-        fs::create_dir_all(parent)?;
+        fs.create_dir_all(parent)?;
     }
 
     let tmp_filename = format!("{filepath}.tmp");
     {
-        let tmp_file = File::create(&tmp_filename)?;
-        serde_json::to_writer(tmp_file, &bookmarked_patchsets)?;
+        let tmp_file = fs.create_writer(Path::new(&tmp_filename))?;
+        serde_json::to_writer(tmp_file, &bookmarked_patchsets).map_err(io::Error::from)?;
     }
-    fs::rename(tmp_filename, filepath)?;
+    fs.rename(Path::new(&tmp_filename), Path::new(filepath))?;
     Ok(())
 }
 
-pub fn load_bookmarked_patchsets(filepath: &str) -> io::Result<Vec<Patch>> {
-    let bookmarked_patchsets_file = File::open(filepath)?;
-    let bookmarked_patchesets = serde_json::from_reader(bookmarked_patchsets_file)?;
+pub fn load_bookmarked_patchsets(
+    fs: &dyn FileSystemTrait,
+    filepath: &str,
+) -> Result<Vec<Patch>, FileSystemError> {
+    let reader = fs.open_bufreader(Path::new(filepath))?;
+    let bookmarked_patchesets = serde_json::from_reader(reader).map_err(io::Error::from)?;
     Ok(bookmarked_patchesets)
 }
 
@@ -384,27 +390,35 @@ fn process_available_lists(available_lists_str: String) -> Vec<MailingList> {
     available_lists
 }
 
-pub fn save_available_lists(available_lists: &Vec<MailingList>, filepath: &str) -> io::Result<()> {
+pub fn save_available_lists(
+    fs: &dyn FileSystemTrait,
+    available_lists: &Vec<MailingList>,
+    filepath: &str,
+) -> Result<(), FileSystemError> {
     if let Some(parent) = Path::new(filepath).parent() {
-        fs::create_dir_all(parent)?;
+        fs.create_dir_all(parent)?;
     }
 
     let tmp_filename = format!("{filepath}.tmp");
     {
-        let tmp_file = File::create(&tmp_filename)?;
-        serde_json::to_writer(tmp_file, &available_lists)?;
+        let tmp_file = fs.create_writer(Path::new(&tmp_filename))?;
+        serde_json::to_writer(tmp_file, &available_lists).map_err(io::Error::from)?;
     }
-    fs::rename(tmp_filename, filepath)?;
+    fs.rename(Path::new(&tmp_filename), Path::new(filepath))?;
     Ok(())
 }
 
-pub fn load_available_lists(filepath: &str) -> io::Result<Vec<MailingList>> {
-    let available_lists_file = File::open(filepath)?;
-    let available_lists = serde_json::from_reader(available_lists_file)?;
+pub fn load_available_lists(
+    fs: &dyn FileSystemTrait,
+    filepath: &str,
+) -> Result<Vec<MailingList>, FileSystemError> {
+    let reader = fs.open_bufreader(Path::new(filepath))?;
+    let available_lists = serde_json::from_reader(reader).map_err(io::Error::from)?;
     Ok(available_lists)
 }
 
 pub fn prepare_reply_patchset_with_reviewed_by<T>(
+    fs: &dyn FileSystemTrait,
     lore_api_client: &T,
     tmp_dir: &Path,
     target_list: &str,
@@ -436,7 +450,7 @@ where
         let reply_path = tmp_dir.join(format!("{message_id}-reply.mbx"));
         let mut reply = generate_patch_reply_template(patch);
         reply.push_str(&format!("\nReviewed-by: {git_signature}\n"));
-        fs::write(&reply_path, &reply).unwrap();
+        fs.write(&reply_path, reply.as_bytes()).unwrap();
 
         let patch_body = lore_api_client.request_patch_html(target_list, message_id)?;
 
@@ -541,24 +555,28 @@ pub fn get_git_signature(git_repo_path: &str) -> (String, String) {
 }
 
 pub fn save_reviewed_patchsets(
+    fs: &dyn FileSystemTrait,
     reviewed_patchsets: &HashMap<String, HashSet<usize>>,
     filepath: &str,
-) -> io::Result<()> {
+) -> Result<(), FileSystemError> {
     if let Some(parent) = Path::new(filepath).parent() {
-        fs::create_dir_all(parent)?;
+        fs.create_dir_all(parent)?;
     }
 
     let tmp_filename = format!("{filepath}.tmp");
     {
-        let tmp_file = File::create(&tmp_filename)?;
-        serde_json::to_writer(tmp_file, &reviewed_patchsets)?;
+        let tmp_file = fs.create_writer(Path::new(&tmp_filename))?;
+        serde_json::to_writer(tmp_file, &reviewed_patchsets).map_err(io::Error::from)?;
     }
-    fs::rename(tmp_filename, filepath)?;
+    fs.rename(Path::new(&tmp_filename), Path::new(filepath))?;
     Ok(())
 }
 
-pub fn load_reviewed_patchsets(filepath: &str) -> io::Result<HashMap<String, HashSet<usize>>> {
-    let reviewed_patchsets_file = File::open(filepath)?;
-    let reviewed_patchsets = serde_json::from_reader(reviewed_patchsets_file)?;
+pub fn load_reviewed_patchsets(
+    fs: &dyn FileSystemTrait,
+    filepath: &str,
+) -> Result<HashMap<String, HashSet<usize>>, FileSystemError> {
+    let reader = fs.open_bufreader(Path::new(filepath))?;
+    let reviewed_patchsets = serde_json::from_reader(reader).map_err(io::Error::from)?;
     Ok(reviewed_patchsets)
 }

--- a/src/lore/lore_session/tests.rs
+++ b/src/lore/lore_session/tests.rs
@@ -506,7 +506,7 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
         ],
     };
 
-    let expected_git_reply_commands = vec![
+    let expected_git_reply_commands = [
         expected_git_reply_command_0,
         expected_git_reply_command_1,
         expected_git_reply_command_2,

--- a/src/lore/lore_session/tests.rs
+++ b/src/lore/lore_session/tests.rs
@@ -1,8 +1,14 @@
 use io::Read;
-use std::fs::{self, File};
+use std::{
+    fs::{self, File},
+    process::Command,
+};
 
 use crate::{
-    infrastructure::file_system::OsFileSystem,
+    infrastructure::{
+        file_system::OsFileSystem,
+        shell::{OsShell, ShellCommand},
+    },
     lore::{
         lore_api_client::{MockBlockingLoreAPIClient, MockPatchFeedRequest},
         patch::Author,
@@ -13,6 +19,10 @@ use super::*;
 
 fn os_fs() -> OsFileSystem {
     OsFileSystem
+}
+
+fn os_shell() -> OsShell {
+    OsShell
 }
 
 #[test]
@@ -398,9 +408,8 @@ fn should_generate_patch_reply_template() {
     )
 }
 
-fn commands_eq(cmd1: &Command, cmd2: &Command) -> bool {
-    cmd1.get_program() == cmd2.get_program()
-        && cmd1.get_args().collect::<Vec<_>>() == cmd2.get_args().collect::<Vec<_>>()
+fn commands_eq(cmd1: &ShellCommand, cmd2: &ShellCommand) -> bool {
+    cmd1.program == cmd2.program && cmd1.args == cmd2.args
 }
 
 #[test]
@@ -409,18 +418,24 @@ fn should_extract_git_reply_command_from_patch_html() {
         "test_samples/lore_session/extract_git_reply_command/patch_lore_sample.html",
     )
     .unwrap();
-    let mut expected_git_reply_command = Command::new("git");
-    expected_git_reply_command
-        .arg("send-email")
-        .arg("--dry-run")
-        .arg("--suppress-cc=all")
-        .arg("--in-reply-to=1234.567-3-john@johnson.com")
-        .arg("--to=foo@bar.com")
-        .arg("--cc=bar@foo.com")
-        .arg("--cc=foo@list.org")
-        .arg("--cc=bar@list.org");
+    let reply_path = "/tmp/some-reply.mbx";
+    let expected_git_reply_command = ShellCommand {
+        program: "git".to_string(),
+        args: vec![
+            "send-email".to_string(),
+            "--dry-run".to_string(),
+            "--suppress-cc=all".to_string(),
+            "--in-reply-to=1234.567-3-john@johnson.com".to_string(),
+            "--to=foo@bar.com".to_string(),
+            "--cc=bar@foo.com".to_string(),
+            "--cc=foo@list.org".to_string(),
+            "--cc=bar@list.org".to_string(),
+            reply_path.to_string(),
+        ],
+    };
 
-    let git_reply_command = extract_git_reply_command(&patch_html, "--dry-run --suppress-cc=all");
+    let git_reply_command =
+        extract_git_reply_command(&patch_html, "--dry-run --suppress-cc=all", reply_path);
 
     assert!(
         commands_eq(&expected_git_reply_command, &git_reply_command),
@@ -446,50 +461,50 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
     let tmp_dir = Command::new("mktemp").arg("--directory").output().unwrap();
     let tmp_dir = Path::new(std::str::from_utf8(&tmp_dir.stdout).unwrap().trim());
 
-    let mut expected_git_reply_command_0 = Command::new("git");
-    expected_git_reply_command_0
-        .arg("send-email")
-        .arg("--dry-run") // Remove this after validating
-        .arg("--suppress-cc=all")
-        .arg("--in-reply-to=1234.567-0-foo@bar.foo.bar")
-        .arg("--to=foo@bar.foo.bar")
-        .arg(format!(
-            "{}/1234.567-0-foo@bar.foo.bar-reply.mbx",
-            tmp_dir.display()
-        ));
-    let mut expected_git_reply_command_1 = Command::new("git");
-    expected_git_reply_command_1
-        .arg("send-email")
-        .arg("--dry-run") // Remove this after validating
-        .arg("--suppress-cc=all")
-        .arg("--in-reply-to=1234.567-1-foo@bar.foo.bar")
-        .arg("--to=foo@bar.foo.bar")
-        .arg(format!(
-            "{}/1234.567-1-foo@bar.foo.bar-reply.mbx",
-            tmp_dir.display()
-        ));
-    let mut expected_git_reply_command_2 = Command::new("git");
-    expected_git_reply_command_2
-        .arg("send-email")
-        .arg("--dry-run") // Remove this after validating
-        .arg("--suppress-cc=all")
-        .arg("--in-reply-to=1234.567-2-foo@bar.foo.bar")
-        .arg("--to=foo@bar.foo.bar")
-        .arg(format!(
-            "{}/1234.567-2-foo@bar.foo.bar-reply.mbx",
-            tmp_dir.display()
-        ));
-    let mut expected_git_reply_command_3 = Command::new("git");
-    expected_git_reply_command_3
-        .arg("send-email")
-        .arg("--dry-run") // Remove this after validating
-        .arg("--suppress-cc=all")
-        .arg("--in-reply-to=1234.567-3-foo@bar.foo.bar")
-        .arg("--to=foo@bar.foo.bar")
-        .arg(format!(
-            "{}/1234.567-3-foo@bar.foo.bar-reply.mbx",
-            tmp_dir.display()
-        ));
+    let expected_git_reply_command_0 = ShellCommand {
+        program: "git".to_string(),
+        args: vec![
+            "send-email".to_string(),
+            "--dry-run".to_string(),
+            "--suppress-cc=all".to_string(),
+            "--in-reply-to=1234.567-0-foo@bar.foo.bar".to_string(),
+            "--to=foo@bar.foo.bar".to_string(),
+            format!("{}/1234.567-0-foo@bar.foo.bar-reply.mbx", tmp_dir.display()),
+        ],
+    };
+    let expected_git_reply_command_1 = ShellCommand {
+        program: "git".to_string(),
+        args: vec![
+            "send-email".to_string(),
+            "--dry-run".to_string(),
+            "--suppress-cc=all".to_string(),
+            "--in-reply-to=1234.567-1-foo@bar.foo.bar".to_string(),
+            "--to=foo@bar.foo.bar".to_string(),
+            format!("{}/1234.567-1-foo@bar.foo.bar-reply.mbx", tmp_dir.display()),
+        ],
+    };
+    let expected_git_reply_command_2 = ShellCommand {
+        program: "git".to_string(),
+        args: vec![
+            "send-email".to_string(),
+            "--dry-run".to_string(),
+            "--suppress-cc=all".to_string(),
+            "--in-reply-to=1234.567-2-foo@bar.foo.bar".to_string(),
+            "--to=foo@bar.foo.bar".to_string(),
+            format!("{}/1234.567-2-foo@bar.foo.bar-reply.mbx", tmp_dir.display()),
+        ],
+    };
+    let expected_git_reply_command_3 = ShellCommand {
+        program: "git".to_string(),
+        args: vec![
+            "send-email".to_string(),
+            "--dry-run".to_string(),
+            "--suppress-cc=all".to_string(),
+            "--in-reply-to=1234.567-3-foo@bar.foo.bar".to_string(),
+            "--to=foo@bar.foo.bar".to_string(),
+            format!("{}/1234.567-3-foo@bar.foo.bar-reply.mbx", tmp_dir.display()),
+        ],
+    };
 
     let expected_git_reply_commands = vec![
         expected_git_reply_command_0,
@@ -601,7 +616,8 @@ fn should_get_local_git_signature() {
         .output()
         .unwrap();
 
-    let (git_user_name, git_user_email) = get_git_signature(mocked_git_repo.to_str().unwrap());
+    let (git_user_name, git_user_email) =
+        get_git_signature(&os_shell(), mocked_git_repo.to_str().unwrap());
 
     assert_eq!(
         "Foo Bar".to_owned(),

--- a/src/lore/lore_session/tests.rs
+++ b/src/lore/lore_session/tests.rs
@@ -1,12 +1,19 @@
 use io::Read;
-use std::fs;
+use std::fs::{self, File};
 
-use crate::lore::{
-    lore_api_client::{MockBlockingLoreAPIClient, MockPatchFeedRequest},
-    patch::Author,
+use crate::{
+    infrastructure::file_system::OsFileSystem,
+    lore::{
+        lore_api_client::{MockBlockingLoreAPIClient, MockPatchFeedRequest},
+        patch::Author,
+    },
 };
 
 use super::*;
+
+fn os_fs() -> OsFileSystem {
+    OsFileSystem
+}
 
 #[test]
 fn can_initialize_fresh_lore_session() {
@@ -134,11 +141,12 @@ fn should_process_multiple_representative_patches() {
 
 #[test]
 fn test_split_patchset_invalid_cases() {
-    let ret: Result<Vec<String>, String> = split_patchset("invalid/path");
+    let fs = os_fs();
+    let ret: Result<Vec<String>, String> = split_patchset(&fs, "invalid/path");
     assert_eq!(Err("invalid/path: Path doesn't exist".to_string()), ret);
 
     let ret: Result<Vec<String>, String> =
-        split_patchset("test_samples/lore_session/split_patchset/not_a_file");
+        split_patchset(&fs, "test_samples/lore_session/split_patchset/not_a_file");
     assert_eq!(
         Err("test_samples/lore_session/split_patchset/not_a_file: Not a file".to_string()),
         ret
@@ -148,6 +156,7 @@ fn test_split_patchset_invalid_cases() {
 #[test]
 fn should_split_patchset_without_cover_letter() {
     let ret: Result<Vec<String>, String> = split_patchset(
+        &os_fs(),
         "test_samples/lore_session/split_patchset/patchset_sample_without_cover_letter.mbx",
     );
 
@@ -183,8 +192,10 @@ fn should_split_patchset_without_cover_letter() {
 
 #[test]
 fn should_split_patchset_complete() {
-    let ret: Result<Vec<String>, String> =
-        split_patchset("test_samples/lore_session/split_patchset/patchset_sample_complete.mbx");
+    let ret: Result<Vec<String>, String> = split_patchset(
+        &os_fs(),
+        "test_samples/lore_session/split_patchset/patchset_sample_complete.mbx",
+    );
 
     if ret.is_err() {
         panic!("Should return a `Vec<String>` type");
@@ -515,6 +526,7 @@ fn should_prepare_reply_patchset_with_reviewed_by() {
     let patches_to_reply = vec![true; patches.len()];
 
     let git_reply_commands = prepare_reply_patchset_with_reviewed_by(
+        &os_fs(),
         &lore_api_client,
         tmp_dir,
         target_list,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use cli::Cli;
 use color_eyre::eyre::bail;
 use handler::run_app;
 use infrastructure::{
+    file_system::OsFileSystem,
     monitoring::{init_monitoring, InitMonitoringProduct},
     terminal::{init, restore},
 };
@@ -32,8 +33,9 @@ fn main() -> color_eyre::Result<()> {
     infrastructure::errors::install_hooks()?;
     let mut terminal = init()?;
 
-    let config = Config::build();
-    config.create_dirs();
+    let fs = OsFileSystem;
+    let config = Config::build(&fs);
+    config.create_dirs(&fs);
 
     // with the config we can update log directory
     let _guards = multi_log_file_writer.update_log_writer_with_config(
@@ -47,7 +49,7 @@ fn main() -> color_eyre::Result<()> {
         ControlFlow::Continue(t) => terminal = t,
     }
 
-    let app = App::new(config)?;
+    let app = App::new(config, Box::new(fs))?;
     if !app.check_external_deps() {
         event!(
             Level::WARN,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use cli::Cli;
 use color_eyre::eyre::bail;
 use handler::run_app;
 use infrastructure::{
+    env::OsEnv,
     file_system::OsFileSystem,
     monitoring::{init_monitoring, InitMonitoringProduct},
     shell::OsShell,
@@ -36,7 +37,8 @@ fn main() -> color_eyre::Result<()> {
 
     let fs = OsFileSystem;
     let shell = OsShell;
-    let config = Config::build(&fs);
+    let env = OsEnv;
+    let config = Config::build(&env, &fs);
     config.create_dirs(&fs);
 
     // with the config we can update log directory
@@ -51,7 +53,7 @@ fn main() -> color_eyre::Result<()> {
         ControlFlow::Continue(t) => terminal = t,
     }
 
-    let app = App::new(config, Box::new(fs), Box::new(shell))?;
+    let app = App::new(config, Box::new(fs), Box::new(shell), Box::new(env))?;
     if !app.check_external_deps() {
         event!(
             Level::WARN,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,11 @@ use infrastructure::{
     env::OsEnv,
     file_system::OsFileSystem,
     monitoring::{init_monitoring, InitMonitoringProduct},
+    net::UreqNetClient,
     shell::OsShell,
     terminal::{init, restore},
 };
+use lore::lore_api_client::BlockingLoreAPIClient;
 use std::ops::ControlFlow;
 use tracing::{event, Level};
 
@@ -53,7 +55,13 @@ fn main() -> color_eyre::Result<()> {
         ControlFlow::Continue(t) => terminal = t,
     }
 
-    let app = App::new(config, Box::new(fs), Box::new(shell), Box::new(env))?;
+    let app = App::new(
+        config,
+        Box::new(fs),
+        Box::new(shell),
+        Box::new(env),
+        BlockingLoreAPIClient::new(Box::new(UreqNetClient::new())),
+    )?;
     if !app.check_external_deps() {
         event!(
             Level::WARN,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use handler::run_app;
 use infrastructure::{
     file_system::OsFileSystem,
     monitoring::{init_monitoring, InitMonitoringProduct},
+    shell::OsShell,
     terminal::{init, restore},
 };
 use std::ops::ControlFlow;
@@ -34,6 +35,7 @@ fn main() -> color_eyre::Result<()> {
     let mut terminal = init()?;
 
     let fs = OsFileSystem;
+    let shell = OsShell;
     let config = Config::build(&fs);
     config.create_dirs(&fs);
 
@@ -49,7 +51,7 @@ fn main() -> color_eyre::Result<()> {
         ControlFlow::Continue(t) => terminal = t,
     }
 
-    let app = App::new(config, Box::new(fs))?;
+    let app = App::new(config, Box::new(fs), Box::new(shell))?;
     if !app.check_external_deps() {
         event!(
             Level::WARN,


### PR DESCRIPTION
## Goal

Before introducing any actors, extract all infrastructure that will not become actors — FileSystem, Shell, Env, and NetClient — into explicit, mockable traits with OS-backed implementations. These are cross-cutting concerns meant to be injected as dependencies, not wrapped as message-based actors.

## What this PR does

Adds src/infrastructure/{file_system,shell,env,net}/ and migrates direct uses of std::fs, std::process::Command, std::env/which, and ureq to go through those traits. App holds the filesystem, shell, and env traits; BlockingLoreAPIClient delegates HTTP via NetClientTrait; config tests switch to MockEnvTrait; and DetailsActions uses Box<dyn PatchHTMLRequest> like the other screens. main.rs wires the concrete implementations (OsFileSystem, OsShell, OsEnv, UreqNetClient) into Config::build and App::new — runtime behavior is unchanged.