### PR TITLE
Phase 3 - Refactoring: Lore caches creation

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -131,17 +131,9 @@ impl App {
         self.latest_patchsets = Some(LatestPatchsets::new(target_list, self.config.page_size()));
     }
 
-    /// Sets field [App::latest_patchsets] to `None` and resets the feed cursor
-    /// in [App::lore_service] so the next visit fetches fresh data.
+    /// Sets field [App::latest_patchsets] to `None`.
     pub fn reset_latest_patchsets(&mut self) {
-        let target_list = self
-            .latest_patchsets
-            .as_ref()
-            .map(|p| p.target_list().to_string());
         self.latest_patchsets = None;
-        if let Some(list) = target_list {
-            self.lore_service.reset_feed_cursor(&list);
-        }
     }
 
     /// Fetches (or re-fetches) the current page of [App::latest_patchsets]
@@ -156,7 +148,7 @@ impl App {
             ..
         } = self;
         if let Some(patchsets) = latest_patchsets.as_mut() {
-            patchsets.fetch_current_page(lore_service.as_mut())
+            patchsets.fetch_current_page(lore_service.as_mut(), CacheMode::UseCache)
         } else {
             Ok(())
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -199,7 +199,7 @@ impl App {
 
         let details = match self
             .lore_service
-            .fetch_patchset_details(&representative_patch)
+            .fetch_patchset_details(&representative_patch, CacheMode::UseCache)
         {
             Ok(d) => d,
             Err(LoreError::PatchNotFound(err)) => return Ok(B4Result::PatchNotFound(err)),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -21,7 +21,7 @@ use crate::{
         shell::{ShellCommand, ShellTrait},
     },
     lore::{
-        application::{api::LoreServiceApi, errors::LoreError},
+        application::{api::LoreServiceApi, cache::CacheMode, errors::LoreError},
         domain::patch::{Author, Patch},
         infrastructure::patchset_parser::split_cover,
     },
@@ -89,11 +89,9 @@ impl App {
         fs: Box<dyn FileSystemTrait>,
         shell: Box<dyn ShellTrait>,
         env: Box<dyn EnvTrait>,
-        lore_service: Box<dyn LoreServiceApi>,
+        mut lore_service: Box<dyn LoreServiceApi>,
     ) -> color_eyre::Result<Self> {
-        let mailing_lists = lore_service.load_available_lists().unwrap_or_default();
-        let bookmarked_patchsets = lore_service.load_bookmarked_patchsets().unwrap_or_default();
-        let reviewed_patchsets = lore_service.load_reviewed_patchsets().unwrap_or_default();
+        let bootstrap = lore_service.warm_bootstrap_cache().unwrap_or_default();
 
         event!(Level::INFO, "patch-hub started");
         collect_garbage(&config);
@@ -101,19 +99,19 @@ impl App {
         Ok(App {
             current_screen: CurrentScreen::MailingListSelection,
             mailing_list_selection: MailingListSelection {
-                mailing_lists: mailing_lists.clone(),
+                mailing_lists: bootstrap.mailing_lists.clone(),
                 target_list: String::new(),
-                possible_mailing_lists: mailing_lists,
+                possible_mailing_lists: bootstrap.mailing_lists,
                 highlighted_list_index: 0,
             },
             latest_patchsets: None,
             details_actions: None,
             edit_config: None,
             bookmarked_patchsets: BookmarkedPatchsets {
-                bookmarked_patchsets,
+                bookmarked_patchsets: bootstrap.bookmarks,
                 patchset_index: 0,
             },
-            reviewed_patchsets,
+            reviewed_patchsets: bootstrap.reviewed,
             config,
             lore_service,
             popup: None,
@@ -175,7 +173,8 @@ impl App {
             mailing_list_selection,
             ..
         } = self;
-        mailing_list_selection.refresh_available_mailing_lists(lore_service.as_ref())
+        mailing_list_selection
+            .refresh_available_mailing_lists(lore_service.as_mut(), CacheMode::Refresh)
     }
 
     /// Initializes field [App::details_actions], from currently selected

--- a/src/app/screens/latest.rs
+++ b/src/app/screens/latest.rs
@@ -1,7 +1,7 @@
 use color_eyre::eyre::bail;
 
 use crate::lore::{
-    application::{api::LoreServiceApi, errors::LoreError},
+    application::{api::LoreServiceApi, cache::CacheMode, errors::LoreError},
     domain::patch::Patch,
 };
 
@@ -46,11 +46,13 @@ impl LatestPatchsets {
     pub fn fetch_current_page(
         &mut self,
         lore_service: &mut dyn LoreServiceApi,
+        mode: CacheMode,
     ) -> color_eyre::Result<()> {
         match lore_service.fetch_next_patch_page(
             &self.target_list,
             self.page_size,
             self.page_number,
+            mode,
         ) {
             Ok(patches) => {
                 self.current_page = patches;
@@ -124,10 +126,10 @@ mod tests {
         let mut mock = MockLoreServiceApi::new();
         mock.expect_fetch_next_patch_page()
             .times(1)
-            .returning(|_, _, _| Ok(vec![make_patch("id-1"), make_patch("id-2")]));
+            .returning(|_, _, _, _| Ok(vec![make_patch("id-1"), make_patch("id-2")]));
 
         let mut lp = LatestPatchsets::new("some-list".to_string(), 5);
-        let result = lp.fetch_current_page(&mut mock);
+        let result = lp.fetch_current_page(&mut mock, CacheMode::UseCache);
 
         assert!(result.is_ok());
         assert_eq!(lp.processed_patchsets_count(), 2);
@@ -138,10 +140,10 @@ mod tests {
         let mut mock = MockLoreServiceApi::new();
         mock.expect_fetch_next_patch_page()
             .times(1)
-            .returning(|_, _, _| Err(LoreError::EndOfFeed));
+            .returning(|_, _, _, _| Err(LoreError::EndOfFeed));
 
         let mut lp = LatestPatchsets::new("some-list".to_string(), 5);
-        let result = lp.fetch_current_page(&mut mock);
+        let result = lp.fetch_current_page(&mut mock, CacheMode::UseCache);
 
         assert!(result.is_ok());
         assert_eq!(lp.processed_patchsets_count(), 0);
@@ -155,7 +157,7 @@ mod tests {
         let mut mock = MockLoreServiceApi::new();
         mock.expect_fetch_next_patch_page()
             .times(1)
-            .returning(|_, _, _| {
+            .returning(|_, _, _, _| {
                 Err(LoreError::Http(LoreHttpError::Net(NetError::HttpStatus {
                     code: 500,
                     message: "Internal Server Error".to_string(),
@@ -163,7 +165,7 @@ mod tests {
             });
 
         let mut lp = LatestPatchsets::new("some-list".to_string(), 5);
-        let result = lp.fetch_current_page(&mut mock);
+        let result = lp.fetch_current_page(&mut mock, CacheMode::UseCache);
 
         assert!(result.is_err());
     }

--- a/src/app/screens/mail_list.rs
+++ b/src/app/screens/mail_list.rs
@@ -1,6 +1,9 @@
 use color_eyre::eyre::bail;
 
-use crate::lore::{application::api::LoreServiceApi, domain::mailing_list::MailingList};
+use crate::lore::{
+    application::{api::LoreServiceApi, cache::CacheMode},
+    domain::mailing_list::MailingList,
+};
 
 pub struct MailingListSelection {
     pub mailing_lists: Vec<MailingList>,
@@ -12,9 +15,10 @@ pub struct MailingListSelection {
 impl MailingListSelection {
     pub fn refresh_available_mailing_lists(
         &mut self,
-        lore_service: &dyn LoreServiceApi,
+        lore_service: &mut dyn LoreServiceApi,
+        mode: CacheMode,
     ) -> color_eyre::Result<()> {
-        match lore_service.refresh_available_lists() {
+        match lore_service.fetch_available_lists(mode) {
             Ok(available_mailing_lists) => {
                 self.mailing_lists = available_mailing_lists;
             }

--- a/src/lore/application/api.rs
+++ b/src/lore/application/api.rs
@@ -50,16 +50,19 @@ pub trait LoreServiceApi {
     ///
     /// Internally fetches more feed pages from the network as needed.
     /// Returns [`LoreError::EndOfFeed`] when the list is exhausted.
+    ///
+    /// * `UseCache`  — return from the in-memory index if not stale and already
+    ///   large enough; otherwise extend the index from the network.
+    /// * `Refresh`   — evict the cached index first, then fetch from the network.
+    /// * `Bypass`    — fetch from the network; the result is still accumulated
+    ///   in the in-memory index for subsequent pagination requests.
     fn fetch_next_patch_page(
         &mut self,
         target_list: &str,
         page_size: usize,
         page_number: usize,
+        mode: CacheMode,
     ) -> Result<Vec<Patch>, LoreError>;
-
-    /// Discard the cached feed state for `target_list` so the next call to
-    /// [`fetch_next_patch_page`] starts from the beginning.
-    fn reset_feed_cursor(&mut self, target_list: &str);
 
     // ── Patchset details ──────────────────────────────────────────────────────
 

--- a/src/lore/application/api.rs
+++ b/src/lore/application/api.rs
@@ -68,9 +68,14 @@ pub trait LoreServiceApi {
 
     /// Download and parse `representative_patch`, returning the full patchset
     /// data needed to populate the details screen.
+    ///
+    /// * `UseCache`  — return from in-memory cache if present and not stale.
+    /// * `Refresh`   — evict the cached entry first, then re-download.
+    /// * `Bypass`    — download and return without reading or writing cache.
     fn fetch_patchset_details(
-        &self,
+        &mut self,
         representative_patch: &Patch,
+        mode: CacheMode,
     ) -> Result<PatchsetDetails, LoreError>;
 
     // ── Reply commands ────────────────────────────────────────────────────────

--- a/src/lore/application/api.rs
+++ b/src/lore/application/api.rs
@@ -8,7 +8,11 @@ use std::{
 use crate::{
     infrastructure::shell::ShellCommand,
     lore::{
-        application::{dto::PatchsetDetails, errors::LoreError},
+        application::{
+            cache::{BootstrapLoreData, CacheMode},
+            dto::PatchsetDetails,
+            errors::LoreError,
+        },
         domain::{mailing_list::MailingList, patch::Patch},
     },
 };
@@ -20,14 +24,16 @@ use crate::{
 /// implementation in a later phase.
 #[automock]
 pub trait LoreServiceApi {
-    // ── Persistence ──────────────────────────────────────────────────────────
+    // ── Mailing lists ─────────────────────────────────────────────────────────
 
-    /// Load available mailing lists from local cache.
-    fn load_available_lists(&self) -> Result<Vec<MailingList>, LoreError>;
+    /// Return available mailing lists according to `mode`:
+    ///
+    /// * `UseCache`  — in-memory hit → disk fallback → error (no network)
+    /// * `Refresh`   — unconditionally fetch from the network, persist, update cache
+    /// * `Bypass`    — fetch from the network without reading or writing cache
+    fn fetch_available_lists(&mut self, mode: CacheMode) -> Result<Vec<MailingList>, LoreError>;
 
-    /// Fetch all available mailing lists from the Lore network, sort them,
-    /// persist the result, and return the updated list.
-    fn refresh_available_lists(&self) -> Result<Vec<MailingList>, LoreError>;
+    // ── User state ────────────────────────────────────────────────────────────
 
     fn load_bookmarked_patchsets(&self) -> Result<Vec<Patch>, LoreError>;
     fn save_bookmarked_patchsets(&self, patchsets: &[Patch]) -> Result<(), LoreError>;
@@ -86,4 +92,14 @@ pub trait LoreServiceApi {
     /// Return `(user.name, user.email)` from `git config` for the given repo
     /// path.  Pass an empty string to use the global git config.
     fn get_git_signature(&self, git_repo_path: &str) -> (String, String);
+
+    // ── Bootstrap ─────────────────────────────────────────────────────────────
+
+    /// Warm the bootstrap cache and return all data needed to initialise `App`.
+    ///
+    /// Internally calls `fetch_available_lists(UseCache)`,
+    /// `load_bookmarked_patchsets`, and `load_reviewed_patchsets`.  Each
+    /// failure is logged and replaced with an empty default so that the caller
+    /// can treat this method as infallible in practice.
+    fn warm_bootstrap_cache(&mut self) -> Result<BootstrapLoreData, LoreError>;
 }

--- a/src/lore/application/cache.rs
+++ b/src/lore/application/cache.rs
@@ -1,8 +1,3 @@
-// All items in this module are consumed by LoreService starting in Commit 3-C.
-// The module is added in Commit 3-A as a pure vocabulary addition; consumers
-// land in subsequent commits of the same Phase 3 branch.
-#![allow(dead_code)]
-
 use std::{
     collections::{HashMap, HashSet},
     time::{Duration, SystemTime},
@@ -28,6 +23,7 @@ use crate::lore::{
 pub enum CacheMode {
     UseCache,
     Refresh,
+    #[expect(dead_code)]
     Bypass,
 }
 
@@ -58,6 +54,10 @@ impl Default for CacheTtl {
 // ── Generic cache policy trait ────────────────────────────────────────────────
 
 /// Homogeneous interface shared by all three cache stores.
+///
+/// Not yet used by any concrete implementor; provided as a documented
+/// extension point for future phases.
+#[allow(dead_code)]
 pub trait CachePolicy<K, V> {
     fn get(&self, key: &K) -> Option<&V>;
     fn put(&mut self, key: K, value: V);
@@ -95,6 +95,7 @@ pub struct FeedCacheEntry {
     pub index: PatchFeedIndex,
     pub fetched_at: SystemTime,
     /// `true` once the gateway has returned `EndOfFeed` for this list.
+    #[allow(dead_code)]
     pub complete: bool,
 }
 

--- a/src/lore/application/cache.rs
+++ b/src/lore/application/cache.rs
@@ -1,0 +1,191 @@
+// All items in this module are consumed by LoreService starting in Commit 3-C.
+// The module is added in Commit 3-A as a pure vocabulary addition; consumers
+// land in subsequent commits of the same Phase 3 branch.
+#![allow(dead_code)]
+
+use std::{
+    collections::{HashMap, HashSet},
+    time::{Duration, SystemTime},
+};
+
+use crate::lore::{
+    application::dto::PatchTagSummary,
+    domain::{mailing_list::MailingList, patch::Patch, patchset::PatchFeedIndex},
+};
+
+// ── Cache mode ────────────────────────────────────────────────────────────────
+
+/// Caller intent for a cache-backed `LoreService` operation.
+///
+/// * `UseCache`  — return in-memory data if present and not stale; fall back to
+///   disk; return an error/empty if neither is available. Never hits the network
+///   unless the data is genuinely missing.
+/// * `Refresh`   — discard any cached data and unconditionally fetch from the
+///   network, then persist the result.
+/// * `Bypass`    — fetch from the network and return the result without reading
+///   or writing the in-memory cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheMode {
+    UseCache,
+    Refresh,
+    Bypass,
+}
+
+// ── TTL configuration ─────────────────────────────────────────────────────────
+
+/// Per-data-type TTL configuration injected into `LoreService`.
+///
+/// Defaults are chosen conservatively:
+/// * mailing lists change rarely → 24 h
+/// * feed pages are refreshed by the user explicitly → 1 h
+/// * patchsets are immutable historical artefacts → never expire
+pub struct CacheTtl {
+    pub mailing_lists: Duration,
+    pub feed: Duration,
+    pub patchset: Duration,
+}
+
+impl Default for CacheTtl {
+    fn default() -> Self {
+        CacheTtl {
+            mailing_lists: Duration::from_secs(86_400),
+            feed: Duration::from_secs(3_600),
+            patchset: Duration::MAX,
+        }
+    }
+}
+
+// ── Generic cache policy trait ────────────────────────────────────────────────
+
+/// Homogeneous interface shared by all three cache stores.
+pub trait CachePolicy<K, V> {
+    fn get(&self, key: &K) -> Option<&V>;
+    fn put(&mut self, key: K, value: V);
+    fn invalidate(&mut self, key: &K);
+    fn clear(&mut self);
+}
+
+// ── Mailing lists cache ───────────────────────────────────────────────────────
+
+pub struct MailingListsCacheEntry {
+    pub lists: Vec<MailingList>,
+    pub fetched_at: SystemTime,
+}
+
+impl MailingListsCacheEntry {
+    pub fn new(lists: Vec<MailingList>) -> Self {
+        MailingListsCacheEntry {
+            lists,
+            fetched_at: SystemTime::now(),
+        }
+    }
+
+    pub fn is_stale(&self, ttl: Duration) -> bool {
+        self.fetched_at.elapsed().map(|e| e > ttl).unwrap_or(true)
+    }
+}
+
+// ── Feed cache ────────────────────────────────────────────────────────────────
+
+/// A feed cache entry wraps the domain-level `PatchFeedIndex` with TTL metadata.
+///
+/// `PatchFeedIndex` (in `domain/patchset.rs`) remains a pure domain type;
+/// all cache concerns live here.
+pub struct FeedCacheEntry {
+    pub index: PatchFeedIndex,
+    pub fetched_at: SystemTime,
+    /// `true` once the gateway has returned `EndOfFeed` for this list.
+    pub complete: bool,
+}
+
+impl FeedCacheEntry {
+    pub fn new(index: PatchFeedIndex) -> Self {
+        FeedCacheEntry {
+            index,
+            fetched_at: SystemTime::now(),
+            complete: false,
+        }
+    }
+
+    pub fn is_stale(&self, ttl: Duration) -> bool {
+        self.fetched_at.elapsed().map(|e| e > ttl).unwrap_or(true)
+    }
+}
+
+// ── Patchset cache ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct PatchsetCacheKey {
+    pub message_id: String,
+    pub version: usize,
+}
+
+impl PatchsetCacheKey {
+    pub fn from_patch(patch: &Patch) -> Self {
+        PatchsetCacheKey {
+            message_id: patch.message_id().href.clone(),
+            version: patch.version(),
+        }
+    }
+}
+
+pub struct PatchsetCacheEntry {
+    pub patchset_path: String,
+    pub raw_patches: Vec<String>,
+    pub tag_summary: Vec<PatchTagSummary>,
+    pub fetched_at: SystemTime,
+}
+
+impl PatchsetCacheEntry {
+    pub fn new(
+        patchset_path: String,
+        raw_patches: Vec<String>,
+        tag_summary: Vec<PatchTagSummary>,
+    ) -> Self {
+        PatchsetCacheEntry {
+            patchset_path,
+            raw_patches,
+            tag_summary,
+            fetched_at: SystemTime::now(),
+        }
+    }
+
+    pub fn is_stale(&self, ttl: Duration) -> bool {
+        self.fetched_at.elapsed().map(|e| e > ttl).unwrap_or(true)
+    }
+}
+
+// ── Aggregate cache ───────────────────────────────────────────────────────────
+
+pub struct LoreCache {
+    pub lists: Option<MailingListsCacheEntry>,
+    pub feeds: HashMap<String, FeedCacheEntry>,
+    pub patchsets: HashMap<PatchsetCacheKey, PatchsetCacheEntry>,
+}
+
+impl LoreCache {
+    pub fn new() -> Self {
+        LoreCache {
+            lists: None,
+            feeds: HashMap::new(),
+            patchsets: HashMap::new(),
+        }
+    }
+}
+
+impl Default for LoreCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Bootstrap result ──────────────────────────────────────────────────────────
+
+/// Data returned by `LoreServiceApi::warm_bootstrap_cache`, used to initialise
+/// `App` without it knowing about persistence paths or network policy.
+#[derive(Default)]
+pub struct BootstrapLoreData {
+    pub mailing_lists: Vec<MailingList>,
+    pub bookmarks: Vec<Patch>,
+    pub reviewed: HashMap<String, HashSet<usize>>,
+}

--- a/src/lore/application/dto.rs
+++ b/src/lore/application/dto.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use crate::lore::domain::patch::{Author, Patch};
 
 /// Per-patch tag summary extracted from a raw patch's cover section.
+#[derive(Clone)]
 pub struct PatchTagSummary {
     pub reviewed_by: HashSet<Author>,
     pub tested_by: HashSet<Author>,

--- a/src/lore/application/mod.rs
+++ b/src/lore/application/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod cache;
 pub mod dto;
 pub mod errors;
 pub mod service;

--- a/src/lore/application/service.rs
+++ b/src/lore/application/service.rs
@@ -14,6 +14,7 @@ use crate::{
     lore::{
         application::{
             api::LoreServiceApi,
+            cache::{BootstrapLoreData, CacheMode, CacheTtl, LoreCache, MailingListsCacheEntry},
             dto::{PatchTagSummary, PatchsetDetails},
             errors::LoreError,
         },
@@ -43,6 +44,8 @@ pub struct LoreService {
     fs: Arc<dyn FileSystemTrait>,
     shell: Arc<dyn ShellTrait>,
     feed_index_by_list: HashMap<String, PatchFeedIndex>,
+    cache: LoreCache,
+    ttl: CacheTtl,
 }
 
 impl LoreService {
@@ -56,6 +59,7 @@ impl LoreService {
         patchset_parser: Arc<dyn PatchsetParser>,
         fs: Arc<dyn FileSystemTrait>,
         shell: Arc<dyn ShellTrait>,
+        ttl: CacheTtl,
     ) -> Self {
         LoreService {
             lists_gateway,
@@ -68,21 +72,49 @@ impl LoreService {
             fs,
             shell,
             feed_index_by_list: HashMap::new(),
+            cache: LoreCache::new(),
+            ttl,
         }
     }
 }
 
 impl LoreServiceApi for LoreService {
-    fn load_available_lists(&self) -> Result<Vec<MailingList>, LoreError> {
-        Ok(self.lists_store.load_available_lists()?)
-    }
-
-    fn refresh_available_lists(&self) -> Result<Vec<MailingList>, LoreError> {
+    fn fetch_available_lists(&mut self, mode: CacheMode) -> Result<Vec<MailingList>, LoreError> {
         const LORE_PAGE_SIZE: usize = 200;
 
-        let gateway = Arc::clone(&self.lists_gateway);
-        let lists_store = Arc::clone(&self.lists_store);
+        if mode == CacheMode::UseCache {
+            // 1. In-memory hit
+            if let Some(entry) = &self.cache.lists {
+                if !entry.is_stale(self.ttl.mailing_lists) {
+                    tracing::debug!("mailing lists cache: hit");
+                    return Ok(entry.lists.clone());
+                }
+                tracing::debug!("mailing lists cache: stale, falling back to disk");
+                self.cache.lists = None;
+            }
+            // 2. Disk fallback
+            match self.lists_store.load_available_lists() {
+                Ok(lists) => {
+                    tracing::debug!("mailing lists cache: disk hit");
+                    self.cache.lists = Some(MailingListsCacheEntry::new(lists.clone()));
+                    return Ok(lists);
+                }
+                Err(e) => {
+                    tracing::debug!(error = %e, "mailing lists cache: disk miss");
+                    return Err(LoreError::Persistence(e));
+                }
+            }
+        }
 
+        if mode == CacheMode::Refresh {
+            tracing::info!("mailing lists cache: refresh requested");
+            self.cache.lists = None;
+        } else {
+            tracing::debug!("mailing lists cache: bypass");
+        }
+
+        // Network fetch (Refresh or Bypass)
+        let gateway = Arc::clone(&self.lists_gateway);
         let mut all_lists: Vec<MailingList> = Vec::new();
         let mut offset = 0;
 
@@ -90,18 +122,21 @@ impl LoreServiceApi for LoreService {
             let body = gateway
                 .fetch_available_lists_page(offset)
                 .map_err(LoreError::Http)?;
-
             let page = parsers::parse_available_lists(&body);
             if page.is_empty() {
                 break;
             }
-
             all_lists.extend(page);
             offset += LORE_PAGE_SIZE;
         }
 
         all_lists.sort();
-        lists_store.save_available_lists(&all_lists)?;
+
+        if mode != CacheMode::Bypass {
+            self.lists_store.save_available_lists(&all_lists)?;
+            self.cache.lists = Some(MailingListsCacheEntry::new(all_lists.clone()));
+        }
+
         Ok(all_lists)
     }
 
@@ -243,6 +278,28 @@ impl LoreServiceApi for LoreService {
         Ok(commands)
     }
 
+    fn warm_bootstrap_cache(&mut self) -> Result<BootstrapLoreData, LoreError> {
+        let mailing_lists = self
+            .fetch_available_lists(CacheMode::UseCache)
+            .unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "bootstrap: failed to load mailing lists");
+                Vec::new()
+            });
+        let bookmarks = self.load_bookmarked_patchsets().unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "bootstrap: failed to load bookmarks");
+            Vec::new()
+        });
+        let reviewed = self.load_reviewed_patchsets().unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "bootstrap: failed to load reviewed patchsets");
+            HashMap::new()
+        });
+        Ok(BootstrapLoreData {
+            mailing_lists,
+            bookmarks,
+            reviewed,
+        })
+    }
+
     fn get_git_signature(&self, git_repo_path: &str) -> (String, String) {
         let mut name_args = vec!["config".to_string(), "user.name".to_string()];
         let mut email_args = vec!["config".to_string(), "user.email".to_string()];
@@ -326,10 +383,15 @@ mod tests {
     };
     use crate::{
         infrastructure::{file_system::MockFileSystemTrait, shell::MockShellTrait},
-        lore::domain::mailing_list::MailingList,
+        lore::{
+            application::cache::{CacheTtl, MailingListsCacheEntry},
+            domain::mailing_list::MailingList,
+        },
     };
 
     use super::*;
+
+    // ── helpers ───────────────────────────────────────────────────────────────
 
     fn make_service(
         lists_gateway: MockListsGateway,
@@ -350,18 +412,40 @@ mod tests {
             Arc::new(parser),
             Arc::new(MockFileSystemTrait::new()),
             Arc::new(MockShellTrait::new()),
+            CacheTtl::default(),
         )
     }
 
+    // ── mailing lists cache tests ─────────────────────────────────────────────
+
     #[test]
-    fn load_available_lists_delegates_to_persistence() {
+    fn fetch_available_lists_use_cache_disk_hit() {
         let mut lists_store = MockMailingListsCacheStore::new();
         lists_store
             .expect_load_available_lists()
             .times(1)
             .returning(|| Ok(vec![MailingList::new("linux-mm", "desc")]));
 
-        let svc = make_service(
+        let mut svc = make_service(
+            MockListsGateway::new(), // gateway must NOT be called
+            MockFeedGateway::new(),
+            MockPatchHtmlGateway::new(),
+            lists_store,
+            MockUserLoreStateStore::new(),
+            MockPatchsetFetcher::new(),
+            MockPatchsetParser::new(),
+        );
+
+        let result = svc.fetch_available_lists(CacheMode::UseCache).unwrap();
+        assert_eq!(1, result.len());
+        assert_eq!("linux-mm", result[0].name());
+    }
+
+    #[test]
+    fn fetch_available_lists_use_cache_memory_hit() {
+        // Gateway and disk must NOT be called after the in-memory entry is warm.
+        let lists_store = MockMailingListsCacheStore::new(); // no expectations
+        let mut svc = make_service(
             MockListsGateway::new(),
             MockFeedGateway::new(),
             MockPatchHtmlGateway::new(),
@@ -371,13 +455,18 @@ mod tests {
             MockPatchsetParser::new(),
         );
 
-        let result = svc.load_available_lists().unwrap();
+        svc.cache.lists = Some(MailingListsCacheEntry::new(vec![MailingList::new(
+            "cached-list",
+            "in memory",
+        )]));
+
+        let result = svc.fetch_available_lists(CacheMode::UseCache).unwrap();
         assert_eq!(1, result.len());
-        assert_eq!("linux-mm", result[0].name());
+        assert_eq!("cached-list", result[0].name());
     }
 
     #[test]
-    fn refresh_available_lists_paginates_and_sorts() {
+    fn fetch_available_lists_refresh_paginates_and_sorts() {
         let mut lists_gateway = MockListsGateway::new();
         lists_gateway
             .expect_fetch_available_lists_page()
@@ -416,7 +505,7 @@ mod tests {
             .times(1)
             .returning(|_| Ok(()));
 
-        let svc = make_service(
+        let mut svc = make_service(
             lists_gateway,
             MockFeedGateway::new(),
             MockPatchHtmlGateway::new(),
@@ -426,11 +515,86 @@ mod tests {
             MockPatchsetParser::new(),
         );
 
-        let lists = svc.refresh_available_lists().unwrap();
+        let lists = svc.fetch_available_lists(CacheMode::Refresh).unwrap();
         assert_eq!(320, lists.len());
         assert_eq!("accel-config", lists[0].name());
         assert_eq!("yocto-toaster", lists[319].name());
     }
+
+    #[test]
+    fn fetch_available_lists_refresh_bypasses_memory_cache() {
+        // Even with a warm memory cache, Refresh must call the gateway.
+        let mut lists_gateway = MockListsGateway::new();
+        lists_gateway
+            .expect_fetch_available_lists_page()
+            .times(1)
+            .returning(|_| Ok(String::new())); // empty page → break loop
+
+        let mut lists_store = MockMailingListsCacheStore::new();
+        lists_store
+            .expect_save_available_lists()
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let mut svc = make_service(
+            lists_gateway,
+            MockFeedGateway::new(),
+            MockPatchHtmlGateway::new(),
+            lists_store,
+            MockUserLoreStateStore::new(),
+            MockPatchsetFetcher::new(),
+            MockPatchsetParser::new(),
+        );
+
+        // Pre-populate the in-memory cache.
+        svc.cache.lists = Some(MailingListsCacheEntry::new(vec![MailingList::new(
+            "stale-list",
+            "",
+        )]));
+
+        let result = svc.fetch_available_lists(CacheMode::Refresh).unwrap();
+        // Network returned an empty page, so result is empty.
+        assert!(result.is_empty());
+        // In-memory cache was updated (cleared then set to empty result).
+        assert!(svc.cache.lists.is_some());
+    }
+
+    #[test]
+    fn warm_bootstrap_cache_loads_all_data() {
+        let mut lists_store = MockMailingListsCacheStore::new();
+        lists_store
+            .expect_load_available_lists()
+            .times(1)
+            .returning(|| Ok(vec![MailingList::new("linux-mm", "")]));
+
+        let mut user_state = MockUserLoreStateStore::new();
+        user_state
+            .expect_load_bookmarked_patchsets()
+            .times(1)
+            .returning(|| Ok(vec![]));
+        user_state
+            .expect_load_reviewed_patchsets()
+            .times(1)
+            .returning(|| Ok(HashMap::new()));
+
+        let mut svc = make_service(
+            MockListsGateway::new(),
+            MockFeedGateway::new(),
+            MockPatchHtmlGateway::new(),
+            lists_store,
+            user_state,
+            MockPatchsetFetcher::new(),
+            MockPatchsetParser::new(),
+        );
+
+        let data = svc.warm_bootstrap_cache().unwrap();
+        assert_eq!(1, data.mailing_lists.len());
+        assert_eq!("linux-mm", data.mailing_lists[0].name());
+        assert!(data.bookmarks.is_empty());
+        assert!(data.reviewed.is_empty());
+    }
+
+    // ── feed tests ────────────────────────────────────────────────────────────
 
     #[test]
     fn fetch_next_patch_page_returns_patches() {

--- a/src/lore/application/service.rs
+++ b/src/lore/application/service.rs
@@ -14,7 +14,10 @@ use crate::{
     lore::{
         application::{
             api::LoreServiceApi,
-            cache::{BootstrapLoreData, CacheMode, CacheTtl, LoreCache, MailingListsCacheEntry},
+            cache::{
+                BootstrapLoreData, CacheMode, CacheTtl, FeedCacheEntry, LoreCache,
+                MailingListsCacheEntry,
+            },
             dto::{PatchTagSummary, PatchsetDetails},
             errors::LoreError,
         },
@@ -43,7 +46,6 @@ pub struct LoreService {
     patchset_parser: Arc<dyn PatchsetParser>,
     fs: Arc<dyn FileSystemTrait>,
     shell: Arc<dyn ShellTrait>,
-    feed_index_by_list: HashMap<String, PatchFeedIndex>,
     cache: LoreCache,
     ttl: CacheTtl,
 }
@@ -71,7 +73,6 @@ impl LoreService {
             patchset_parser,
             fs,
             shell,
-            feed_index_by_list: HashMap::new(),
             cache: LoreCache::new(),
             ttl,
         }
@@ -164,46 +165,78 @@ impl LoreServiceApi for LoreService {
         target_list: &str,
         page_size: usize,
         page_number: usize,
+        mode: CacheMode,
     ) -> Result<Vec<Patch>, LoreError> {
         let needed = page_size * page_number;
 
-        self.feed_index_by_list
+        if mode == CacheMode::Refresh {
+            tracing::info!(list = target_list, "feed cache: refresh requested");
+            self.cache.feeds.remove(target_list);
+        }
+
+        // UseCache: return from in-memory index if not stale and already sufficient.
+        if mode == CacheMode::UseCache {
+            if let Some(entry) = self.cache.feeds.get(target_list) {
+                if entry.is_stale(self.ttl.feed) {
+                    tracing::debug!(list = target_list, "feed cache: stale, evicting");
+                    self.cache.feeds.remove(target_list);
+                } else {
+                    let current = entry.index.representative_patch_ids().len();
+                    if current >= needed {
+                        tracing::debug!(list = target_list, "feed cache: hit");
+                        return match entry.index.get_page(page_size, page_number) {
+                            Some(patches) => Ok(patches.into_iter().cloned().collect()),
+                            None => Err(LoreError::EndOfFeed),
+                        };
+                    }
+                }
+            }
+        }
+
+        // Get-or-create the cache entry.
+        self.cache
+            .feeds
             .entry(target_list.to_string())
-            .or_insert_with(|| PatchFeedIndex::new(target_list.to_string()));
+            .or_insert_with(|| FeedCacheEntry::new(PatchFeedIndex::new(target_list.to_string())));
 
         // Clone the Arc so the borrow on `self.feed_gateway` doesn't conflict
-        // with the mutable borrow on `self.feed_index_by_list`.
+        // with the mutable borrow on `self.cache.feeds`.
         let gateway = Arc::clone(&self.feed_gateway);
 
         loop {
-            let current = self.feed_index_by_list[target_list]
+            let current = self.cache.feeds[target_list]
+                .index
                 .representative_patch_ids()
                 .len();
             if current >= needed {
                 break;
             }
 
-            let offset = self.feed_index_by_list[target_list].next_offset();
+            let offset = self.cache.feeds[target_list].index.next_offset();
             match gateway.fetch_patch_feed_page(target_list, offset) {
                 Ok(body) => {
                     let feed = parsers::parse_patch_feed(&body).map_err(LoreError::Parse)?;
-                    let index = self.feed_index_by_list.get_mut(target_list).unwrap();
-                    index.process_feed_page(feed);
-                    index.advance_offset();
+                    let entry = self.cache.feeds.get_mut(target_list).unwrap();
+                    entry.index.process_feed_page(feed);
+                    entry.index.advance_offset();
                 }
-                Err(LoreHttpError::EndOfFeed) => break,
+                Err(LoreHttpError::EndOfFeed) => {
+                    if let Some(entry) = self.cache.feeds.get_mut(target_list) {
+                        entry.complete = true;
+                    }
+                    break;
+                }
                 Err(e) => return Err(LoreError::Http(e)),
             }
         }
 
-        match self.feed_index_by_list[target_list].get_page(page_size, page_number) {
+        match self.cache.feeds[target_list]
+            .index
+            .get_page(page_size, page_number)
+        {
             Some(patches) => Ok(patches.into_iter().cloned().collect()),
             None => Err(LoreError::EndOfFeed),
         }
-    }
-
-    fn reset_feed_cursor(&mut self, target_list: &str) {
-        self.feed_index_by_list.remove(target_list);
     }
 
     fn fetch_patchset_details(
@@ -384,8 +417,8 @@ mod tests {
     use crate::{
         infrastructure::{file_system::MockFileSystemTrait, shell::MockShellTrait},
         lore::{
-            application::cache::{CacheTtl, MailingListsCacheEntry},
-            domain::mailing_list::MailingList,
+            application::cache::{CacheTtl, FeedCacheEntry, MailingListsCacheEntry},
+            domain::{mailing_list::MailingList, patchset::PatchFeedIndex},
         },
     };
 
@@ -618,7 +651,9 @@ mod tests {
             MockPatchsetParser::new(),
         );
 
-        let patches = svc.fetch_next_patch_page(target, 1, 1).unwrap();
+        let patches = svc
+            .fetch_next_patch_page(target, 1, 1, CacheMode::UseCache)
+            .unwrap();
         assert_eq!(1, patches.len());
         assert!(patches[0]
             .message_id()
@@ -644,19 +679,53 @@ mod tests {
             MockPatchsetParser::new(),
         );
 
-        let result = svc.fetch_next_patch_page("some-list", 1, 1);
+        let result = svc.fetch_next_patch_page("some-list", 1, 1, CacheMode::UseCache);
         assert!(matches!(result, Err(LoreError::EndOfFeed)));
     }
 
     #[test]
-    fn reset_feed_cursor_clears_index() {
+    fn fetch_next_patch_page_use_cache_hit() {
+        // Pre-populate the feed cache with 1 patch; the gateway must NOT be called.
+        let src = "test_samples/lore_session/process_representative_patch/patch_feed_sample_1.xml";
+        let target = "some-list";
+
+        let mut svc = make_service(
+            MockListsGateway::new(),
+            MockFeedGateway::new(), // no expectations
+            MockPatchHtmlGateway::new(),
+            MockMailingListsCacheStore::new(),
+            MockUserLoreStateStore::new(),
+            MockPatchsetFetcher::new(),
+            MockPatchsetParser::new(),
+        );
+
+        let feed = {
+            use crate::lore::infrastructure::parsers::parse_patch_feed;
+            let xml = fs::read_to_string(src).unwrap();
+            parse_patch_feed(&xml).unwrap()
+        };
+        let mut index = PatchFeedIndex::new(target.to_string());
+        index.process_feed_page(feed);
+        svc.cache
+            .feeds
+            .insert(target.to_string(), FeedCacheEntry::new(index));
+
+        let patches = svc
+            .fetch_next_patch_page(target, 1, 1, CacheMode::UseCache)
+            .unwrap();
+        assert_eq!(1, patches.len());
+    }
+
+    #[test]
+    fn fetch_next_patch_page_refresh_bypasses_cache() {
+        // Even with a warm cache, Refresh must hit the gateway.
         let src = "test_samples/lore_session/process_representative_patch/patch_feed_sample_1.xml";
         let target = "some-list";
 
         let mut feed_gateway = MockFeedGateway::new();
-        // First call: returns page with 1 patch
         feed_gateway
             .expect_fetch_patch_feed_page()
+            .times(1)
             .returning(move |_, _| Ok(fs::read_to_string(src).unwrap()));
 
         let mut svc = make_service(
@@ -669,10 +738,20 @@ mod tests {
             MockPatchsetParser::new(),
         );
 
-        svc.fetch_next_patch_page(target, 1, 1).unwrap();
-        assert!(svc.feed_index_by_list.contains_key(target));
+        // Pre-populate the cache.
+        let feed = {
+            let xml = fs::read_to_string(src).unwrap();
+            crate::lore::infrastructure::parsers::parse_patch_feed(&xml).unwrap()
+        };
+        let mut index = PatchFeedIndex::new(target.to_string());
+        index.process_feed_page(feed);
+        svc.cache
+            .feeds
+            .insert(target.to_string(), FeedCacheEntry::new(index));
 
-        svc.reset_feed_cursor(target);
-        assert!(!svc.feed_index_by_list.contains_key(target));
+        let patches = svc
+            .fetch_next_patch_page(target, 1, 1, CacheMode::Refresh)
+            .unwrap();
+        assert_eq!(1, patches.len());
     }
 }

--- a/src/lore/application/service.rs
+++ b/src/lore/application/service.rs
@@ -27,7 +27,7 @@ use crate::{
             parsers,
             patchset_fetcher::PatchsetFetcher,
             patchset_parser::{self, PatchsetParser},
-            persistence::LorePersistence,
+            persistence::{MailingListsCacheStore, UserLoreStateStore},
         },
     },
 };
@@ -36,7 +36,8 @@ pub struct LoreService {
     lists_gateway: Arc<dyn ListsGateway>,
     feed_gateway: Arc<dyn FeedGateway>,
     patch_html_gateway: Arc<dyn PatchHtmlGateway>,
-    persistence: Arc<dyn LorePersistence>,
+    lists_store: Arc<dyn MailingListsCacheStore>,
+    user_state: Arc<dyn UserLoreStateStore>,
     patchset_fetcher: Arc<dyn PatchsetFetcher>,
     patchset_parser: Arc<dyn PatchsetParser>,
     fs: Arc<dyn FileSystemTrait>,
@@ -49,7 +50,8 @@ impl LoreService {
         lists_gateway: Arc<dyn ListsGateway>,
         feed_gateway: Arc<dyn FeedGateway>,
         patch_html_gateway: Arc<dyn PatchHtmlGateway>,
-        persistence: Arc<dyn LorePersistence>,
+        lists_store: Arc<dyn MailingListsCacheStore>,
+        user_state: Arc<dyn UserLoreStateStore>,
         patchset_fetcher: Arc<dyn PatchsetFetcher>,
         patchset_parser: Arc<dyn PatchsetParser>,
         fs: Arc<dyn FileSystemTrait>,
@@ -59,7 +61,8 @@ impl LoreService {
             lists_gateway,
             feed_gateway,
             patch_html_gateway,
-            persistence,
+            lists_store,
+            user_state,
             patchset_fetcher,
             patchset_parser,
             fs,
@@ -71,14 +74,14 @@ impl LoreService {
 
 impl LoreServiceApi for LoreService {
     fn load_available_lists(&self) -> Result<Vec<MailingList>, LoreError> {
-        Ok(self.persistence.load_available_lists()?)
+        Ok(self.lists_store.load_available_lists()?)
     }
 
     fn refresh_available_lists(&self) -> Result<Vec<MailingList>, LoreError> {
         const LORE_PAGE_SIZE: usize = 200;
 
         let gateway = Arc::clone(&self.lists_gateway);
-        let persistence = Arc::clone(&self.persistence);
+        let lists_store = Arc::clone(&self.lists_store);
 
         let mut all_lists: Vec<MailingList> = Vec::new();
         let mut offset = 0;
@@ -98,27 +101,27 @@ impl LoreServiceApi for LoreService {
         }
 
         all_lists.sort();
-        persistence.save_available_lists(&all_lists)?;
+        lists_store.save_available_lists(&all_lists)?;
         Ok(all_lists)
     }
 
     fn load_bookmarked_patchsets(&self) -> Result<Vec<Patch>, LoreError> {
-        Ok(self.persistence.load_bookmarked_patchsets()?)
+        Ok(self.user_state.load_bookmarked_patchsets()?)
     }
 
     fn save_bookmarked_patchsets(&self, patchsets: &[Patch]) -> Result<(), LoreError> {
-        Ok(self.persistence.save_bookmarked_patchsets(patchsets)?)
+        Ok(self.user_state.save_bookmarked_patchsets(patchsets)?)
     }
 
     fn load_reviewed_patchsets(&self) -> Result<HashMap<String, HashSet<usize>>, LoreError> {
-        Ok(self.persistence.load_reviewed_patchsets()?)
+        Ok(self.user_state.load_reviewed_patchsets()?)
     }
 
     fn save_reviewed_patchsets(
         &self,
         reviewed: &HashMap<String, HashSet<usize>>,
     ) -> Result<(), LoreError> {
-        Ok(self.persistence.save_reviewed_patchsets(reviewed)?)
+        Ok(self.user_state.save_reviewed_patchsets(reviewed)?)
     }
 
     fn fetch_next_patch_page(
@@ -319,7 +322,7 @@ mod tests {
         },
         patchset_fetcher::MockPatchsetFetcher,
         patchset_parser::MockPatchsetParser,
-        persistence::MockLorePersistence,
+        persistence::{MockMailingListsCacheStore, MockUserLoreStateStore},
     };
     use crate::{
         infrastructure::{file_system::MockFileSystemTrait, shell::MockShellTrait},
@@ -332,7 +335,8 @@ mod tests {
         lists_gateway: MockListsGateway,
         feed_gateway: MockFeedGateway,
         patch_html_gateway: MockPatchHtmlGateway,
-        persistence: MockLorePersistence,
+        lists_store: MockMailingListsCacheStore,
+        user_state: MockUserLoreStateStore,
         fetcher: MockPatchsetFetcher,
         parser: MockPatchsetParser,
     ) -> LoreService {
@@ -340,7 +344,8 @@ mod tests {
             Arc::new(lists_gateway),
             Arc::new(feed_gateway),
             Arc::new(patch_html_gateway),
-            Arc::new(persistence),
+            Arc::new(lists_store),
+            Arc::new(user_state),
             Arc::new(fetcher),
             Arc::new(parser),
             Arc::new(MockFileSystemTrait::new()),
@@ -350,8 +355,8 @@ mod tests {
 
     #[test]
     fn load_available_lists_delegates_to_persistence() {
-        let mut persistence = MockLorePersistence::new();
-        persistence
+        let mut lists_store = MockMailingListsCacheStore::new();
+        lists_store
             .expect_load_available_lists()
             .times(1)
             .returning(|| Ok(vec![MailingList::new("linux-mm", "desc")]));
@@ -360,7 +365,8 @@ mod tests {
             MockListsGateway::new(),
             MockFeedGateway::new(),
             MockPatchHtmlGateway::new(),
-            persistence,
+            lists_store,
+            MockUserLoreStateStore::new(),
             MockPatchsetFetcher::new(),
             MockPatchsetParser::new(),
         );
@@ -404,8 +410,8 @@ mod tests {
                 .unwrap())
             });
 
-        let mut persistence = MockLorePersistence::new();
-        persistence
+        let mut lists_store = MockMailingListsCacheStore::new();
+        lists_store
             .expect_save_available_lists()
             .times(1)
             .returning(|_| Ok(()));
@@ -414,7 +420,8 @@ mod tests {
             lists_gateway,
             MockFeedGateway::new(),
             MockPatchHtmlGateway::new(),
-            persistence,
+            lists_store,
+            MockUserLoreStateStore::new(),
             MockPatchsetFetcher::new(),
             MockPatchsetParser::new(),
         );
@@ -441,7 +448,8 @@ mod tests {
             MockListsGateway::new(),
             feed_gateway,
             MockPatchHtmlGateway::new(),
-            MockLorePersistence::new(),
+            MockMailingListsCacheStore::new(),
+            MockUserLoreStateStore::new(),
             MockPatchsetFetcher::new(),
             MockPatchsetParser::new(),
         );
@@ -466,7 +474,8 @@ mod tests {
             MockListsGateway::new(),
             feed_gateway,
             MockPatchHtmlGateway::new(),
-            MockLorePersistence::new(),
+            MockMailingListsCacheStore::new(),
+            MockUserLoreStateStore::new(),
             MockPatchsetFetcher::new(),
             MockPatchsetParser::new(),
         );
@@ -490,7 +499,8 @@ mod tests {
             MockListsGateway::new(),
             feed_gateway,
             MockPatchHtmlGateway::new(),
-            MockLorePersistence::new(),
+            MockMailingListsCacheStore::new(),
+            MockUserLoreStateStore::new(),
             MockPatchsetFetcher::new(),
             MockPatchsetParser::new(),
         );

--- a/src/lore/application/service.rs
+++ b/src/lore/application/service.rs
@@ -16,7 +16,7 @@ use crate::{
             api::LoreServiceApi,
             cache::{
                 BootstrapLoreData, CacheMode, CacheTtl, FeedCacheEntry, LoreCache,
-                MailingListsCacheEntry,
+                MailingListsCacheEntry, PatchsetCacheEntry, PatchsetCacheKey,
             },
             dto::{PatchTagSummary, PatchsetDetails},
             errors::LoreError,
@@ -83,35 +83,37 @@ impl LoreServiceApi for LoreService {
     fn fetch_available_lists(&mut self, mode: CacheMode) -> Result<Vec<MailingList>, LoreError> {
         const LORE_PAGE_SIZE: usize = 200;
 
-        if mode == CacheMode::UseCache {
-            // 1. In-memory hit
-            if let Some(entry) = &self.cache.lists {
-                if !entry.is_stale(self.ttl.mailing_lists) {
-                    tracing::debug!("mailing lists cache: hit");
-                    return Ok(entry.lists.clone());
+        match mode {
+            CacheMode::UseCache => {
+                // 1. In-memory hit
+                if let Some(entry) = &self.cache.lists {
+                    if !entry.is_stale(self.ttl.mailing_lists) {
+                        tracing::debug!("mailing lists cache: hit");
+                        return Ok(entry.lists.clone());
+                    }
+                    tracing::debug!("mailing lists cache: stale, falling back to disk");
+                    self.cache.lists = None;
                 }
-                tracing::debug!("mailing lists cache: stale, falling back to disk");
+                // 2. Disk fallback
+                match self.lists_store.load_available_lists() {
+                    Ok(lists) => {
+                        tracing::debug!("mailing lists cache: disk hit");
+                        self.cache.lists = Some(MailingListsCacheEntry::new(lists.clone()));
+                        return Ok(lists);
+                    }
+                    Err(e) => {
+                        tracing::debug!(error = %e, "mailing lists cache: disk miss");
+                        return Err(LoreError::Persistence(e));
+                    }
+                }
+            }
+            CacheMode::Refresh => {
+                tracing::info!("mailing lists cache: refresh requested");
                 self.cache.lists = None;
             }
-            // 2. Disk fallback
-            match self.lists_store.load_available_lists() {
-                Ok(lists) => {
-                    tracing::debug!("mailing lists cache: disk hit");
-                    self.cache.lists = Some(MailingListsCacheEntry::new(lists.clone()));
-                    return Ok(lists);
-                }
-                Err(e) => {
-                    tracing::debug!(error = %e, "mailing lists cache: disk miss");
-                    return Err(LoreError::Persistence(e));
-                }
+            CacheMode::Bypass => {
+                tracing::debug!("mailing lists cache: bypass");
             }
-        }
-
-        if mode == CacheMode::Refresh {
-            tracing::info!("mailing lists cache: refresh requested");
-            self.cache.lists = None;
-        } else {
-            tracing::debug!("mailing lists cache: bypass");
         }
 
         // Network fetch (Refresh or Bypass)
@@ -133,9 +135,12 @@ impl LoreServiceApi for LoreService {
 
         all_lists.sort();
 
-        if mode != CacheMode::Bypass {
-            self.lists_store.save_available_lists(&all_lists)?;
-            self.cache.lists = Some(MailingListsCacheEntry::new(all_lists.clone()));
+        match mode {
+            CacheMode::Bypass => {}
+            CacheMode::Refresh | CacheMode::UseCache => {
+                self.lists_store.save_available_lists(&all_lists)?;
+                self.cache.lists = Some(MailingListsCacheEntry::new(all_lists.clone()));
+            }
         }
 
         Ok(all_lists)
@@ -169,28 +174,30 @@ impl LoreServiceApi for LoreService {
     ) -> Result<Vec<Patch>, LoreError> {
         let needed = page_size * page_number;
 
-        if mode == CacheMode::Refresh {
-            tracing::info!(list = target_list, "feed cache: refresh requested");
-            self.cache.feeds.remove(target_list);
-        }
-
-        // UseCache: return from in-memory index if not stale and already sufficient.
-        if mode == CacheMode::UseCache {
-            if let Some(entry) = self.cache.feeds.get(target_list) {
-                if entry.is_stale(self.ttl.feed) {
-                    tracing::debug!(list = target_list, "feed cache: stale, evicting");
-                    self.cache.feeds.remove(target_list);
-                } else {
-                    let current = entry.index.representative_patch_ids().len();
-                    if current >= needed {
-                        tracing::debug!(list = target_list, "feed cache: hit");
-                        return match entry.index.get_page(page_size, page_number) {
-                            Some(patches) => Ok(patches.into_iter().cloned().collect()),
-                            None => Err(LoreError::EndOfFeed),
-                        };
+        match mode {
+            CacheMode::Refresh => {
+                tracing::info!(list = target_list, "feed cache: refresh requested");
+                self.cache.feeds.remove(target_list);
+            }
+            CacheMode::UseCache => {
+                // Return from in-memory index if not stale and already sufficient.
+                if let Some(entry) = self.cache.feeds.get(target_list) {
+                    if entry.is_stale(self.ttl.feed) {
+                        tracing::debug!(list = target_list, "feed cache: stale, evicting");
+                        self.cache.feeds.remove(target_list);
+                    } else {
+                        let current = entry.index.representative_patch_ids().len();
+                        if current >= needed {
+                            tracing::debug!(list = target_list, "feed cache: hit");
+                            return match entry.index.get_page(page_size, page_number) {
+                                Some(patches) => Ok(patches.into_iter().cloned().collect()),
+                                None => Err(LoreError::EndOfFeed),
+                            };
+                        }
                     }
                 }
             }
+            CacheMode::Bypass => {}
         }
 
         // Get-or-create the cache entry.
@@ -240,9 +247,36 @@ impl LoreServiceApi for LoreService {
     }
 
     fn fetch_patchset_details(
-        &self,
+        &mut self,
         representative_patch: &Patch,
+        mode: CacheMode,
     ) -> Result<PatchsetDetails, LoreError> {
+        let key = PatchsetCacheKey::from_patch(representative_patch);
+
+        match mode {
+            CacheMode::Refresh => {
+                tracing::info!(msg_id = %key.message_id, "patchset cache: refresh requested");
+                self.cache.patchsets.remove(&key);
+            }
+            CacheMode::UseCache => {
+                if let Some(entry) = self.cache.patchsets.get(&key) {
+                    if entry.is_stale(self.ttl.patchset) {
+                        tracing::debug!(msg_id = %key.message_id, "patchset cache: stale, evicting");
+                        self.cache.patchsets.remove(&key);
+                    } else {
+                        tracing::debug!(msg_id = %key.message_id, "patchset cache: hit");
+                        return Ok(PatchsetDetails {
+                            representative_patch: representative_patch.clone(),
+                            patchset_path: entry.patchset_path.clone(),
+                            raw_patches: entry.raw_patches.clone(),
+                            tag_summary: entry.tag_summary.clone(),
+                        });
+                    }
+                }
+            }
+            CacheMode::Bypass => {}
+        }
+
         let patchset_path = self
             .patchset_fetcher
             .download(representative_patch)
@@ -253,7 +287,22 @@ impl LoreServiceApi for LoreService {
             .split_patchset(&patchset_path)
             .map_err(LoreError::Parse)?;
 
-        let tag_summary = raw_patches.iter().map(|p| extract_tag_summary(p)).collect();
+        let tag_summary: Vec<PatchTagSummary> =
+            raw_patches.iter().map(|p| extract_tag_summary(p)).collect();
+
+        match mode {
+            CacheMode::Bypass => {}
+            CacheMode::Refresh | CacheMode::UseCache => {
+                self.cache.patchsets.insert(
+                    key,
+                    PatchsetCacheEntry::new(
+                        patchset_path.clone(),
+                        raw_patches.clone(),
+                        tag_summary.clone(),
+                    ),
+                );
+            }
+        }
 
         Ok(PatchsetDetails {
             representative_patch: representative_patch.clone(),
@@ -417,7 +466,10 @@ mod tests {
     use crate::{
         infrastructure::{file_system::MockFileSystemTrait, shell::MockShellTrait},
         lore::{
-            application::cache::{CacheTtl, FeedCacheEntry, MailingListsCacheEntry},
+            application::cache::{
+                CacheTtl, FeedCacheEntry, MailingListsCacheEntry, PatchsetCacheEntry,
+                PatchsetCacheKey,
+            },
             domain::{mailing_list::MailingList, patchset::PatchFeedIndex},
         },
     };
@@ -753,5 +805,130 @@ mod tests {
             .fetch_next_patch_page(target, 1, 1, CacheMode::Refresh)
             .unwrap();
         assert_eq!(1, patches.len());
+    }
+
+    // ── patchset details cache tests ──────────────────────────────────────────
+
+    fn make_patch_for_cache(msg_id: &str) -> Patch {
+        serde_json::from_value(serde_json::json!({
+            "title": "test",
+            "author": { "name": "T", "email": "t@t.com" },
+            "link": { "@href": msg_id },
+            "updated": "2023-01-01"
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn fetch_patchset_details_use_cache_hit() {
+        // Pre-populate the cache; fetcher and parser must NOT be called.
+        let patch = make_patch_for_cache("msg-1");
+
+        let mut svc = make_service(
+            MockListsGateway::new(),
+            MockFeedGateway::new(),
+            MockPatchHtmlGateway::new(),
+            MockMailingListsCacheStore::new(),
+            MockUserLoreStateStore::new(),
+            MockPatchsetFetcher::new(), // no expectations
+            MockPatchsetParser::new(),  // no expectations
+        );
+
+        let key = PatchsetCacheKey::from_patch(&patch);
+        svc.cache.patchsets.insert(
+            key,
+            PatchsetCacheEntry::new(
+                "/tmp/cached.mbx".to_string(),
+                vec!["raw patch content".to_string()],
+                vec![],
+            ),
+        );
+
+        let details = svc
+            .fetch_patchset_details(&patch, CacheMode::UseCache)
+            .unwrap();
+        assert_eq!("/tmp/cached.mbx", details.patchset_path);
+        assert_eq!(1, details.raw_patches.len());
+    }
+
+    #[test]
+    fn fetch_patchset_details_cache_miss_downloads() {
+        // No cache entry; fetcher and parser are called once each.
+        let patch = make_patch_for_cache("msg-2");
+
+        let mut fetcher = MockPatchsetFetcher::new();
+        fetcher
+            .expect_download()
+            .times(1)
+            .returning(|_| Ok("/tmp/new.mbx".to_string()));
+
+        let mut parser = MockPatchsetParser::new();
+        parser
+            .expect_split_patchset()
+            .times(1)
+            .returning(|_| Ok(vec!["raw".to_string()]));
+
+        let mut svc = make_service(
+            MockListsGateway::new(),
+            MockFeedGateway::new(),
+            MockPatchHtmlGateway::new(),
+            MockMailingListsCacheStore::new(),
+            MockUserLoreStateStore::new(),
+            fetcher,
+            parser,
+        );
+
+        let details = svc
+            .fetch_patchset_details(&patch, CacheMode::UseCache)
+            .unwrap();
+        assert_eq!("/tmp/new.mbx", details.patchset_path);
+        // The result should now be in cache.
+        let key = PatchsetCacheKey::from_patch(&patch);
+        assert!(svc.cache.patchsets.contains_key(&key));
+    }
+
+    #[test]
+    fn fetch_patchset_details_refresh_re_downloads() {
+        // Even with a warm cache, Refresh must call fetcher and parser.
+        let patch = make_patch_for_cache("msg-3");
+
+        let mut fetcher = MockPatchsetFetcher::new();
+        fetcher
+            .expect_download()
+            .times(1)
+            .returning(|_| Ok("/tmp/refreshed.mbx".to_string()));
+
+        let mut parser = MockPatchsetParser::new();
+        parser
+            .expect_split_patchset()
+            .times(1)
+            .returning(|_| Ok(vec!["fresh raw".to_string()]));
+
+        let mut svc = make_service(
+            MockListsGateway::new(),
+            MockFeedGateway::new(),
+            MockPatchHtmlGateway::new(),
+            MockMailingListsCacheStore::new(),
+            MockUserLoreStateStore::new(),
+            fetcher,
+            parser,
+        );
+
+        // Pre-populate the cache.
+        let key = PatchsetCacheKey::from_patch(&patch);
+        svc.cache.patchsets.insert(
+            key.clone(),
+            PatchsetCacheEntry::new("/tmp/old.mbx".to_string(), vec![], vec![]),
+        );
+
+        let details = svc
+            .fetch_patchset_details(&patch, CacheMode::Refresh)
+            .unwrap();
+        assert_eq!("/tmp/refreshed.mbx", details.patchset_path);
+        // Cache is updated with the fresh entry.
+        assert_eq!(
+            "/tmp/refreshed.mbx",
+            svc.cache.patchsets[&key].patchset_path
+        );
     }
 }

--- a/src/lore/infrastructure/persistence.rs
+++ b/src/lore/infrastructure/persistence.rs
@@ -12,11 +12,20 @@ use crate::{
     lore::domain::{mailing_list::MailingList, patch::Patch},
 };
 
+/// Backing store for the mailing-lists remote-data cache.
 #[automock]
-pub trait LorePersistence: Send + Sync {
+pub trait MailingListsCacheStore: Send + Sync {
     fn load_available_lists(&self) -> Result<Vec<MailingList>, FileSystemError>;
     fn save_available_lists(&self, lists: &[MailingList]) -> Result<(), FileSystemError>;
+}
 
+/// Persistence for user-local Lore state (bookmarks and reviewed patchsets).
+///
+/// Intentionally separate from [`MailingListsCacheStore`]: user state is not
+/// a cache of remote data — it never expires and is never refreshed from the
+/// network.
+#[automock]
+pub trait UserLoreStateStore: Send + Sync {
     fn load_bookmarked_patchsets(&self) -> Result<Vec<Patch>, FileSystemError>;
     fn save_bookmarked_patchsets(&self, patchsets: &[Patch]) -> Result<(), FileSystemError>;
 
@@ -75,7 +84,7 @@ impl FileLorePersistence {
     }
 }
 
-impl LorePersistence for FileLorePersistence {
+impl MailingListsCacheStore for FileLorePersistence {
     fn load_available_lists(&self) -> Result<Vec<MailingList>, FileSystemError> {
         self.read_json(&self.mailing_lists_path)
     }
@@ -83,7 +92,9 @@ impl LorePersistence for FileLorePersistence {
     fn save_available_lists(&self, lists: &[MailingList]) -> Result<(), FileSystemError> {
         self.atomic_write_json(lists, &self.mailing_lists_path)
     }
+}
 
+impl UserLoreStateStore for FileLorePersistence {
     fn load_bookmarked_patchsets(&self) -> Result<Vec<Patch>, FileSystemError> {
         self.read_json(&self.bookmarked_path)
     }
@@ -145,6 +156,7 @@ mod tests {
             MailingList::new("linux-kernel", "LKML"),
         ];
 
+        // MailingListsCacheStore
         p.save_available_lists(&lists).unwrap();
         let loaded = p.load_available_lists().unwrap();
 
@@ -164,6 +176,7 @@ mod tests {
         reviewed.entry("some-id".to_string()).or_default().insert(1);
         reviewed.entry("some-id".to_string()).or_default().insert(2);
 
+        // UserLoreStateStore
         p.save_reviewed_patchsets(&reviewed).unwrap();
         let loaded = p.load_reviewed_patchsets().unwrap();
 
@@ -179,6 +192,7 @@ mod tests {
         let dir = tmp_dir("missing");
         let p = make_persistence(&dir);
 
+        // Both traits return errors when backing files are absent
         assert!(p.load_available_lists().is_err());
         assert!(p.load_bookmarked_patchsets().is_err());
         assert!(p.load_reviewed_patchsets().is_err());

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use infrastructure::{
     terminal::{init, restore},
 };
 use lore::{
-    application::{api::LoreServiceApi, service::LoreService},
+    application::{api::LoreServiceApi, cache::CacheTtl, service::LoreService},
     infrastructure::{
         http_lore_client::HttpLoreGateway,
         patchset_fetcher::B4PatchsetFetcher,
@@ -90,6 +90,7 @@ fn main() -> color_eyre::Result<()> {
         parser,
         fs_arc,
         shell_arc,
+        CacheTtl::default(),
     ));
 
     let app = App::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,10 @@ use infrastructure::{
 use lore::{
     application::{api::LoreServiceApi, service::LoreService},
     infrastructure::{
-        http_lore_client::HttpLoreGateway, patchset_fetcher::B4PatchsetFetcher,
-        patchset_parser::MboxPatchsetParser, persistence::FileLorePersistence,
+        http_lore_client::HttpLoreGateway,
+        patchset_fetcher::B4PatchsetFetcher,
+        patchset_parser::MboxPatchsetParser,
+        persistence::{FileLorePersistence, MailingListsCacheStore, UserLoreStateStore},
     },
 };
 use std::{ops::ControlFlow, sync::Arc};
@@ -82,7 +84,8 @@ fn main() -> color_eyre::Result<()> {
         gateway.clone(),
         gateway.clone(),
         gateway.clone(),
-        persistence,
+        persistence.clone() as Arc<dyn MailingListsCacheStore>,
+        persistence.clone() as Arc<dyn UserLoreStateStore>,
         fetcher,
         parser,
         fs_arc,


### PR DESCRIPTION
## Goal

Make caching an explicit internal responsibility of LoreService. No screen, App state, or bootstrap flow should decide how to persist or reuse Lore data — that logic belongs inside the Lore bounded context, ahead of promoting it to an actor.

## What this PR does

Introduces cache vocabulary in lore/application/cache.rs: CacheMode (UseCache / Refresh / Bypass), CacheTtl, CachePolicy, typed cache entries, and LoreCache as the aggregate store. Splits LorePersistence into MailingListsCacheStore (remote lists cache) and UserLoreStateStore (bookmarks and reviewed patchsets), each independently injectable and mockable.

LoreService owns all three caches (mailing lists, feed pages, patchset details) with TTL-based invalidation. LoreServiceApi gains CacheMode on fetch methods; warm_bootstrap_cache replaces the separate load calls in App::new; reset_feed_cursor is removed. App and screens pass CacheMode through instead of managing cache state themselves — runtime behavior is unchanged.