### PR TITLE
Phase 4 - Refactoring: Simplifying App

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -1,0 +1,23 @@
+//! High-level application intents. Intended to become the App actor message
+//! protocol in later phases; most handlers still call `App` methods directly.
+
+use crate::{app::screens::CurrentScreen, lore::domain::patch::Patch};
+
+/// Sub-actions performed during [`crate::app::App::consolidate_patchset_actions`].
+#[allow(dead_code)] // reserved for future command dispatch
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PatchsetCommand {
+    SyncBookmark,
+    ReplyWithReviewedBy,
+    Apply,
+}
+
+/// Top-level commands the application may process (placeholder for future wiring).
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum AppCommand {
+    NavigateTo(CurrentScreen),
+    SelectMailingList(String),
+    FetchNextPage,
+    OpenPatchset(Patch),
+}

--- a/src/app/config/mod.rs
+++ b/src/app/config/mod.rs
@@ -17,6 +17,21 @@ pub const DEFAULT_CONFIG_PATH_SUFFIX: &str = ".config/patch-hub/config.json";
 
 use super::{cover_renderer::CoverRenderer, patch_renderer::PatchRenderer};
 
+/// Parsed edits from the edit-config screen, ready to merge into [`Config`].
+///
+/// Each field is independent: only `Some` values are applied by [`Config::apply_update`].
+#[derive(Debug, Default, Clone)]
+pub struct ConfigUpdateDraft {
+    pub page_size: Option<usize>,
+    pub cache_dir: Option<String>,
+    pub data_dir: Option<String>,
+    pub git_send_email_option: Option<String>,
+    pub git_am_option: Option<String>,
+    pub patch_renderer: Option<String>,
+    pub cover_renderer: Option<String>,
+    pub max_log_age: Option<usize>,
+}
+
 #[cfg(test)]
 mod tests;
 
@@ -225,6 +240,34 @@ impl Config {
 
     pub fn set_max_log_age(&mut self, max_log_age: usize) {
         self.max_log_age = max_log_age;
+    }
+
+    /// Merges validated field updates from the edit-config flow into this config.
+    pub fn apply_update(&mut self, draft: ConfigUpdateDraft) {
+        if let Some(page_size) = draft.page_size {
+            self.set_page_size(page_size);
+        }
+        if let Some(cache_dir) = draft.cache_dir {
+            self.set_cache_dir(cache_dir);
+        }
+        if let Some(data_dir) = draft.data_dir {
+            self.set_data_dir(data_dir);
+        }
+        if let Some(git_send_email_options) = draft.git_send_email_option {
+            self.set_git_send_email_option(git_send_email_options);
+        }
+        if let Some(git_am_options) = draft.git_am_option {
+            self.set_git_am_option(git_am_options);
+        }
+        if let Some(s) = draft.patch_renderer {
+            self.set_patch_renderer(s.into());
+        }
+        if let Some(s) = draft.cover_renderer {
+            self.set_cover_renderer(s.into());
+        }
+        if let Some(max_log_age) = draft.max_log_age {
+            self.set_max_log_age(max_log_age);
+        }
     }
 
     pub fn save_patch_hub_config(

--- a/src/app/errors.rs
+++ b/src/app/errors.rs
@@ -1,0 +1,23 @@
+use thiserror::Error;
+
+use crate::lore::application::errors::LoreError;
+
+/// Errors surfaced by the application orchestration layer (`App`).
+///
+/// Used as the typed boundary for future App-actor messages; many methods still
+/// return `color_eyre::Result` during the refactor.
+#[allow(dead_code)]
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error("invalid navigation state: {0}")]
+    InvalidState(String),
+
+    #[error("lore error: {0}")]
+    Lore(#[from] LoreError),
+
+    #[error("render error: {0}")]
+    Render(String),
+
+    #[error("config error: {0}")]
+    Config(String),
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,7 +1,9 @@
 pub mod config;
 mod cover_renderer;
-mod patch_renderer;
+pub mod errors;
+pub mod patch_renderer;
 pub mod screens;
+pub mod state;
 
 use ansi_to_tui::IntoText;
 use color_eyre::eyre::{bail, eyre};
@@ -25,12 +27,12 @@ use crate::{
         domain::patch::{Author, Patch},
         infrastructure::patchset_parser::split_cover,
     },
-    ui::popup::{info_popup::InfoPopUp, PopUp},
+    ui::popup::info_popup::InfoPopUp,
 };
 
 use config::Config;
 use cover_renderer::render_cover;
-use patch_renderer::{render_patch_preview, PatchRenderer};
+use patch_renderer::render_patch_preview;
 use screens::{
     bookmarked::BookmarkedPatchsetsState,
     details_actions::{PatchsetAction, PatchsetDetailsState},
@@ -39,6 +41,15 @@ use screens::{
     mail_list::MailingListSelectionState,
     CurrentScreen,
 };
+pub use state::{AppState, ConfigUiState, LoreUiState, NavigationState, UserLoreState};
+
+/// Injected capabilities used by `App` orchestration (not screen state).
+pub struct AppServices {
+    pub lore: Box<dyn LoreServiceApi>,
+    pub shell: Box<dyn ShellTrait>,
+    pub fs: Box<dyn FileSystemTrait>,
+    pub env: Box<dyn EnvTrait>,
+}
 
 /// Result type signalling whether a patchset was successfully loaded.
 pub enum B4Result {
@@ -46,34 +57,10 @@ pub enum B4Result {
     PatchNotFound(String),
 }
 
-/// Type that represents the overall state of the application. It can be viewed
-/// as the **Model** component of `patch-hub`.
+/// Central orchestrator: holds explicit [`AppState`] and [`AppServices`].
 pub struct App {
-    /// The current active screen
-    pub current_screen: CurrentScreen,
-    /// Screen to navigate and select the mailing lists archived on Lore
-    pub mailing_list_selection: MailingListSelectionState,
-    /// Screen with listing patchsets that were previously bookmarked
-    pub bookmarked_patchsets: BookmarkedPatchsetsState,
-    /// Screen with paginated listing of latest patchsets from a target list
-    pub latest_patchsets: Option<LatestPatchsetsState>,
-    /// Screen with details (metadata and previewing) and runnable actions of individual patchset
-    pub details_actions: Option<PatchsetDetailsState>,
-    /// Screen to edit configurations of the app
-    pub edit_config: Option<EditConfigState>,
-    /// Database to track patchsets `Reviewed-by` state
-    pub reviewed_patchsets: HashMap<String, HashSet<usize>>,
-    /// Configurations of the app
-    pub config: Config,
-    /// Single entry-point to the Lore bounded context
-    pub lore_service: Box<dyn LoreServiceApi>,
-    pub popup: Option<Box<dyn PopUp>>,
-    /// Filesystem abstraction
-    pub fs: Box<dyn FileSystemTrait>,
-    /// Shell abstraction
-    pub shell: Box<dyn ShellTrait>,
-    /// Environment abstraction
-    pub env: Box<dyn EnvTrait>,
+    pub state: AppState,
+    pub services: AppServices,
 }
 
 impl App {
@@ -97,99 +84,109 @@ impl App {
         collect_garbage(&config);
 
         Ok(App {
-            current_screen: CurrentScreen::MailingListSelection,
-            mailing_list_selection: MailingListSelectionState {
-                mailing_lists: bootstrap.mailing_lists.clone(),
-                target_list: String::new(),
-                possible_mailing_lists: bootstrap.mailing_lists,
-                highlighted_list_index: 0,
+            state: AppState {
+                navigation: NavigationState {
+                    current_screen: CurrentScreen::MailingListSelection,
+                },
+                lore: LoreUiState {
+                    mailing_list_selection: MailingListSelectionState {
+                        mailing_lists: bootstrap.mailing_lists.clone(),
+                        target_list: String::new(),
+                        possible_mailing_lists: bootstrap.mailing_lists,
+                        highlighted_list_index: 0,
+                    },
+                    latest_patchsets: None,
+                    details: None,
+                },
+                user_state: UserLoreState {
+                    bookmarked_patchsets: BookmarkedPatchsetsState {
+                        bookmarked_patchsets: bootstrap.bookmarks,
+                        patchset_index: 0,
+                    },
+                    reviewed_patchsets: bootstrap.reviewed,
+                },
+                config_state: ConfigUiState { edit_config: None },
+                config,
+                popup: None,
             },
-            latest_patchsets: None,
-            details_actions: None,
-            edit_config: None,
-            bookmarked_patchsets: BookmarkedPatchsetsState {
-                bookmarked_patchsets: bootstrap.bookmarks,
-                patchset_index: 0,
+            services: AppServices {
+                lore: lore_service,
+                shell,
+                fs,
+                env,
             },
-            reviewed_patchsets: bootstrap.reviewed,
-            config,
-            lore_service,
-            popup: None,
-            fs,
-            shell,
-            env,
         })
     }
 
-    /// Initializes field [App::latest_patchsets], from currently selected
-    /// mailing list in [App::mailing_list_selection].
+    /// Initializes [`LoreUiState::latest_patchsets`] from the currently selected
+    /// mailing list.
     pub fn init_latest_patchsets(&mut self) {
-        let list_index = self.mailing_list_selection.highlighted_list_index;
-        let target_list = self.mailing_list_selection.possible_mailing_lists[list_index]
+        let list_index = self
+            .state
+            .lore
+            .mailing_list_selection
+            .highlighted_list_index;
+        let target_list = self
+            .state
+            .lore
+            .mailing_list_selection
+            .possible_mailing_lists[list_index]
             .name()
             .to_string();
-        self.latest_patchsets = Some(LatestPatchsetsState::new(
+        self.state.lore.latest_patchsets = Some(LatestPatchsetsState::new(
             target_list,
-            self.config.page_size(),
+            self.state.config.page_size(),
         ));
     }
 
-    /// Sets field [App::latest_patchsets] to `None`.
+    /// Sets [`LoreUiState::latest_patchsets`] to `None`.
     pub fn reset_latest_patchsets(&mut self) {
-        self.latest_patchsets = None;
+        self.state.lore.latest_patchsets = None;
     }
 
-    /// Fetches (or re-fetches) the current page of [App::latest_patchsets]
-    /// from [App::lore_service].
-    ///
-    /// Uses field-level splitting so the borrow checker can see that
-    /// `lore_service` and `latest_patchsets` are disjoint borrows.
+    /// Fetches (or re-fetches) the current page of latest patchsets from Lore.
     pub fn fetch_latest_current_page(&mut self) -> color_eyre::Result<()> {
-        let App {
-            lore_service,
-            latest_patchsets,
-            ..
-        } = self;
+        let lore = self.services.lore.as_mut();
+        let latest_patchsets = &mut self.state.lore.latest_patchsets;
         if let Some(patchsets) = latest_patchsets.as_mut() {
-            patchsets.fetch_current_page(lore_service.as_mut(), CacheMode::UseCache)
+            patchsets.fetch_current_page(lore, CacheMode::UseCache)
         } else {
             Ok(())
         }
     }
 
-    /// Refreshes available mailing lists via [App::lore_service] and updates
-    /// [App::mailing_list_selection].
-    ///
-    /// Uses field-level splitting so the borrow checker can see that
-    /// `lore_service` and `mailing_list_selection` are disjoint borrows.
+    /// Refreshes available mailing lists and updates [`LoreUiState::mailing_list_selection`].
     pub fn refresh_mailing_lists(&mut self) -> color_eyre::Result<()> {
-        let App {
-            lore_service,
-            mailing_list_selection,
-            ..
-        } = self;
-        mailing_list_selection
-            .refresh_available_mailing_lists(lore_service.as_mut(), CacheMode::Refresh)
+        self.state
+            .lore
+            .mailing_list_selection
+            .refresh_available_mailing_lists(self.services.lore.as_mut(), CacheMode::Refresh)
     }
 
-    /// Initializes field [App::details_actions], from currently selected
-    /// patchset in [App::bookmarked_patchsets] or [App::latest_patchsets],
-    /// depending on the value of [App::current_screen].
+    /// Loads patchset details into [`LoreUiState::details`].
     pub fn init_details_actions(&mut self) -> color_eyre::Result<B4Result> {
         let representative_patch: Patch;
         let mut is_patchset_bookmarked = true;
 
-        match &self.current_screen {
+        match &self.state.navigation.current_screen {
             CurrentScreen::BookmarkedPatchsets => {
-                representative_patch = self.bookmarked_patchsets.get_selected_patchset();
+                representative_patch = self
+                    .state
+                    .user_state
+                    .bookmarked_patchsets
+                    .get_selected_patchset();
             }
             CurrentScreen::LatestPatchsets => {
                 representative_patch = self
+                    .state
+                    .lore
                     .latest_patchsets
                     .as_ref()
                     .unwrap()
                     .get_selected_patchset();
                 if !self
+                    .state
+                    .user_state
                     .bookmarked_patchsets
                     .bookmarked_patchsets
                     .contains(&representative_patch)
@@ -201,7 +198,8 @@ impl App {
         };
 
         let details = match self
-            .lore_service
+            .services
+            .lore
             .fetch_patchset_details(&representative_patch, CacheMode::UseCache)
         {
             Ok(d) => d,
@@ -222,29 +220,35 @@ impl App {
             tested_by.push(tag_summary.tested_by.clone());
             acked_by.push(tag_summary.acked_by.clone());
 
-            let rendered_cover =
-                match render_cover(&*self.shell, raw_cover, self.config.cover_renderer()) {
-                    Ok(render) => render,
-                    Err(_) => {
-                        event!(
-                            Level::ERROR,
-                            "Failed to render cover preview with external program"
-                        );
-                        raw_cover.to_string()
-                    }
-                };
+            let rendered_cover = match render_cover(
+                &*self.services.shell,
+                raw_cover,
+                self.state.config.cover_renderer(),
+            ) {
+                Ok(render) => render,
+                Err(_) => {
+                    event!(
+                        Level::ERROR,
+                        "Failed to render cover preview with external program"
+                    );
+                    raw_cover.to_string()
+                }
+            };
 
-            let rendered_patch =
-                match render_patch_preview(&*self.shell, raw_diff, self.config.patch_renderer()) {
-                    Ok(render) => render,
-                    Err(_) => {
-                        event!(
-                            Level::ERROR,
-                            "Failed to render patch preview with external program",
-                        );
-                        raw_diff.to_string()
-                    }
-                };
+            let rendered_patch = match render_patch_preview(
+                &*self.services.shell,
+                raw_diff,
+                self.state.config.patch_renderer(),
+            ) {
+                Ok(render) => render,
+                Err(_) => {
+                    event!(
+                        Level::ERROR,
+                        "Failed to render patch preview with external program",
+                    );
+                    raw_diff.to_string()
+                }
+            };
 
             patches_preview.push(format!("{rendered_cover}---\n{rendered_patch}").into_text()?);
         }
@@ -252,7 +256,7 @@ impl App {
         let has_cover_letter = representative_patch.number_in_series() == 0;
         let patches_to_reply = vec![false; details.raw_patches.len()];
 
-        self.details_actions = Some(PatchsetDetailsState {
+        self.state.lore.details = Some(PatchsetDetailsState {
             representative_patch,
             raw_patches: details.raw_patches,
             patchset_path: details.patchset_path,
@@ -271,56 +275,68 @@ impl App {
             reviewed_by,
             tested_by,
             acked_by,
-            last_screen: self.current_screen.clone(),
+            last_screen: self.state.navigation.current_screen.clone(),
         });
 
         Ok(B4Result::PatchFound)
     }
 
-    /// Sets field [App::details_actions] to `None`.
+    /// Clears [`LoreUiState::details`].
     pub fn reset_details_actions(&mut self) {
-        self.details_actions = None;
+        self.state.lore.details = None;
     }
 
-    /// Determines and consolidates all actions (if any) to take for the current
-    /// patchset stored in `details_actions`.
+    /// Consolidates patchset actions from the details screen.
     ///
     /// # Panics
     ///
-    /// This function will panic if `details_actions` is `None`.
+    /// Panics if [`LoreUiState::details`] is `None`.
     pub fn consolidate_patchset_actions(&mut self) -> color_eyre::Result<()> {
-        let details_actions = self.details_actions.as_ref().unwrap();
-
-        let representative_patch = details_actions.representative_patch.clone();
-        let patchset_actions = details_actions.patchset_actions.clone();
-        let raw_patches = details_actions.raw_patches.clone();
-        let patches_to_reply = details_actions.patches_to_reply.clone();
+        let details = self.state.lore.details.as_ref().unwrap();
+        let representative_patch = details.representative_patch.clone();
+        let patchset_actions = details.patchset_actions.clone();
+        let raw_patches = details.raw_patches.clone();
+        let patches_to_reply = details.patches_to_reply.clone();
 
         if let Some(true) = patchset_actions.get(&PatchsetAction::Bookmark) {
-            self.bookmarked_patchsets
+            self.state
+                .user_state
+                .bookmarked_patchsets
                 .bookmark_selected_patch(&representative_patch);
         } else {
-            self.bookmarked_patchsets
+            self.state
+                .user_state
+                .bookmarked_patchsets
                 .unbookmark_selected_patch(&representative_patch);
         }
 
-        self.lore_service
-            .save_bookmarked_patchsets(&self.bookmarked_patchsets.bookmarked_patchsets)
+        self.services
+            .lore
+            .save_bookmarked_patchsets(
+                &self
+                    .state
+                    .user_state
+                    .bookmarked_patchsets
+                    .bookmarked_patchsets,
+            )
             .map_err(|e| eyre!("{e:#?}"))?;
 
         if let Some(true) = patchset_actions.get(&PatchsetAction::ReplyWithReviewedBy) {
             let mut successful_indexes = self
+                .state
+                .user_state
                 .reviewed_patchsets
                 .remove(&representative_patch.message_id().href)
                 .unwrap_or_default();
 
-            let (git_user_name, git_user_email) = self.lore_service.get_git_signature("");
+            let (git_user_name, git_user_email) = self.services.lore.get_git_signature("");
 
             if git_user_name.is_empty() || git_user_email.is_empty() {
                 println!("`git config user.name` or `git config user.email` not set\nAborting...");
             } else {
                 let mktemp_cmd = ShellCommand::new("mktemp").arg("--directory");
                 let tmp_out = self
+                    .services
                     .shell
                     .execute(&mktemp_cmd)
                     .map_err(|e| eyre!("failed to create temp directory: {}", e))?;
@@ -332,14 +348,15 @@ impl App {
 
                 let git_signature = format!("{git_user_name} <{git_user_email}>");
                 let git_reply_commands = self
-                    .lore_service
+                    .services
+                    .lore
                     .prepare_reply_commands(
                         tmp_dir,
                         "all",
                         &raw_patches,
                         &patches_to_reply,
                         &git_signature,
-                        self.config.git_send_email_options(),
+                        self.state.config.git_send_email_options(),
                     )
                     .map_err(|e| eyre!("{e:#?}"))?;
 
@@ -349,146 +366,109 @@ impl App {
                     .filter_map(|(i, &val)| if val { Some(i) } else { None })
                     .collect();
                 for (i, command) in git_reply_commands.into_iter().enumerate() {
-                    let success = self.shell.spawn_interactive(&command).unwrap_or(false);
+                    let success = self
+                        .services
+                        .shell
+                        .spawn_interactive(&command)
+                        .unwrap_or(false);
                     if success {
                         successful_indexes.insert(reply_indexes[i]);
                     }
                 }
             }
 
-            self.reviewed_patchsets.insert(
+            self.state.user_state.reviewed_patchsets.insert(
                 representative_patch.message_id().href.clone(),
                 successful_indexes,
             );
 
-            self.lore_service
-                .save_reviewed_patchsets(&self.reviewed_patchsets)
+            self.services
+                .lore
+                .save_reviewed_patchsets(&self.state.user_state.reviewed_patchsets)
                 .map_err(|e| eyre!("{e:#?}"))?;
 
-            self.details_actions
+            self.state
+                .lore
+                .details
                 .as_mut()
                 .unwrap()
                 .reset_reply_with_reviewed_by_action();
         }
 
         if let Some(true) = self
-            .details_actions
+            .state
+            .lore
+            .details
             .as_ref()
             .unwrap()
             .patchset_actions
             .get(&PatchsetAction::Apply)
         {
-            let popup = match self.details_actions.as_ref().unwrap().apply_patchset(
-                &*self.fs,
-                &*self.shell,
-                &self.config,
+            let popup = match self.state.lore.details.as_ref().unwrap().apply_patchset(
+                &*self.services.fs,
+                &*self.services.shell,
+                &self.state.config,
             ) {
                 Ok(msg) => InfoPopUp::generate_info_popup("Patchset Apply Success", &msg),
                 Err(msg) => InfoPopUp::generate_info_popup("Patchset Apply Fail", &msg),
             };
 
-            self.popup = Some(popup);
+            self.state.popup = Some(popup);
 
-            self.details_actions.as_mut().unwrap().toggle_apply_action();
+            self.state
+                .lore
+                .details
+                .as_mut()
+                .unwrap()
+                .toggle_apply_action();
         }
 
         Ok(())
     }
 
-    /// Initializes field [App::edit_config], using values from [App::config].
+    /// Opens the edit-config screen from current [`Config`].
     pub fn init_edit_config(&mut self) {
-        self.edit_config = Some(EditConfigState::new(&self.config));
+        self.state.config_state.edit_config = Some(EditConfigState::new(&self.state.config));
     }
 
-    /// Sets field [App::edit_config] to `None`.
     pub fn reset_edit_config(&mut self) {
-        self.edit_config = None;
+        self.state.config_state.edit_config = None;
     }
 
-    /// Based on the edited config values from [App::edit_config], commit them
-    /// to field [App::config].
+    /// Applies edited values from [`ConfigUiState::edit_config`] into [`AppState::config`].
     pub fn consolidate_edit_config(&mut self) {
         // TODO: Handle invalid values!
-        if let Some(edit_config) = &mut self.edit_config {
+        if let Some(edit_config) = &mut self.state.config_state.edit_config {
             if let Ok(page_size) = edit_config.page_size() {
-                self.config.set_page_size(page_size)
+                self.state.config.set_page_size(page_size)
             }
-            if let Ok(cache_dir) = edit_config.cache_dir(&*self.fs) {
-                self.config.set_cache_dir(cache_dir)
+            if let Ok(cache_dir) = edit_config.cache_dir(&*self.services.fs) {
+                self.state.config.set_cache_dir(cache_dir)
             }
-            if let Ok(data_dir) = edit_config.data_dir(&*self.fs) {
-                self.config.set_data_dir(data_dir)
+            if let Ok(data_dir) = edit_config.data_dir(&*self.services.fs) {
+                self.state.config.set_data_dir(data_dir)
             }
             if let Ok(git_send_email_option) = edit_config.git_send_email_option() {
-                self.config.set_git_send_email_option(git_send_email_option)
+                self.state
+                    .config
+                    .set_git_send_email_option(git_send_email_option)
             }
             if let Ok(git_am_option) = edit_config.git_am_option() {
-                self.config.set_git_am_option(git_am_option)
+                self.state.config.set_git_am_option(git_am_option)
             }
             if let Ok(patch_renderer) = edit_config.extract_patch_renderer() {
-                self.config.set_patch_renderer(patch_renderer.into())
+                self.state.config.set_patch_renderer(patch_renderer.into())
             }
             if let Ok(cover_renderer) = edit_config.extract_cover_renderer() {
-                self.config.set_cover_renderer(cover_renderer.into())
+                self.state.config.set_cover_renderer(cover_renderer.into())
             }
             if let Ok(max_log_age) = edit_config.max_log_age() {
-                self.config.set_max_log_age(max_log_age)
+                self.state.config.set_max_log_age(max_log_age)
             }
         }
     }
 
-    /// Change the current active screen in [App::current_screen].
     pub fn set_current_screen(&mut self, new_current_screen: CurrentScreen) {
-        self.current_screen = new_current_screen;
-    }
-
-    /// Check if the external dependencies are installed
-    ///
-    /// If soft dependencies are missing, the application can still run and
-    /// their absence will only be logged
-    pub fn check_external_deps(&self) -> bool {
-        let mut app_can_run = true;
-
-        if !self.env.which("b4") {
-            event!(
-                Level::ERROR,
-                "b4 is not installed, patchsets cannot be downloaded"
-            );
-            app_can_run = false;
-        }
-
-        if !self.env.which("git") {
-            event!(Level::WARN, "git is not installed, send-email won't work");
-        }
-
-        match self.config.patch_renderer() {
-            PatchRenderer::Bat => {
-                if !self.env.which("bat") {
-                    event!(
-                        Level::WARN,
-                        "bat is not installed, patch rendering will fallback to default"
-                    );
-                }
-            }
-            PatchRenderer::Delta => {
-                if !self.env.which("delta") {
-                    event!(
-                        Level::WARN,
-                        "delta is not installed, patch rendering will fallback to default",
-                    );
-                }
-            }
-            PatchRenderer::DiffSoFancy => {
-                if !self.env.which("diff-so-fancy") {
-                    event!(
-                        Level::WARN,
-                        "diff-so-fancy is not installed, patch rendering will fallback to default",
-                    );
-                }
-            }
-            _ => {}
-        }
-
-        app_can_run
+        self.state.navigation.current_screen = new_current_screen;
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,6 +5,7 @@ pub mod errors;
 pub mod patch_renderer;
 pub mod screens;
 pub mod state;
+pub mod view_model;
 
 use ansi_to_tui::IntoText;
 use color_eyre::eyre::{bail, eyre};
@@ -41,6 +42,7 @@ use screens::{
     CurrentScreen,
 };
 pub use state::{AppState, ConfigUiState, LoreUiState, NavigationState, UserLoreState};
+pub use view_model::AppViewModel;
 
 /// Injected capabilities used by `App` orchestration (not screen state).
 pub struct AppServices {
@@ -166,7 +168,7 @@ impl App {
     }
 
     /// Loads patchset details into [`LoreUiState::details`].
-    pub fn init_details_actions(&mut self) -> color_eyre::Result<B4Result> {
+    pub fn open_patchset_details(&mut self) -> color_eyre::Result<B4Result> {
         let representative_patch: Patch;
         let mut is_patchset_bookmarked = true;
 
@@ -438,5 +440,11 @@ impl App {
 
     pub fn set_current_screen(&mut self, new_current_screen: CurrentScreen) {
         self.state.navigation.current_screen = new_current_screen;
+    }
+
+    /// Borrows state for one UI frame without passing [`App`] into `ui/`.
+    #[must_use]
+    pub fn to_view_model(&self) -> AppViewModel<'_> {
+        AppViewModel { state: &self.state }
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -414,34 +414,9 @@ impl App {
 
     /// Applies edited values from [`ConfigUiState::edit_config`] into [`AppState::config`].
     pub fn consolidate_edit_config(&mut self) {
-        // TODO: Handle invalid values!
-        if let Some(edit_config) = &mut self.state.config_state.edit_config {
-            if let Ok(page_size) = edit_config.page_size() {
-                self.state.config.set_page_size(page_size)
-            }
-            if let Ok(cache_dir) = edit_config.cache_dir(&*self.services.fs) {
-                self.state.config.set_cache_dir(cache_dir)
-            }
-            if let Ok(data_dir) = edit_config.data_dir(&*self.services.fs) {
-                self.state.config.set_data_dir(data_dir)
-            }
-            if let Ok(git_send_email_option) = edit_config.git_send_email_option() {
-                self.state
-                    .config
-                    .set_git_send_email_option(git_send_email_option)
-            }
-            if let Ok(git_am_option) = edit_config.git_am_option() {
-                self.state.config.set_git_am_option(git_am_option)
-            }
-            if let Ok(patch_renderer) = edit_config.extract_patch_renderer() {
-                self.state.config.set_patch_renderer(patch_renderer.into())
-            }
-            if let Ok(cover_renderer) = edit_config.extract_cover_renderer() {
-                self.state.config.set_cover_renderer(cover_renderer.into())
-            }
-            if let Ok(max_log_age) = edit_config.max_log_age() {
-                self.state.config.set_max_log_age(max_log_age)
-            }
+        if let Some(edit_config) = &self.state.config_state.edit_config {
+            let draft = edit_config.to_update_draft(&*self.services.fs);
+            self.state.config.apply_update(draft);
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,5 @@
 pub mod config;
-mod cover_renderer;
+pub mod cover_renderer;
 pub mod errors;
 pub mod patch_renderer;
 pub mod screens;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20,19 +20,17 @@ use crate::{
         env::EnvTrait,
         file_system::FileSystemTrait,
         monitoring::logging::garbage_collector::collect_garbage,
+        render::RenderServiceApi,
         shell::{ShellCommand, ShellTrait},
     },
     lore::{
         application::{api::LoreServiceApi, cache::CacheMode, errors::LoreError},
         domain::patch::{Author, Patch},
-        infrastructure::patchset_parser::split_cover,
     },
     ui::popup::info_popup::InfoPopUp,
 };
 
 use config::Config;
-use cover_renderer::render_cover;
-use patch_renderer::render_patch_preview;
 use screens::{
     bookmarked::BookmarkedPatchsetsState,
     details_actions::{PatchsetAction, PatchsetDetailsState},
@@ -46,6 +44,7 @@ pub use state::{AppState, ConfigUiState, LoreUiState, NavigationState, UserLoreS
 /// Injected capabilities used by `App` orchestration (not screen state).
 pub struct AppServices {
     pub lore: Box<dyn LoreServiceApi>,
+    pub render: Box<dyn RenderServiceApi>,
     pub shell: Box<dyn ShellTrait>,
     pub fs: Box<dyn FileSystemTrait>,
     pub env: Box<dyn EnvTrait>,
@@ -77,6 +76,7 @@ impl App {
         shell: Box<dyn ShellTrait>,
         env: Box<dyn EnvTrait>,
         mut lore_service: Box<dyn LoreServiceApi>,
+        render: Box<dyn RenderServiceApi>,
     ) -> color_eyre::Result<Self> {
         let bootstrap = lore_service.warm_bootstrap_cache().unwrap_or_default();
 
@@ -111,6 +111,7 @@ impl App {
             },
             services: AppServices {
                 lore: lore_service,
+                render,
                 shell,
                 fs,
                 env,
@@ -207,50 +208,26 @@ impl App {
             Err(e) => bail!("{e:#?}"),
         };
 
+        let preview_lines = self
+            .services
+            .render
+            .render_patchset_preview(
+                &details.raw_patches,
+                self.state.config.patch_renderer(),
+                self.state.config.cover_renderer(),
+            )
+            .map_err(|e| eyre!("{e}"))?;
+
         let mut patches_preview: Vec<Text> = Vec::new();
         let mut reviewed_by: Vec<HashSet<Author>> = Vec::new();
         let mut tested_by: Vec<HashSet<Author>> = Vec::new();
         let mut acked_by: Vec<HashSet<Author>> = Vec::new();
 
-        for (raw_patch, tag_summary) in details.raw_patches.iter().zip(details.tag_summary.iter()) {
-            let raw_patch_expanded = raw_patch.replace('\t', "        ");
-            let (raw_cover, raw_diff) = split_cover(&raw_patch_expanded);
-
+        for (line, tag_summary) in preview_lines.iter().zip(details.tag_summary.iter()) {
             reviewed_by.push(tag_summary.reviewed_by.clone());
             tested_by.push(tag_summary.tested_by.clone());
             acked_by.push(tag_summary.acked_by.clone());
-
-            let rendered_cover = match render_cover(
-                &*self.services.shell,
-                raw_cover,
-                self.state.config.cover_renderer(),
-            ) {
-                Ok(render) => render,
-                Err(_) => {
-                    event!(
-                        Level::ERROR,
-                        "Failed to render cover preview with external program"
-                    );
-                    raw_cover.to_string()
-                }
-            };
-
-            let rendered_patch = match render_patch_preview(
-                &*self.services.shell,
-                raw_diff,
-                self.state.config.patch_renderer(),
-            ) {
-                Ok(render) => render,
-                Err(_) => {
-                    event!(
-                        Level::ERROR,
-                        "Failed to render patch preview with external program",
-                    );
-                    raw_diff.to_string()
-                }
-            };
-
-            patches_preview.push(format!("{rendered_cover}---\n{rendered_patch}").into_text()?);
+            patches_preview.push(line.as_str().into_text()?);
         }
 
         let has_cover_letter = representative_patch.number_in_series() == 0;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+pub mod commands;
 pub mod config;
 pub mod cover_renderer;
 pub mod errors;
@@ -269,22 +270,27 @@ impl App {
     ///
     /// Panics if [`LoreUiState::details`] is `None`.
     pub fn consolidate_patchset_actions(&mut self) -> color_eyre::Result<()> {
+        self.sync_patchset_bookmark()?;
+        self.execute_reviewed_reply()?;
+        self.execute_apply_patchset();
+        Ok(())
+    }
+
+    fn sync_patchset_bookmark(&mut self) -> color_eyre::Result<()> {
         let details = self.state.lore.details.as_ref().unwrap();
-        let representative_patch = details.representative_patch.clone();
-        let patchset_actions = details.patchset_actions.clone();
-        let raw_patches = details.raw_patches.clone();
-        let patches_to_reply = details.patches_to_reply.clone();
+        let representative_patch = &details.representative_patch;
+        let patchset_actions = &details.patchset_actions;
 
         if let Some(true) = patchset_actions.get(&PatchsetAction::Bookmark) {
             self.state
                 .user_state
                 .bookmarked_patchsets
-                .bookmark_selected_patch(&representative_patch);
+                .bookmark_selected_patch(representative_patch);
         } else {
             self.state
                 .user_state
                 .bookmarked_patchsets
-                .unbookmark_selected_patch(&representative_patch);
+                .unbookmark_selected_patch(representative_patch);
         }
 
         self.services
@@ -297,6 +303,15 @@ impl App {
                     .bookmarked_patchsets,
             )
             .map_err(|e| eyre!("{e:#?}"))?;
+        Ok(())
+    }
+
+    fn execute_reviewed_reply(&mut self) -> color_eyre::Result<()> {
+        let details = self.state.lore.details.as_ref().unwrap();
+        let representative_patch = details.representative_patch.clone();
+        let patchset_actions = &details.patchset_actions;
+        let raw_patches = details.raw_patches.clone();
+        let patches_to_reply = details.patches_to_reply.clone();
 
         if let Some(true) = patchset_actions.get(&PatchsetAction::ReplyWithReviewedBy) {
             let mut successful_indexes = self
@@ -371,7 +386,10 @@ impl App {
                 .unwrap()
                 .reset_reply_with_reviewed_by_action();
         }
+        Ok(())
+    }
 
+    fn execute_apply_patchset(&mut self) {
         if let Some(true) = self
             .state
             .lore
@@ -399,8 +417,6 @@ impl App {
                 .unwrap()
                 .toggle_apply_action();
         }
-
-        Ok(())
     }
 
     /// Opens the edit-config screen from current [`Config`].

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -32,11 +32,11 @@ use config::Config;
 use cover_renderer::render_cover;
 use patch_renderer::{render_patch_preview, PatchRenderer};
 use screens::{
-    bookmarked::BookmarkedPatchsets,
-    details_actions::{DetailsActions, PatchsetAction},
-    edit_config::EditConfig,
-    latest::LatestPatchsets,
-    mail_list::MailingListSelection,
+    bookmarked::BookmarkedPatchsetsState,
+    details_actions::{PatchsetAction, PatchsetDetailsState},
+    edit_config::EditConfigState,
+    latest::LatestPatchsetsState,
+    mail_list::MailingListSelectionState,
     CurrentScreen,
 };
 
@@ -52,15 +52,15 @@ pub struct App {
     /// The current active screen
     pub current_screen: CurrentScreen,
     /// Screen to navigate and select the mailing lists archived on Lore
-    pub mailing_list_selection: MailingListSelection,
+    pub mailing_list_selection: MailingListSelectionState,
     /// Screen with listing patchsets that were previously bookmarked
-    pub bookmarked_patchsets: BookmarkedPatchsets,
+    pub bookmarked_patchsets: BookmarkedPatchsetsState,
     /// Screen with paginated listing of latest patchsets from a target list
-    pub latest_patchsets: Option<LatestPatchsets>,
+    pub latest_patchsets: Option<LatestPatchsetsState>,
     /// Screen with details (metadata and previewing) and runnable actions of individual patchset
-    pub details_actions: Option<DetailsActions>,
+    pub details_actions: Option<PatchsetDetailsState>,
     /// Screen to edit configurations of the app
-    pub edit_config: Option<EditConfig>,
+    pub edit_config: Option<EditConfigState>,
     /// Database to track patchsets `Reviewed-by` state
     pub reviewed_patchsets: HashMap<String, HashSet<usize>>,
     /// Configurations of the app
@@ -98,7 +98,7 @@ impl App {
 
         Ok(App {
             current_screen: CurrentScreen::MailingListSelection,
-            mailing_list_selection: MailingListSelection {
+            mailing_list_selection: MailingListSelectionState {
                 mailing_lists: bootstrap.mailing_lists.clone(),
                 target_list: String::new(),
                 possible_mailing_lists: bootstrap.mailing_lists,
@@ -107,7 +107,7 @@ impl App {
             latest_patchsets: None,
             details_actions: None,
             edit_config: None,
-            bookmarked_patchsets: BookmarkedPatchsets {
+            bookmarked_patchsets: BookmarkedPatchsetsState {
                 bookmarked_patchsets: bootstrap.bookmarks,
                 patchset_index: 0,
             },
@@ -128,7 +128,10 @@ impl App {
         let target_list = self.mailing_list_selection.possible_mailing_lists[list_index]
             .name()
             .to_string();
-        self.latest_patchsets = Some(LatestPatchsets::new(target_list, self.config.page_size()));
+        self.latest_patchsets = Some(LatestPatchsetsState::new(
+            target_list,
+            self.config.page_size(),
+        ));
     }
 
     /// Sets field [App::latest_patchsets] to `None`.
@@ -249,7 +252,7 @@ impl App {
         let has_cover_letter = representative_patch.number_in_series() == 0;
         let patches_to_reply = vec![false; details.raw_patches.len()];
 
-        self.details_actions = Some(DetailsActions {
+        self.details_actions = Some(PatchsetDetailsState {
             representative_patch,
             raw_patches: details.raw_patches,
             patchset_path: details.patchset_path,
@@ -394,7 +397,7 @@ impl App {
 
     /// Initializes field [App::edit_config], using values from [App::config].
     pub fn init_edit_config(&mut self) {
-        self.edit_config = Some(EditConfig::new(&self.config));
+        self.edit_config = Some(EditConfigState::new(&self.config));
     }
 
     /// Sets field [App::edit_config] to `None`.

--- a/src/app/screens/bookmarked.rs
+++ b/src/app/screens/bookmarked.rs
@@ -1,11 +1,11 @@
 use crate::lore::domain::patch::Patch;
 
-pub struct BookmarkedPatchsets {
+pub struct BookmarkedPatchsetsState {
     pub bookmarked_patchsets: Vec<Patch>,
     pub patchset_index: usize,
 }
 
-impl BookmarkedPatchsets {
+impl BookmarkedPatchsetsState {
     pub fn select_below_patchset(&mut self) {
         if self.patchset_index + 1 < self.bookmarked_patchsets.len() {
             self.patchset_index += 1;

--- a/src/app/screens/details_actions.rs
+++ b/src/app/screens/details_actions.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::CurrentScreen;
 
-pub struct DetailsActions {
+pub struct PatchsetDetailsState {
     pub representative_patch: Patch,
     /// Raw patches as plain text files
     pub raw_patches: Vec<String>,
@@ -52,7 +52,7 @@ pub enum PatchsetAction {
     Apply,
 }
 
-impl DetailsActions {
+impl PatchsetDetailsState {
     pub fn preview_next_patch(&mut self) {
         if (self.preview_index + 1) < self.patches_preview.len() {
             self.preview_index += 1;
@@ -159,7 +159,7 @@ impl DetailsActions {
         let current_value = *self
             .patchset_actions
             .get(&patchset_action)
-            .expect("DetailsActions::Patchset_actions must be initialized properly");
+            .expect("PatchsetDetailsState::patchset_actions must be initialized properly");
         self.patchset_actions
             .insert(patchset_action, !current_value);
     }

--- a/src/app/screens/edit_config.rs
+++ b/src/app/screens/edit_config.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, fmt::Display, path::Path};
 use crate::{app::config::Config, infrastructure::file_system::FileSystemTrait};
 
 #[derive(Debug, Getters)]
-pub struct EditConfig {
+pub struct EditConfigState {
     #[getter(skip)]
     config_buffer: HashMap<EditableConfig, String>,
     highlighted: usize,
@@ -14,7 +14,7 @@ pub struct EditConfig {
     curr_edit: String,
 }
 
-impl EditConfig {
+impl EditConfigState {
     pub fn new(config: &Config) -> Self {
         let mut config_buffer = HashMap::new();
         config_buffer.insert(EditableConfig::PageSize, config.page_size().to_string());
@@ -38,7 +38,7 @@ impl EditConfig {
         );
         config_buffer.insert(EditableConfig::MaxLogAge, config.max_log_age().to_string());
 
-        EditConfig {
+        EditConfigState {
             config_buffer,
             highlighted: 0,
             is_editing: false,
@@ -114,7 +114,7 @@ impl EditConfig {
     }
 }
 
-impl EditConfig {
+impl EditConfigState {
     fn extract_config_buffer_val(&mut self, editable_config: &EditableConfig) -> String {
         let mut ret_value = String::new();
         if let Some(config_value) = self.config_buffer.get_mut(editable_config) {

--- a/src/app/screens/edit_config.rs
+++ b/src/app/screens/edit_config.rs
@@ -3,7 +3,10 @@ use derive_getters::Getters;
 
 use std::{collections::HashMap, fmt::Display, path::Path};
 
-use crate::{app::config::Config, infrastructure::file_system::FileSystemTrait};
+use crate::{
+    app::config::{Config, ConfigUpdateDraft},
+    infrastructure::file_system::FileSystemTrait,
+};
 
 #[derive(Debug, Getters)]
 pub struct EditConfigState {
@@ -112,31 +115,6 @@ impl EditConfigState {
                 .insert(editable_config, std::mem::take(&mut self.curr_edit));
         }
     }
-}
-
-impl EditConfigState {
-    fn extract_config_buffer_val(&mut self, editable_config: &EditableConfig) -> String {
-        let mut ret_value = String::new();
-        if let Some(config_value) = self.config_buffer.get_mut(editable_config) {
-            std::mem::swap(&mut ret_value, config_value);
-        }
-        ret_value
-    }
-
-    /// Extracts the page size from the config
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the page size inserted string is not a valid integer
-    pub fn page_size(&mut self) -> Result<usize, ()> {
-        match self
-            .extract_config_buffer_val(&EditableConfig::PageSize)
-            .parse::<usize>()
-        {
-            Ok(value) => Ok(value),
-            Err(_) => Err(()),
-        }
-    }
 
     fn is_valid_dir(fs: &dyn FileSystemTrait, dir_path: &str) -> bool {
         let path_to_check = Path::new(dir_path);
@@ -148,69 +126,43 @@ impl EditConfigState {
         }
     }
 
-    /// Extracts the cache directory from the config
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the cache directory is not a valid directory
-    pub fn cache_dir(&mut self, fs: &dyn FileSystemTrait) -> Result<String, ()> {
-        let cache_dir = self.extract_config_buffer_val(&EditableConfig::CacheDir);
-        match Self::is_valid_dir(fs, &cache_dir) {
-            true => Ok(cache_dir),
-            false => Err(()),
+    /// Builds a [`ConfigUpdateDraft`] from the current buffer values that pass validation,
+    /// without mutating the buffer.
+    pub fn to_update_draft(&self, fs: &dyn FileSystemTrait) -> ConfigUpdateDraft {
+        let mut draft = ConfigUpdateDraft::default();
+        if let Some(s) = self.config_buffer.get(&EditableConfig::PageSize) {
+            if let Ok(v) = s.parse::<usize>() {
+                draft.page_size = Some(v);
+            }
         }
-    }
-
-    /// Extracts the data directory from the config
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the data directory is not a valid directory
-    pub fn data_dir(&mut self, fs: &dyn FileSystemTrait) -> Result<String, ()> {
-        let data_dir = self.extract_config_buffer_val(&EditableConfig::DataDir);
-        match Self::is_valid_dir(fs, &data_dir) {
-            true => Ok(data_dir),
-            false => Err(()),
+        if let Some(s) = self.config_buffer.get(&EditableConfig::CacheDir) {
+            if Self::is_valid_dir(fs, s) {
+                draft.cache_dir = Some(s.clone());
+            }
         }
-    }
-
-    /// Extracts the `git send email` option from the config
-    pub fn git_send_email_option(&mut self) -> Result<String, ()> {
-        let git_send_emial_option =
-            self.extract_config_buffer_val(&EditableConfig::GitSendEmailOpt);
-        // TODO: Check if the option is valid
-        Ok(git_send_emial_option)
-    }
-
-    /// Extracts the `git am` option from the config
-    pub fn git_am_option(&mut self) -> Result<String, ()> {
-        let git_am_option = self.extract_config_buffer_val(&EditableConfig::GitAmOpt);
-        Ok(git_am_option)
-    }
-
-    pub fn extract_patch_renderer(&mut self) -> Result<String, ()> {
-        let patch_renderer = self.extract_config_buffer_val(&EditableConfig::PatchRenderer);
-        Ok(patch_renderer)
-    }
-
-    pub fn extract_cover_renderer(&mut self) -> Result<String, ()> {
-        let cover_renderer = self.extract_config_buffer_val(&EditableConfig::CoverRenderer);
-        Ok(cover_renderer)
-    }
-
-    /// Extracts the max log age from the config
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the max log age inserted string is not a valid integer
-    pub fn max_log_age(&mut self) -> Result<usize, ()> {
-        match self
-            .extract_config_buffer_val(&EditableConfig::MaxLogAge)
-            .parse::<usize>()
-        {
-            Ok(value) => Ok(value),
-            Err(_) => Err(()),
+        if let Some(s) = self.config_buffer.get(&EditableConfig::DataDir) {
+            if Self::is_valid_dir(fs, s) {
+                draft.data_dir = Some(s.clone());
+            }
         }
+        if let Some(s) = self.config_buffer.get(&EditableConfig::GitSendEmailOpt) {
+            draft.git_send_email_option = Some(s.clone());
+        }
+        if let Some(s) = self.config_buffer.get(&EditableConfig::GitAmOpt) {
+            draft.git_am_option = Some(s.clone());
+        }
+        if let Some(s) = self.config_buffer.get(&EditableConfig::PatchRenderer) {
+            draft.patch_renderer = Some(s.clone());
+        }
+        if let Some(s) = self.config_buffer.get(&EditableConfig::CoverRenderer) {
+            draft.cover_renderer = Some(s.clone());
+        }
+        if let Some(s) = self.config_buffer.get(&EditableConfig::MaxLogAge) {
+            if let Ok(v) = s.parse::<usize>() {
+                draft.max_log_age = Some(v);
+            }
+        }
+        draft
     }
 }
 

--- a/src/app/screens/latest.rs
+++ b/src/app/screens/latest.rs
@@ -5,7 +5,7 @@ use crate::lore::{
     domain::patch::Patch,
 };
 
-pub struct LatestPatchsets {
+pub struct LatestPatchsetsState {
     target_list: String,
     page_number: usize,
     /// Index of the selected patchset within the current page (0-based).
@@ -15,9 +15,9 @@ pub struct LatestPatchsets {
     current_page: Vec<Patch>,
 }
 
-impl LatestPatchsets {
-    pub fn new(target_list: String, page_size: usize) -> LatestPatchsets {
-        LatestPatchsets {
+impl LatestPatchsetsState {
+    pub fn new(target_list: String, page_size: usize) -> LatestPatchsetsState {
+        LatestPatchsetsState {
             target_list,
             page_number: 1,
             patchset_index: 0,
@@ -128,7 +128,7 @@ mod tests {
             .times(1)
             .returning(|_, _, _, _| Ok(vec![make_patch("id-1"), make_patch("id-2")]));
 
-        let mut lp = LatestPatchsets::new("some-list".to_string(), 5);
+        let mut lp = LatestPatchsetsState::new("some-list".to_string(), 5);
         let result = lp.fetch_current_page(&mut mock, CacheMode::UseCache);
 
         assert!(result.is_ok());
@@ -142,7 +142,7 @@ mod tests {
             .times(1)
             .returning(|_, _, _, _| Err(LoreError::EndOfFeed));
 
-        let mut lp = LatestPatchsets::new("some-list".to_string(), 5);
+        let mut lp = LatestPatchsetsState::new("some-list".to_string(), 5);
         let result = lp.fetch_current_page(&mut mock, CacheMode::UseCache);
 
         assert!(result.is_ok());
@@ -164,7 +164,7 @@ mod tests {
                 })))
             });
 
-        let mut lp = LatestPatchsets::new("some-list".to_string(), 5);
+        let mut lp = LatestPatchsetsState::new("some-list".to_string(), 5);
         let result = lp.fetch_current_page(&mut mock, CacheMode::UseCache);
 
         assert!(result.is_err());
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     fn test_select_below_patchset() {
-        let mut lp = LatestPatchsets::new("some-list".to_string(), 3);
+        let mut lp = LatestPatchsetsState::new("some-list".to_string(), 3);
         lp.current_page = vec![make_patch("a"), make_patch("b"), make_patch("c")];
         lp.patchset_index = 0;
 
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn test_select_below_patchset_empty_page() {
-        let mut lp = LatestPatchsets::new("some-list".to_string(), 3);
+        let mut lp = LatestPatchsetsState::new("some-list".to_string(), 3);
         lp.patchset_index = 0;
         lp.select_below_patchset();
         assert_eq!(lp.patchset_index(), 0);
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn test_select_above_patchset() {
-        let mut lp = LatestPatchsets::new("some-list".to_string(), 3);
+        let mut lp = LatestPatchsetsState::new("some-list".to_string(), 3);
         lp.current_page = vec![make_patch("a"), make_patch("b"), make_patch("c")];
         lp.patchset_index = 2;
 
@@ -214,7 +214,7 @@ mod tests {
 
     #[test]
     fn test_increment_page_full_page() {
-        let mut lp = LatestPatchsets::new("some-list".to_string(), 3);
+        let mut lp = LatestPatchsetsState::new("some-list".to_string(), 3);
         lp.current_page = vec![make_patch("a"), make_patch("b"), make_patch("c")];
         lp.patchset_index = 2;
 
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_increment_page_partial_page() {
-        let mut lp = LatestPatchsets::new("some-list".to_string(), 3);
+        let mut lp = LatestPatchsetsState::new("some-list".to_string(), 3);
         lp.current_page = vec![make_patch("a"), make_patch("b")]; // 2 < page_size=3
 
         lp.increment_page();
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn test_increment_page_sequential() {
-        let mut lp = LatestPatchsets::new("some-list".to_string(), 1);
+        let mut lp = LatestPatchsetsState::new("some-list".to_string(), 1);
         lp.current_page = vec![make_patch("a")];
 
         lp.increment_page();
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn test_decrement_page() {
-        let mut lp = LatestPatchsets::new("some-list".to_string(), 3);
+        let mut lp = LatestPatchsetsState::new("some-list".to_string(), 3);
 
         // Already on page 1, no change
         lp.decrement_page();
@@ -270,13 +270,13 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_get_selected_patchset_before_fetching_page() {
-        let lp = LatestPatchsets::new("some-list".to_string(), 3);
+        let lp = LatestPatchsetsState::new("some-list".to_string(), 3);
         let _patch = lp.get_selected_patchset();
     }
 
     #[test]
     fn test_get_selected_patchset() {
-        let mut lp = LatestPatchsets::new("some-list".to_string(), 3);
+        let mut lp = LatestPatchsetsState::new("some-list".to_string(), 3);
         lp.current_page = vec![make_patch("id-1"), make_patch("id-2"), make_patch("id-3")];
 
         lp.patchset_index = 0;
@@ -304,7 +304,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_get_selected_patchset_invalid_index() {
-        let mut lp = LatestPatchsets::new("some-list".to_string(), 3);
+        let mut lp = LatestPatchsetsState::new("some-list".to_string(), 3);
         lp.current_page = vec![make_patch("id-1")];
         lp.patchset_index = 99;
         let _patch = lp.get_selected_patchset();

--- a/src/app/screens/mail_list.rs
+++ b/src/app/screens/mail_list.rs
@@ -5,14 +5,14 @@ use crate::lore::{
     domain::mailing_list::MailingList,
 };
 
-pub struct MailingListSelection {
+pub struct MailingListSelectionState {
     pub mailing_lists: Vec<MailingList>,
     pub target_list: String,
     pub possible_mailing_lists: Vec<MailingList>,
     pub highlighted_list_index: usize,
 }
 
-impl MailingListSelection {
+impl MailingListSelectionState {
     pub fn refresh_available_mailing_lists(
         &mut self,
         lore_service: &mut dyn LoreServiceApi,
@@ -90,7 +90,7 @@ mod tests {
     fn test_remove_last_target_list_char_empty_target_list() {
         let possible_mailing_lists = vec![MailingList::new("mailing list", "")];
         let highlighted_list_index = 9;
-        let mut selection = MailingListSelection {
+        let mut selection = MailingListSelectionState {
             mailing_lists: vec![],
             target_list: "".to_string(),
             possible_mailing_lists: possible_mailing_lists.clone(),
@@ -112,7 +112,7 @@ mod tests {
             MailingList::new("non target", ""),
         ];
         let highlighted_list_index = 9;
-        let mut selection = MailingListSelection {
+        let mut selection = MailingListSelectionState {
             mailing_lists: mailing_lists.clone(),
             target_list: "target".to_string(),
             possible_mailing_lists: vec![],
@@ -136,7 +136,7 @@ mod tests {
             MailingList::new("target", ""),
             MailingList::new("non target", ""),
         ];
-        let mut selection = MailingListSelection {
+        let mut selection = MailingListSelectionState {
             mailing_lists: mailing_lists.clone(),
             target_list: "targe".to_string(),
             possible_mailing_lists: vec![],
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn test_clear_target_list() {
-        let mut selection = MailingListSelection {
+        let mut selection = MailingListSelectionState {
             mailing_lists: vec![],
             target_list: "some value".to_string(),
             possible_mailing_lists: vec![MailingList::new("match", "")],
@@ -249,7 +249,7 @@ mod tests {
         ];
 
         for test_case in test_cases {
-            let mut mailing_list_selection = MailingListSelection {
+            let mut mailing_list_selection = MailingListSelectionState {
                 mailing_lists: test_case.mailing_lists,
                 target_list: test_case.target_list.to_string(),
                 possible_mailing_lists: vec![],
@@ -276,7 +276,7 @@ mod tests {
             MailingList::new("some-list", ""),
             MailingList::new("some-list-2", ""),
         ];
-        let mut selection = MailingListSelection {
+        let mut selection = MailingListSelectionState {
             mailing_lists: vec![],
             target_list: "".to_string(),
             possible_mailing_lists,
@@ -294,7 +294,7 @@ mod tests {
     #[test]
     fn test_highlight_above_list() {
         let mailing_list = MailingList::new("some-list", "");
-        let mut selection = MailingListSelection {
+        let mut selection = MailingListSelectionState {
             mailing_lists: vec![],
             target_list: "".to_string(),
             possible_mailing_lists: vec![mailing_list.clone(), mailing_list.clone()],
@@ -315,7 +315,7 @@ mod tests {
     #[test]
     fn test_has_valid_target_list() {
         let mailing_list = MailingList::new("some-list", "");
-        let selection_valid = MailingListSelection {
+        let selection_valid = MailingListSelectionState {
             mailing_lists: vec![],
             target_list: "".to_string(),
             possible_mailing_lists: vec![mailing_list.clone()],
@@ -323,7 +323,7 @@ mod tests {
         };
         assert!(selection_valid.has_valid_target_list());
 
-        let selection_invalid = MailingListSelection {
+        let selection_invalid = MailingListSelectionState {
             mailing_lists: vec![],
             target_list: "".to_string(),
             possible_mailing_lists: vec![mailing_list.clone()],

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,0 +1,46 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+    app::{
+        config::Config,
+        screens::{
+            bookmarked::BookmarkedPatchsetsState, details_actions::PatchsetDetailsState,
+            edit_config::EditConfigState, latest::LatestPatchsetsState,
+            mail_list::MailingListSelectionState, CurrentScreen,
+        },
+    },
+    ui::popup::PopUp,
+};
+
+/// Navigation-only state: which screen is active.
+pub struct NavigationState {
+    pub current_screen: CurrentScreen,
+}
+
+/// Lore-related UI: mailing list picker, feed, patchset details.
+pub struct LoreUiState {
+    pub mailing_list_selection: MailingListSelectionState,
+    pub latest_patchsets: Option<LatestPatchsetsState>,
+    pub details: Option<PatchsetDetailsState>,
+}
+
+/// User-owned Lore data (bookmarks and review markers).
+pub struct UserLoreState {
+    pub bookmarked_patchsets: BookmarkedPatchsetsState,
+    pub reviewed_patchsets: HashMap<String, HashSet<usize>>,
+}
+
+/// Edit-config screen state (transient form).
+pub struct ConfigUiState {
+    pub edit_config: Option<EditConfigState>,
+}
+
+/// All application state grouped for the future App actor.
+pub struct AppState {
+    pub navigation: NavigationState,
+    pub lore: LoreUiState,
+    pub user_state: UserLoreState,
+    pub config_state: ConfigUiState,
+    pub config: Config,
+    pub popup: Option<Box<dyn PopUp>>,
+}

--- a/src/app/view_model.rs
+++ b/src/app/view_model.rs
@@ -1,0 +1,9 @@
+//! Read-only projections for rendering: keeps `ui/` independent of the [`super::App`] struct.
+
+use super::state::AppState;
+
+/// References into [`AppState`] for one Ratatui frame. Built via [`super::App::to_view_model`].
+#[derive(Clone, Copy)]
+pub struct AppViewModel<'a> {
+    pub state: &'a AppState,
+}

--- a/src/handler/bookmarked.rs
+++ b/src/handler/bookmarked.rs
@@ -23,17 +23,23 @@ where
     match key.code {
         KeyCode::Char('?') => {
             let popup = generate_help_popup();
-            app.popup = Some(popup);
+            app.state.popup = Some(popup);
         }
         KeyCode::Esc | KeyCode::Char('q') => {
-            app.bookmarked_patchsets.patchset_index = 0;
+            app.state.user_state.bookmarked_patchsets.patchset_index = 0;
             app.set_current_screen(CurrentScreen::MailingListSelection);
         }
         KeyCode::Char('j') | KeyCode::Down => {
-            app.bookmarked_patchsets.select_below_patchset();
+            app.state
+                .user_state
+                .bookmarked_patchsets
+                .select_below_patchset();
         }
         KeyCode::Char('k') | KeyCode::Up => {
-            app.bookmarked_patchsets.select_above_patchset();
+            app.state
+                .user_state
+                .bookmarked_patchsets
+                .select_above_patchset();
         }
         KeyCode::Enter => {
             terminal = loading_screen! {
@@ -50,7 +56,7 @@ where
                                 app.set_current_screen(CurrentScreen::PatchsetDetails);
                             }
                             B4Result::PatchNotFound(err_cause) => {
-                                app.popup = Some(InfoPopUp::generate_info_popup(
+                                app.state.popup = Some(InfoPopUp::generate_info_popup(
                                     "Error",&format!("The selected patchset couldn't be retrieved.\nReason: {err_cause}\nPlease choose another patchset.")
                                 ));
                                 app.set_current_screen(CurrentScreen::BookmarkedPatchsets);

--- a/src/handler/bookmarked.rs
+++ b/src/handler/bookmarked.rs
@@ -45,7 +45,7 @@ where
             terminal = loading_screen! {
                 terminal,
                 "Loading patchset" => {
-                    let result = app.init_details_actions();
+                    let result = app.open_patchset_details();
                     if result.is_ok() {
                         // If a patchset has been bookmarked UI, this means that
                         // b4 was successful in fetching it, so it shouldn't be

--- a/src/handler/details_actions.rs
+++ b/src/handler/details_actions.rs
@@ -19,7 +19,7 @@ pub fn handle_patchset_details<B: Backend>(
     key: KeyEvent,
     terminal: &mut Terminal<B>,
 ) -> color_eyre::Result<()> {
-    let patchset_details_and_actions = app.details_actions.as_mut().unwrap();
+    let patchset_details_and_actions = app.state.lore.details.as_mut().unwrap();
 
     if key.modifiers.contains(KeyModifiers::SHIFT) {
         match key.code {
@@ -51,7 +51,7 @@ pub fn handle_patchset_details<B: Backend>(
             KeyCode::Char('t') => {
                 let popup =
                     ReviewTrailersPopUp::generate_trailers_popup(patchset_details_and_actions);
-                app.popup = Some(popup);
+                app.state.popup = Some(popup);
             }
             _ => {}
         }
@@ -61,7 +61,7 @@ pub fn handle_patchset_details<B: Backend>(
     match key.code {
         KeyCode::Char('?') => {
             let popup = generate_help_popup();
-            app.popup = Some(popup);
+            app.state.popup = Some(popup);
         }
         KeyCode::Esc | KeyCode::Char('q') => {
             let ps_da_clone = patchset_details_and_actions.last_screen.clone();

--- a/src/handler/edit_config.rs
+++ b/src/handler/edit_config.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()> {
-    if let Some(edit_config_state) = app.edit_config.as_mut() {
+    if let Some(edit_config_state) = app.state.config_state.edit_config.as_mut() {
         match edit_config_state.is_editing() {
             true => match key.code {
                 KeyCode::Esc => {
@@ -29,11 +29,13 @@ pub fn handle_edit_config(app: &mut App, key: KeyEvent) -> color_eyre::Result<()
             false => match key.code {
                 KeyCode::Char('?') => {
                     let popup = generate_help_popup();
-                    app.popup = Some(popup);
+                    app.state.popup = Some(popup);
                 }
                 KeyCode::Esc | KeyCode::Char('q') => {
                     app.consolidate_edit_config();
-                    app.config.save_patch_hub_config(&*app.env, &*app.fs)?;
+                    app.state
+                        .config
+                        .save_patch_hub_config(&*app.services.env, &*app.services.fs)?;
                     app.reset_edit_config();
                     app.set_current_screen(CurrentScreen::MailingListSelection);
                 }

--- a/src/handler/latest.rs
+++ b/src/handler/latest.rs
@@ -20,12 +20,12 @@ pub fn handle_latest_patchsets<B>(
 where
     B: Backend + Send + 'static,
 {
-    let latest_patchsets = app.latest_patchsets.as_mut().unwrap();
+    let latest_patchsets = app.state.lore.latest_patchsets.as_mut().unwrap();
 
     match key.code {
         KeyCode::Char('?') => {
             let popup = generate_help_popup();
-            app.popup = Some(popup);
+            app.state.popup = Some(popup);
         }
         KeyCode::Esc | KeyCode::Char('q') => {
             app.reset_latest_patchsets();
@@ -56,14 +56,14 @@ where
             terminal = loading_screen! {
                 terminal,
                 "Loading patchset" => {
-                    let result = app.init_details_actions();
+                    let result = app.open_patchset_details();
                     if result.is_ok() {
                         match result.unwrap() {
                             B4Result::PatchFound => {
                                 app.set_current_screen(CurrentScreen::PatchsetDetails);
                             }
                             B4Result::PatchNotFound(err_cause) => {
-                                app.popup = Some(InfoPopUp::generate_info_popup(
+                                app.state.popup = Some(InfoPopUp::generate_info_popup(
                                     "Error",&format!("The selected patchset couldn't be retrieved.\nReason: {err_cause}\nPlease choose another patchset.")
                                 ));
                                 app.set_current_screen(CurrentScreen::LatestPatchsets);

--- a/src/handler/mail_list.rs
+++ b/src/handler/mail_list.rs
@@ -23,12 +23,19 @@ where
     match key.code {
         KeyCode::Char('?') => {
             let popup = generate_help_popup();
-            app.popup = Some(popup);
+            app.state.popup = Some(popup);
         }
         KeyCode::Enter => {
-            if app.mailing_list_selection.has_valid_target_list() {
+            if app
+                .state
+                .lore
+                .mailing_list_selection
+                .has_valid_target_list()
+            {
                 app.init_latest_patchsets();
                 let list_name = app
+                    .state
+                    .lore
                     .latest_patchsets
                     .as_ref()
                     .unwrap()
@@ -40,7 +47,7 @@ where
                     format!("Fetching patchsets from {}", list_name) => {
                         let result = app.fetch_latest_current_page();
                         if result.is_ok() {
-                            app.mailing_list_selection.clear_target_list();
+                            app.state.lore.mailing_list_selection.clear_target_list();
                             app.set_current_screen(CurrentScreen::LatestPatchsets);
                         }
                         result
@@ -61,25 +68,37 @@ where
             app.set_current_screen(CurrentScreen::EditConfig);
         }
         KeyCode::F(1) => {
-            if !app.bookmarked_patchsets.bookmarked_patchsets.is_empty() {
-                app.mailing_list_selection.clear_target_list();
+            if !app
+                .state
+                .user_state
+                .bookmarked_patchsets
+                .bookmarked_patchsets
+                .is_empty()
+            {
+                app.state.lore.mailing_list_selection.clear_target_list();
                 app.set_current_screen(CurrentScreen::BookmarkedPatchsets);
             }
         }
         KeyCode::Backspace => {
-            app.mailing_list_selection.remove_last_target_list_char();
+            app.state
+                .lore
+                .mailing_list_selection
+                .remove_last_target_list_char();
         }
         KeyCode::Esc => {
             return Ok(ControlFlow::Break(()));
         }
         KeyCode::Char(ch) => {
-            app.mailing_list_selection.push_char_to_target_list(ch);
+            app.state
+                .lore
+                .mailing_list_selection
+                .push_char_to_target_list(ch);
         }
         KeyCode::Down => {
-            app.mailing_list_selection.highlight_below_list();
+            app.state.lore.mailing_list_selection.highlight_below_list();
         }
         KeyCode::Up => {
-            app.mailing_list_selection.highlight_above_list();
+            app.state.lore.mailing_list_selection.highlight_above_list();
         }
         _ => {}
     }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -35,14 +35,14 @@ fn key_handling<B>(
 where
     B: Backend + Send + 'static,
 {
-    if let Some(popup) = app.popup.as_mut() {
+    if let Some(popup) = app.state.popup.as_mut() {
         if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
-            app.popup = None;
+            app.state.popup = None;
         } else {
             popup.handle(key)?;
         }
     } else {
-        match app.current_screen {
+        match app.state.navigation.current_screen {
             CurrentScreen::MailingListSelection => {
                 return handle_mailing_list_selection(app, key, terminal);
             }
@@ -67,9 +67,15 @@ fn logic_handling<B>(mut terminal: Terminal<B>, app: &mut App) -> color_eyre::Re
 where
     B: Backend + Send + 'static,
 {
-    match app.current_screen {
+    match app.state.navigation.current_screen {
         CurrentScreen::MailingListSelection => {
-            if app.mailing_list_selection.mailing_lists.is_empty() {
+            if app
+                .state
+                .lore
+                .mailing_list_selection
+                .mailing_lists
+                .is_empty()
+            {
                 terminal = loading_screen! {
                     terminal, "Fetching mailing lists" => {
                         app.refresh_mailing_lists()
@@ -78,7 +84,7 @@ where
             }
         }
         CurrentScreen::LatestPatchsets => {
-            let patchsets_state = app.latest_patchsets.as_mut().unwrap();
+            let patchsets_state = app.state.lore.latest_patchsets.as_ref().unwrap();
 
             if patchsets_state.processed_patchsets_count() == 0 {
                 let target_list = patchsets_state.target_list().to_string();
@@ -89,11 +95,17 @@ where
                     }
                 };
 
-                app.mailing_list_selection.clear_target_list();
+                app.state.lore.mailing_list_selection.clear_target_list();
             }
         }
         CurrentScreen::BookmarkedPatchsets => {
-            if app.bookmarked_patchsets.bookmarked_patchsets.is_empty() {
+            if app
+                .state
+                .user_state
+                .bookmarked_patchsets
+                .bookmarked_patchsets
+                .is_empty()
+            {
                 app.set_current_screen(CurrentScreen::MailingListSelection);
             }
         }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -122,7 +122,7 @@ where
     loop {
         terminal = logic_handling(terminal, &mut app)?;
 
-        terminal.draw(|f| draw_ui(f, &app))?;
+        terminal.draw(|f| draw_ui(f, &app.to_view_model()))?;
 
         // *IMPORTANT*: Uncommenting the if below makes `patch-hub` not block
         // until an event is captured.  We should only do it when (if ever) we

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -3,5 +3,6 @@ pub mod errors;
 pub mod file_system;
 pub mod monitoring;
 pub mod net;
+pub mod render;
 pub mod shell;
 pub mod terminal;

--- a/src/infrastructure/render/mod.rs
+++ b/src/infrastructure/render/mod.rs
@@ -1,15 +1,12 @@
 //! Rich patch/cover preview via external programs (`bat`, `delta`, `diff-so-fancy`).
-//!
-//! `ShellRenderService` is wired from `App` in a follow-up commit; this module is
-//! compiled first so the trait and implementation exist without dead-code noise.
-
-#![allow(dead_code)]
 
 mod r#trait;
 
 pub use r#trait::{RenderError, RenderServiceApi};
 
 use std::sync::Arc;
+
+use tracing::{event, Level};
 
 use crate::{
     app::cover_renderer::render_cover, app::patch_renderer::render_patch_preview,
@@ -42,10 +39,26 @@ impl RenderServiceApi for ShellRenderService {
         for raw_patch in raw_patches {
             let raw_patch_expanded = raw_patch.replace('\t', "        ");
             let (raw_cover, raw_diff) = split_cover(&raw_patch_expanded);
-            let rendered_cover = render_cover(shell, raw_cover, cover_renderer)
-                .map_err(|e| RenderError::Failed(e.to_string()))?;
-            let rendered_patch = render_patch_preview(shell, raw_diff, patch_renderer)
-                .map_err(|e| RenderError::Failed(e.to_string()))?;
+            let rendered_cover = match render_cover(shell, raw_cover, cover_renderer) {
+                Ok(render) => render,
+                Err(_) => {
+                    event!(
+                        Level::ERROR,
+                        "Failed to render cover preview with external program"
+                    );
+                    raw_cover.to_string()
+                }
+            };
+            let rendered_patch = match render_patch_preview(shell, raw_diff, patch_renderer) {
+                Ok(render) => render,
+                Err(_) => {
+                    event!(
+                        Level::ERROR,
+                        "Failed to render patch preview with external program",
+                    );
+                    raw_diff.to_string()
+                }
+            };
             previews.push(format!("{rendered_cover}---\n{rendered_patch}"));
         }
         Ok(previews)

--- a/src/infrastructure/render/mod.rs
+++ b/src/infrastructure/render/mod.rs
@@ -1,0 +1,56 @@
+//! Rich patch/cover preview via external programs (`bat`, `delta`, `diff-so-fancy`).
+//!
+//! `ShellRenderService` is wired from `App` in a follow-up commit; this module is
+//! compiled first so the trait and implementation exist without dead-code noise.
+
+#![allow(dead_code)]
+
+mod r#trait;
+
+pub use r#trait::{RenderError, RenderServiceApi};
+
+use std::sync::Arc;
+
+use crate::{
+    app::cover_renderer::render_cover, app::patch_renderer::render_patch_preview,
+    infrastructure::shell::ShellTrait, lore::infrastructure::patchset_parser::split_cover,
+};
+
+use crate::app::cover_renderer::CoverRenderer;
+use crate::app::patch_renderer::PatchRenderer;
+
+/// [`RenderServiceApi`] backed by [`ShellTrait`] and the existing `app` renderer helpers.
+pub struct ShellRenderService {
+    shell: Arc<dyn ShellTrait>,
+}
+
+impl ShellRenderService {
+    pub fn new(shell: Arc<dyn ShellTrait>) -> Self {
+        Self { shell }
+    }
+}
+
+impl RenderServiceApi for ShellRenderService {
+    fn render_patchset_preview(
+        &self,
+        raw_patches: &[String],
+        patch_renderer: &PatchRenderer,
+        cover_renderer: &CoverRenderer,
+    ) -> Result<Vec<String>, RenderError> {
+        let shell = self.shell.as_ref();
+        let mut previews = Vec::with_capacity(raw_patches.len());
+        for raw_patch in raw_patches {
+            let raw_patch_expanded = raw_patch.replace('\t', "        ");
+            let (raw_cover, raw_diff) = split_cover(&raw_patch_expanded);
+            let rendered_cover = render_cover(shell, raw_cover, cover_renderer)
+                .map_err(|e| RenderError::Failed(e.to_string()))?;
+            let rendered_patch = render_patch_preview(shell, raw_diff, patch_renderer)
+                .map_err(|e| RenderError::Failed(e.to_string()))?;
+            previews.push(format!("{rendered_cover}---\n{rendered_patch}"));
+        }
+        Ok(previews)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/infrastructure/render/tests.rs
+++ b/src/infrastructure/render/tests.rs
@@ -1,0 +1,18 @@
+use std::sync::Arc;
+
+use crate::infrastructure::{
+    render::{RenderServiceApi, ShellRenderService},
+    shell::OsShell,
+};
+use crate::{app::cover_renderer::CoverRenderer, app::patch_renderer::PatchRenderer};
+
+#[test]
+fn shell_render_service_produces_one_preview_per_patch() {
+    let svc: Arc<dyn RenderServiceApi> = Arc::new(ShellRenderService::new(Arc::new(OsShell)));
+    let raw = vec!["subject\n\nbody\n---\n+line\n".to_string()];
+    let out = svc
+        .render_patchset_preview(&raw, &PatchRenderer::Default, &CoverRenderer::Default)
+        .expect("default renderers should not spawn");
+    assert_eq!(out.len(), 1);
+    assert!(out[0].contains("---"));
+}

--- a/src/infrastructure/render/trait.rs
+++ b/src/infrastructure/render/trait.rs
@@ -5,6 +5,10 @@ use crate::app::cover_renderer::CoverRenderer;
 use crate::app::patch_renderer::PatchRenderer;
 
 /// Failure while running an external preview renderer (bat, delta, etc.).
+///
+/// Reserved for future strict error propagation; [`super::ShellRenderService`]
+/// currently falls back to raw text and returns `Ok`.
+#[allow(dead_code)]
 #[derive(Debug, Error)]
 pub enum RenderError {
     #[error("render failed: {0}")]

--- a/src/infrastructure/render/trait.rs
+++ b/src/infrastructure/render/trait.rs
@@ -1,0 +1,28 @@
+use mockall::automock;
+use thiserror::Error;
+
+use crate::app::cover_renderer::CoverRenderer;
+use crate::app::patch_renderer::PatchRenderer;
+
+/// Failure while running an external preview renderer (bat, delta, etc.).
+#[derive(Debug, Error)]
+pub enum RenderError {
+    #[error("render failed: {0}")]
+    Failed(String),
+}
+
+/// Abstraction for rich-text patch/cover preview (shell-backed renderers).
+///
+/// Implemented by [`super::ShellRenderService`]; mockable for tests.
+#[automock]
+pub trait RenderServiceApi: Send + Sync {
+    /// Renders each raw patch string to the same format used by the patchset
+    /// details screen: expanded tabs, split cover/diff, external renderers, then
+    /// `"{cover}---\\n{patch}"` per entry.
+    fn render_patchset_preview(
+        &self,
+        raw_patches: &[String],
+        patch_renderer: &PatchRenderer,
+        cover_renderer: &CoverRenderer,
+    ) -> Result<Vec<String>, RenderError>;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,13 +6,13 @@ mod lore;
 mod macros;
 mod ui;
 
-use app::{config::Config, App};
+use app::{config::Config, patch_renderer::PatchRenderer, App};
 use clap::Parser;
 use cli::Cli;
 use color_eyre::eyre::bail;
 use handler::run_app;
 use infrastructure::{
-    env::OsEnv,
+    env::{EnvTrait, OsEnv},
     file_system::OsFileSystem,
     monitoring::{init_monitoring, InitMonitoringProduct},
     net::UreqNetClient,
@@ -30,6 +30,55 @@ use lore::{
 };
 use std::{ops::ControlFlow, sync::Arc};
 use tracing::{event, Level};
+
+/// Verifies required and optional external binaries before the TUI runs.
+///
+/// Soft dependencies only emit warnings; a missing `b4` makes the app refuse to start.
+fn check_external_deps(env: &dyn EnvTrait, config: &Config) -> bool {
+    let mut app_can_run = true;
+
+    if !env.which("b4") {
+        event!(
+            Level::ERROR,
+            "b4 is not installed, patchsets cannot be downloaded"
+        );
+        app_can_run = false;
+    }
+
+    if !env.which("git") {
+        event!(Level::WARN, "git is not installed, send-email won't work");
+    }
+
+    match config.patch_renderer() {
+        PatchRenderer::Bat => {
+            if !env.which("bat") {
+                event!(
+                    Level::WARN,
+                    "bat is not installed, patch rendering will fallback to default"
+                );
+            }
+        }
+        PatchRenderer::Delta => {
+            if !env.which("delta") {
+                event!(
+                    Level::WARN,
+                    "delta is not installed, patch rendering will fallback to default",
+                );
+            }
+        }
+        PatchRenderer::DiffSoFancy => {
+            if !env.which("diff-so-fancy") {
+                event!(
+                    Level::WARN,
+                    "diff-so-fancy is not installed, patch rendering will fallback to default",
+                );
+            }
+        }
+        _ => {}
+    }
+
+    app_can_run
+}
 
 fn main() -> color_eyre::Result<()> {
     // file writer guards should be propagated to main() so the logging thread lives enough
@@ -100,7 +149,7 @@ fn main() -> color_eyre::Result<()> {
         Box::new(env),
         lore_service,
     )?;
-    if !app.check_external_deps() {
+    if !check_external_deps(&*app.services.env, &app.state.config) {
         event!(
             Level::WARN,
             "patch-hub cannot be executed because some dependencies are missing"

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use infrastructure::{
     file_system::OsFileSystem,
     monitoring::{init_monitoring, InitMonitoringProduct},
     net::UreqNetClient,
+    render::{RenderServiceApi, ShellRenderService},
     shell::OsShell,
     terminal::{init, restore},
 };
@@ -129,6 +130,8 @@ fn main() -> color_eyre::Result<()> {
     ));
     let parser = Arc::new(MboxPatchsetParser::new(fs_arc.clone()));
 
+    let render: Box<dyn RenderServiceApi> = Box::new(ShellRenderService::new(shell_arc.clone()));
+
     let lore_service: Box<dyn LoreServiceApi> = Box::new(LoreService::new(
         gateway.clone(),
         gateway.clone(),
@@ -148,6 +151,7 @@ fn main() -> color_eyre::Result<()> {
         Box::new(OsShell),
         Box::new(env),
         lore_service,
+        render,
     )?;
     if !check_external_deps(&*app.services.env, &app.state.config) {
         event!(

--- a/src/ui/bookmarked.rs
+++ b/src/ui/bookmarked.rs
@@ -6,9 +6,9 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::screens::bookmarked::BookmarkedPatchsets;
+use crate::app::screens::bookmarked::BookmarkedPatchsetsState;
 
-pub fn render_main(f: &mut Frame, bookmarked_patchsets: &BookmarkedPatchsets, chunk: Rect) {
+pub fn render_main(f: &mut Frame, bookmarked_patchsets: &BookmarkedPatchsetsState, chunk: Rect) {
     let patchset_index = bookmarked_patchsets.patchset_index;
     let mut list_items = Vec::<ListItem>::new();
 

--- a/src/ui/details_actions.rs
+++ b/src/ui/details_actions.rs
@@ -8,7 +8,7 @@ use ratatui::{
 
 use crate::app::{
     screens::details_actions::{PatchsetAction, PatchsetDetailsState},
-    App,
+    AppViewModel,
 };
 
 /// Returns a `Line` type that represents a line containing stats about reply
@@ -47,8 +47,13 @@ fn review_trailers_details(details_actions: &PatchsetDetailsState) -> Line<'stat
     ])
 }
 
-fn render_details_and_actions(f: &mut Frame, app: &App, details_chunk: Rect, actions_chunk: Rect) {
-    let patchset_details_and_actions = app.state.lore.details.as_ref().unwrap();
+fn render_details_and_actions(
+    f: &mut Frame,
+    vm: &AppViewModel<'_>,
+    details_chunk: Rect,
+    actions_chunk: Rect,
+) {
+    let patchset_details_and_actions = vm.state.lore.details.as_ref().unwrap();
 
     let mut staged_to_reply = String::new();
     if let Some(true) = patchset_details_and_actions
@@ -199,8 +204,8 @@ fn render_details_and_actions(f: &mut Frame, app: &App, details_chunk: Rect, act
     f.render_widget(patchset_actions, actions_chunk);
 }
 
-fn render_preview(f: &mut Frame, app: &App, chunk: Rect) {
-    let patchset_details_and_actions = app.state.lore.details.as_ref().unwrap();
+fn render_preview(f: &mut Frame, vm: &AppViewModel<'_>, chunk: Rect) {
+    let patchset_details_and_actions = vm.state.lore.details.as_ref().unwrap();
 
     let preview_index = patchset_details_and_actions.preview_index;
 
@@ -210,7 +215,7 @@ fn render_preview(f: &mut Frame, app: &App, chunk: Rect) {
         .href;
     let mut preview_title = String::from(" Preview ");
     if matches!(
-        app.state
+        vm.state
             .user_state
             .reviewed_patchsets
             .get(representative_patch_message_id),
@@ -245,11 +250,11 @@ fn render_preview(f: &mut Frame, app: &App, chunk: Rect) {
     f.render_widget(patch_preview, chunk);
 }
 
-pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
-    let patchset_details_and_actions = app.state.lore.details.as_ref().unwrap();
+pub fn render_main(f: &mut Frame, vm: &AppViewModel<'_>, chunk: Rect) {
+    let patchset_details_and_actions = vm.state.lore.details.as_ref().unwrap();
 
     if patchset_details_and_actions.preview_fullscreen {
-        render_preview(f, app, chunk);
+        render_preview(f, vm, chunk);
     } else {
         let chunks = Layout::default()
             .direction(Direction::Horizontal)
@@ -263,11 +268,11 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
 
         render_details_and_actions(
             f,
-            app,
+            vm,
             details_and_actions_chunks[0],
             details_and_actions_chunks[1],
         );
-        render_preview(f, app, chunks[1]);
+        render_preview(f, vm, chunks[1]);
     }
 }
 

--- a/src/ui/details_actions.rs
+++ b/src/ui/details_actions.rs
@@ -48,7 +48,7 @@ fn review_trailers_details(details_actions: &PatchsetDetailsState) -> Line<'stat
 }
 
 fn render_details_and_actions(f: &mut Frame, app: &App, details_chunk: Rect, actions_chunk: Rect) {
-    let patchset_details_and_actions = app.details_actions.as_ref().unwrap();
+    let patchset_details_and_actions = app.state.lore.details.as_ref().unwrap();
 
     let mut staged_to_reply = String::new();
     if let Some(true) = patchset_details_and_actions
@@ -200,7 +200,7 @@ fn render_details_and_actions(f: &mut Frame, app: &App, details_chunk: Rect, act
 }
 
 fn render_preview(f: &mut Frame, app: &App, chunk: Rect) {
-    let patchset_details_and_actions = app.details_actions.as_ref().unwrap();
+    let patchset_details_and_actions = app.state.lore.details.as_ref().unwrap();
 
     let preview_index = patchset_details_and_actions.preview_index;
 
@@ -210,7 +210,10 @@ fn render_preview(f: &mut Frame, app: &App, chunk: Rect) {
         .href;
     let mut preview_title = String::from(" Preview ");
     if matches!(
-        app.reviewed_patchsets.get(representative_patch_message_id),
+        app.state
+            .user_state
+            .reviewed_patchsets
+            .get(representative_patch_message_id),
         Some(successful_indexes) if successful_indexes.contains(&preview_index)
     ) {
         preview_title = " Preview [REVIEWED-BY] ".to_string();
@@ -243,7 +246,7 @@ fn render_preview(f: &mut Frame, app: &App, chunk: Rect) {
 }
 
 pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
-    let patchset_details_and_actions = app.details_actions.as_ref().unwrap();
+    let patchset_details_and_actions = app.state.lore.details.as_ref().unwrap();
 
     if patchset_details_and_actions.preview_fullscreen {
         render_preview(f, app, chunk);

--- a/src/ui/details_actions.rs
+++ b/src/ui/details_actions.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use crate::app::{
-    screens::details_actions::{DetailsActions, PatchsetAction},
+    screens::details_actions::{PatchsetAction, PatchsetDetailsState},
     App,
 };
 
@@ -17,7 +17,7 @@ use crate::app::{
 /// of line returned:
 ///
 /// _**Reviewed-by: 1 | Tested-by: 0 | Acked-by: 2**_
-fn review_trailers_details(details_actions: &DetailsActions) -> Line<'static> {
+fn review_trailers_details(details_actions: &PatchsetDetailsState) -> Line<'static> {
     let i = details_actions.preview_index;
 
     let resolve_color = |n_trailers: usize| -> Style {

--- a/src/ui/edit_config.rs
+++ b/src/ui/edit_config.rs
@@ -7,10 +7,10 @@ use ratatui::{
 };
 use tracing::{event, Level};
 
-use crate::app::App;
+use crate::app::AppViewModel;
 
-pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
-    let edit_config = app.state.config_state.edit_config.as_ref().unwrap();
+pub fn render_main(f: &mut Frame, vm: &AppViewModel<'_>, chunk: Rect) {
+    let edit_config = vm.state.config_state.edit_config.as_ref().unwrap();
     let mut constraints = Vec::new();
 
     for _ in 0..(chunk.height / 3) {
@@ -64,8 +64,8 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
     }
 }
 
-pub fn mode_footer_text(app: &App) -> Vec<Span> {
-    let edit_config_state = app.state.config_state.edit_config.as_ref().unwrap();
+pub fn mode_footer_text<'a>(vm: &'a AppViewModel<'a>) -> Vec<Span<'a>> {
+    let edit_config_state = vm.state.config_state.edit_config.as_ref().unwrap();
     vec![if edit_config_state.is_editing() {
         Span::styled("Editing...", Style::default().fg(Color::LightYellow))
     } else {
@@ -73,8 +73,8 @@ pub fn mode_footer_text(app: &App) -> Vec<Span> {
     }]
 }
 
-pub fn keys_hint(app: &App) -> Span {
-    let edit_config_state = app.state.config_state.edit_config.as_ref().unwrap();
+pub fn keys_hint<'a>(vm: &'a AppViewModel<'a>) -> Span<'a> {
+    let edit_config_state = vm.state.config_state.edit_config.as_ref().unwrap();
     match edit_config_state.is_editing() {
         true => Span::styled(
             "(ESC) cancel | (ENTER) confirm",

--- a/src/ui/edit_config.rs
+++ b/src/ui/edit_config.rs
@@ -10,7 +10,7 @@ use tracing::{event, Level};
 use crate::app::App;
 
 pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
-    let edit_config = app.edit_config.as_ref().unwrap();
+    let edit_config = app.state.config_state.edit_config.as_ref().unwrap();
     let mut constraints = Vec::new();
 
     for _ in 0..(chunk.height / 3) {
@@ -65,7 +65,7 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
 }
 
 pub fn mode_footer_text(app: &App) -> Vec<Span> {
-    let edit_config_state = app.edit_config.as_ref().unwrap();
+    let edit_config_state = app.state.config_state.edit_config.as_ref().unwrap();
     vec![if edit_config_state.is_editing() {
         Span::styled("Editing...", Style::default().fg(Color::LightYellow))
     } else {
@@ -74,7 +74,7 @@ pub fn mode_footer_text(app: &App) -> Vec<Span> {
 }
 
 pub fn keys_hint(app: &App) -> Span {
-    let edit_config_state = app.edit_config.as_ref().unwrap();
+    let edit_config_state = app.state.config_state.edit_config.as_ref().unwrap();
     match edit_config_state.is_editing() {
         true => Span::styled(
             "(ESC) cancel | (ENTER) confirm",

--- a/src/ui/latest.rs
+++ b/src/ui/latest.rs
@@ -9,18 +9,32 @@ use ratatui::{
 use crate::{app::App, lore::domain::patch::Patch};
 
 pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
-    let page_number = app.latest_patchsets.as_ref().unwrap().page_number();
-    let patchset_index = app.latest_patchsets.as_ref().unwrap().patchset_index();
+    let page_number = app
+        .state
+        .lore
+        .latest_patchsets
+        .as_ref()
+        .unwrap()
+        .page_number();
+    let patchset_index = app
+        .state
+        .lore
+        .latest_patchsets
+        .as_ref()
+        .unwrap()
+        .patchset_index();
     let mut list_items = Vec::<ListItem>::new();
 
     let patch_feed_page: Vec<&Patch> = app
+        .state
+        .lore
         .latest_patchsets
         .as_ref()
         .unwrap()
         .get_current_patch_feed_page()
         .unwrap();
 
-    let mut index: usize = (page_number - 1) * app.config.page_size();
+    let mut index: usize = (page_number - 1) * app.state.config.page_size();
     for patch in patch_feed_page {
         let patch_title = format!("{:width$}", patch.title(), width = 70);
         let patch_title = format!("{:.width$}", patch_title, width = 70);
@@ -69,8 +83,18 @@ pub fn mode_footer_text(app: &App) -> Vec<Span> {
     vec![Span::styled(
         format!(
             "Latest Patchsets from {} (page {})",
-            &app.latest_patchsets.as_ref().unwrap().target_list(),
-            &app.latest_patchsets.as_ref().unwrap().page_number()
+            &app.state
+                .lore
+                .latest_patchsets
+                .as_ref()
+                .unwrap()
+                .target_list(),
+            &app.state
+                .lore
+                .latest_patchsets
+                .as_ref()
+                .unwrap()
+                .page_number()
         ),
         Style::default().fg(Color::Green),
     )]

--- a/src/ui/latest.rs
+++ b/src/ui/latest.rs
@@ -6,17 +6,17 @@ use ratatui::{
     Frame,
 };
 
-use crate::{app::App, lore::domain::patch::Patch};
+use crate::{app::AppViewModel, lore::domain::patch::Patch};
 
-pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
-    let page_number = app
+pub fn render_main(f: &mut Frame, vm: &AppViewModel<'_>, chunk: Rect) {
+    let page_number = vm
         .state
         .lore
         .latest_patchsets
         .as_ref()
         .unwrap()
         .page_number();
-    let patchset_index = app
+    let patchset_index = vm
         .state
         .lore
         .latest_patchsets
@@ -25,7 +25,7 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
         .patchset_index();
     let mut list_items = Vec::<ListItem>::new();
 
-    let patch_feed_page: Vec<&Patch> = app
+    let patch_feed_page: Vec<&Patch> = vm
         .state
         .lore
         .latest_patchsets
@@ -34,7 +34,7 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
         .get_current_patch_feed_page()
         .unwrap();
 
-    let mut index: usize = (page_number - 1) * app.state.config.page_size();
+    let mut index: usize = (page_number - 1) * vm.state.config.page_size();
     for patch in patch_feed_page {
         let patch_title = format!("{:width$}", patch.title(), width = 70);
         let patch_title = format!("{:.width$}", patch_title, width = 70);
@@ -79,17 +79,17 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
     f.render_stateful_widget(list, chunk, &mut list_state);
 }
 
-pub fn mode_footer_text(app: &App) -> Vec<Span> {
+pub fn mode_footer_text<'a>(vm: &'a AppViewModel<'a>) -> Vec<Span<'a>> {
     vec![Span::styled(
         format!(
             "Latest Patchsets from {} (page {})",
-            &app.state
+            &vm.state
                 .lore
                 .latest_patchsets
                 .as_ref()
                 .unwrap()
                 .target_list(),
-            &app.state
+            &vm.state
                 .lore
                 .latest_patchsets
                 .as_ref()

--- a/src/ui/mail_list.rs
+++ b/src/ui/mail_list.rs
@@ -6,13 +6,13 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::App;
+use crate::app::AppViewModel;
 
-pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
-    let highlighted_list_index = app.state.lore.mailing_list_selection.highlighted_list_index;
+pub fn render_main(f: &mut Frame, vm: &AppViewModel<'_>, chunk: Rect) {
+    let highlighted_list_index = vm.state.lore.mailing_list_selection.highlighted_list_index;
     let mut list_items = Vec::<ListItem>::new();
 
-    for mailing_list in &app.state.lore.mailing_list_selection.possible_mailing_lists {
+    for mailing_list in &vm.state.lore.mailing_list_selection.possible_mailing_lists {
         list_items.push(ListItem::new(
             Line::from(vec![
                 Span::styled(
@@ -50,35 +50,35 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
     f.render_stateful_widget(list, chunk, &mut list_state);
 }
 
-pub fn mode_footer_text(app: &App) -> Vec<Span> {
+pub fn mode_footer_text<'a>(vm: &'a AppViewModel<'a>) -> Vec<Span<'a>> {
     let mut text_area = Span::default();
 
-    if app.state.lore.mailing_list_selection.target_list.is_empty() {
+    if vm.state.lore.mailing_list_selection.target_list.is_empty() {
         text_area = Span::styled("type the target list", Style::default().fg(Color::DarkGray))
     } else {
-        for mailing_list in &app.state.lore.mailing_list_selection.mailing_lists {
+        for mailing_list in &vm.state.lore.mailing_list_selection.mailing_lists {
             if mailing_list
                 .name()
-                .eq(&app.state.lore.mailing_list_selection.target_list)
+                .eq(&vm.state.lore.mailing_list_selection.target_list)
             {
                 text_area = Span::styled(
-                    &app.state.lore.mailing_list_selection.target_list,
+                    &vm.state.lore.mailing_list_selection.target_list,
                     Style::default().fg(Color::Green),
                 );
                 break;
             } else if mailing_list
                 .name()
-                .starts_with(&app.state.lore.mailing_list_selection.target_list)
+                .starts_with(&vm.state.lore.mailing_list_selection.target_list)
             {
                 text_area = Span::styled(
-                    &app.state.lore.mailing_list_selection.target_list,
+                    &vm.state.lore.mailing_list_selection.target_list,
                     Style::default().fg(Color::LightCyan),
                 );
             }
         }
         if text_area.content.is_empty() {
             text_area = Span::styled(
-                &app.state.lore.mailing_list_selection.target_list,
+                &vm.state.lore.mailing_list_selection.target_list,
                 Style::default().fg(Color::Red),
             );
         }

--- a/src/ui/mail_list.rs
+++ b/src/ui/mail_list.rs
@@ -9,10 +9,10 @@ use ratatui::{
 use crate::app::App;
 
 pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
-    let highlighted_list_index = app.mailing_list_selection.highlighted_list_index;
+    let highlighted_list_index = app.state.lore.mailing_list_selection.highlighted_list_index;
     let mut list_items = Vec::<ListItem>::new();
 
-    for mailing_list in &app.mailing_list_selection.possible_mailing_lists {
+    for mailing_list in &app.state.lore.mailing_list_selection.possible_mailing_lists {
         list_items.push(ListItem::new(
             Line::from(vec![
                 Span::styled(
@@ -53,32 +53,32 @@ pub fn render_main(f: &mut Frame, app: &App, chunk: Rect) {
 pub fn mode_footer_text(app: &App) -> Vec<Span> {
     let mut text_area = Span::default();
 
-    if app.mailing_list_selection.target_list.is_empty() {
+    if app.state.lore.mailing_list_selection.target_list.is_empty() {
         text_area = Span::styled("type the target list", Style::default().fg(Color::DarkGray))
     } else {
-        for mailing_list in &app.mailing_list_selection.mailing_lists {
+        for mailing_list in &app.state.lore.mailing_list_selection.mailing_lists {
             if mailing_list
                 .name()
-                .eq(&app.mailing_list_selection.target_list)
+                .eq(&app.state.lore.mailing_list_selection.target_list)
             {
                 text_area = Span::styled(
-                    &app.mailing_list_selection.target_list,
+                    &app.state.lore.mailing_list_selection.target_list,
                     Style::default().fg(Color::Green),
                 );
                 break;
             } else if mailing_list
                 .name()
-                .starts_with(&app.mailing_list_selection.target_list)
+                .starts_with(&app.state.lore.mailing_list_selection.target_list)
             {
                 text_area = Span::styled(
-                    &app.mailing_list_selection.target_list,
+                    &app.state.lore.mailing_list_selection.target_list,
                     Style::default().fg(Color::LightCyan),
                 );
             }
         }
         if text_area.content.is_empty() {
             text_area = Span::styled(
-                &app.mailing_list_selection.target_list,
+                &app.state.lore.mailing_list_selection.target_list,
                 Style::default().fg(Color::Red),
             );
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,9 +15,9 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{screens::CurrentScreen, App};
+use crate::app::{screens::CurrentScreen, AppViewModel};
 
-pub fn draw_ui(f: &mut Frame, app: &App) {
+pub fn draw_ui(f: &mut Frame, vm: &AppViewModel<'_>) {
     // Clear the whole screen for sanitizing reasons
     f.render_widget(Clear, f.area());
 
@@ -32,19 +32,19 @@ pub fn draw_ui(f: &mut Frame, app: &App) {
 
     render_title(f, chunks[0]);
 
-    match app.state.navigation.current_screen {
-        CurrentScreen::MailingListSelection => mail_list::render_main(f, app, chunks[1]),
+    match vm.state.navigation.current_screen {
+        CurrentScreen::MailingListSelection => mail_list::render_main(f, vm, chunks[1]),
         CurrentScreen::BookmarkedPatchsets => {
-            bookmarked::render_main(f, &app.state.user_state.bookmarked_patchsets, chunks[1])
+            bookmarked::render_main(f, &vm.state.user_state.bookmarked_patchsets, chunks[1])
         }
-        CurrentScreen::LatestPatchsets => latest::render_main(f, app, chunks[1]),
-        CurrentScreen::PatchsetDetails => details_actions::render_main(f, app, chunks[1]),
-        CurrentScreen::EditConfig => edit_config::render_main(f, app, chunks[1]),
+        CurrentScreen::LatestPatchsets => latest::render_main(f, vm, chunks[1]),
+        CurrentScreen::PatchsetDetails => details_actions::render_main(f, vm, chunks[1]),
+        CurrentScreen::EditConfig => edit_config::render_main(f, vm, chunks[1]),
     }
 
-    navigation_bar::render(f, app, chunks[2]);
+    navigation_bar::render(f, vm, chunks[2]);
 
-    app.state.popup.as_ref().inspect(|p| {
+    vm.state.popup.as_ref().inspect(|p| {
         let (x, y) = p.dimensions();
         let rect = centered_rect(x, y, f.area());
         p.render(f, rect);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -32,10 +32,10 @@ pub fn draw_ui(f: &mut Frame, app: &App) {
 
     render_title(f, chunks[0]);
 
-    match app.current_screen {
+    match app.state.navigation.current_screen {
         CurrentScreen::MailingListSelection => mail_list::render_main(f, app, chunks[1]),
         CurrentScreen::BookmarkedPatchsets => {
-            bookmarked::render_main(f, &app.bookmarked_patchsets, chunks[1])
+            bookmarked::render_main(f, &app.state.user_state.bookmarked_patchsets, chunks[1])
         }
         CurrentScreen::LatestPatchsets => latest::render_main(f, app, chunks[1]),
         CurrentScreen::PatchsetDetails => details_actions::render_main(f, app, chunks[1]),
@@ -44,7 +44,7 @@ pub fn draw_ui(f: &mut Frame, app: &App) {
 
     navigation_bar::render(f, app, chunks[2]);
 
-    app.popup.as_ref().inspect(|p| {
+    app.state.popup.as_ref().inspect(|p| {
         let (x, y) = p.dimensions();
         let rect = centered_rect(x, y, f.area());
         p.render(f, rect);

--- a/src/ui/navigation_bar.rs
+++ b/src/ui/navigation_bar.rs
@@ -10,7 +10,7 @@ use crate::app::{screens::CurrentScreen, App};
 use super::{bookmarked, details_actions, edit_config, latest, mail_list};
 
 pub fn render(f: &mut Frame, app: &App, chunk: Rect) {
-    let mode_footer_text = match app.current_screen {
+    let mode_footer_text = match app.state.navigation.current_screen {
         CurrentScreen::MailingListSelection => mail_list::mode_footer_text(app),
         CurrentScreen::BookmarkedPatchsets => bookmarked::mode_footer_text(),
         CurrentScreen::LatestPatchsets => latest::mode_footer_text(app),
@@ -22,7 +22,7 @@ pub fn render(f: &mut Frame, app: &App, chunk: Rect) {
         .centered();
 
     let current_keys_hint = {
-        match app.current_screen {
+        match app.state.navigation.current_screen {
             CurrentScreen::MailingListSelection => mail_list::keys_hint(),
             CurrentScreen::BookmarkedPatchsets => bookmarked::keys_hint(),
             CurrentScreen::LatestPatchsets => latest::keys_hint(),

--- a/src/ui/navigation_bar.rs
+++ b/src/ui/navigation_bar.rs
@@ -5,29 +5,29 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{screens::CurrentScreen, App};
+use crate::app::{screens::CurrentScreen, AppViewModel};
 
 use super::{bookmarked, details_actions, edit_config, latest, mail_list};
 
-pub fn render(f: &mut Frame, app: &App, chunk: Rect) {
-    let mode_footer_text = match app.state.navigation.current_screen {
-        CurrentScreen::MailingListSelection => mail_list::mode_footer_text(app),
+pub fn render(f: &mut Frame, vm: &AppViewModel<'_>, chunk: Rect) {
+    let mode_footer_text = match vm.state.navigation.current_screen {
+        CurrentScreen::MailingListSelection => mail_list::mode_footer_text(vm),
         CurrentScreen::BookmarkedPatchsets => bookmarked::mode_footer_text(),
-        CurrentScreen::LatestPatchsets => latest::mode_footer_text(app),
+        CurrentScreen::LatestPatchsets => latest::mode_footer_text(vm),
         CurrentScreen::PatchsetDetails => details_actions::mode_footer_text(),
-        CurrentScreen::EditConfig => edit_config::mode_footer_text(app),
+        CurrentScreen::EditConfig => edit_config::mode_footer_text(vm),
     };
     let mode_footer = Paragraph::new(Line::from(mode_footer_text))
         .block(Block::default().borders(Borders::ALL))
         .centered();
 
     let current_keys_hint = {
-        match app.state.navigation.current_screen {
+        match vm.state.navigation.current_screen {
             CurrentScreen::MailingListSelection => mail_list::keys_hint(),
             CurrentScreen::BookmarkedPatchsets => bookmarked::keys_hint(),
             CurrentScreen::LatestPatchsets => latest::keys_hint(),
             CurrentScreen::PatchsetDetails => details_actions::keys_hint(),
-            CurrentScreen::EditConfig => edit_config::keys_hint(app),
+            CurrentScreen::EditConfig => edit_config::keys_hint(vm),
         }
     };
 

--- a/src/ui/popup/review_trailers.rs
+++ b/src/ui/popup/review_trailers.rs
@@ -8,7 +8,7 @@ use ratatui::{
 
 use std::collections::HashSet;
 
-use crate::{app::screens::details_actions::DetailsActions, lore::domain::patch::Author};
+use crate::{app::screens::details_actions::PatchsetDetailsState, lore::domain::patch::Author};
 
 use super::PopUp;
 
@@ -31,7 +31,7 @@ impl ReviewTrailersPopUp {
     /// the fields `reviewed_by`, `tested_by`, and `acked_by`, which are the
     /// tags considered for the generated pop-up. This function succeeds regardless if
     /// there are no code-review trailers for the specific patch.
-    pub fn generate_trailers_popup(details_actions: &DetailsActions) -> Box<dyn PopUp> {
+    pub fn generate_trailers_popup(details_actions: &PatchsetDetailsState) -> Box<dyn PopUp> {
         let i = details_actions.preview_index;
         let mut reviewed_by_text = String::new();
         let mut tested_by_text = String::new();


### PR DESCRIPTION
## Goal

Decompose the monolithic App struct into explicit state containers and remove infrastructure coupling, so the app layer is ready to become an actor. Screens should hold UI state, services should hold dependencies, and the UI layer should not need to import the orchestrator directly.

## What this PR does

Renames screen structs to *State suffix (MailingListSelectionState, LatestPatchsetsState, etc.) and splits App into AppState (navigation, lore UI, user lore, config UI, popup) and AppServices (lore, shell, fs, env, render). check_external_deps moves to main.rs startup.

Introduces RenderServiceApi with ShellRenderService for patchset preview, ConfigUpdateDraft/apply_update for the edit-config flow, and PatchsetCommand/AppCommand enums as scaffolding for a future App actor protocol. consolidate_patchset_actions splits into sync_patchset_bookmark, execute_reviewed_reply, and execute_apply_patchset.

Adds AppViewModel as a read-only view of AppState — draw_ui and all screen render helpers take AppViewModel instead of App, breaking the app ↔ ui import cycle. Runtime behavior is unchanged.